### PR TITLE
Fix the Missing a Javadoc comment problem during compilation

### DIFF
--- a/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/MySqlBinlogSourceITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/MySqlBinlogSourceITCase.java
@@ -27,7 +27,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 /**
- * Tests for {@link MySqlBinlogSource}
+ * Tests for {@link MySqlBinlogSource}.
  */
 @Ignore
 public class MySqlBinlogSourceITCase extends MySqlBinlogTestBase {

--- a/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/MySqlBinlogSourceITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/MySqlBinlogSourceITCase.java
@@ -26,6 +26,9 @@ import com.alibaba.ververica.cdc.debezium.StringDebeziumDeserializationSchema;
 import org.junit.Ignore;
 import org.junit.Test;
 
+/**
+ * Tests for {@link MySqlBinlogSource}
+ */
 @Ignore
 public class MySqlBinlogSourceITCase extends MySqlBinlogTestBase {
 


### PR DESCRIPTION
fix problem during compilation :

`Error: java: JavadocType: Missing a Javadoc comment.`

The solution is to add comment to the class