### PR TITLE
Support to specific MySQL Binlog position

### DIFF
--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/DebeziumSourceFunction.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/DebeziumSourceFunction.java
@@ -375,4 +375,5 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T> implements
 	public TypeInformation<T> getProducedType() {
 		return deserializer.getProducedType();
 	}
+
 }

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/FlinkDatabaseHistory.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/FlinkDatabaseHistory.java
@@ -64,6 +64,7 @@ public class FlinkDatabaseHistory extends AbstractDatabaseHistory {
 
 	private ConcurrentLinkedQueue<HistoryRecord> records;
 	private String instanceName;
+	private boolean databaseexists;
 
 	/**
 	 * Registers the given HistoryRecords into global variable under the given instance name,
@@ -104,6 +105,7 @@ public class FlinkDatabaseHistory extends AbstractDatabaseHistory {
 			throw new IllegalStateException(
 				String.format("Couldn't find engine instance %s in the global records.", instanceName));
 		}
+		this.databaseexists = config.getBoolean("database.history.exists", true);
 	}
 
 	@Override
@@ -129,7 +131,7 @@ public class FlinkDatabaseHistory extends AbstractDatabaseHistory {
 
 	@Override
 	public boolean exists() {
-		return true;
+		return databaseexists;
 	}
 
 	@Override

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/MySQLSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/MySQLSource.java
@@ -18,10 +18,17 @@
 
 package com.alibaba.ververica.cdc.connectors.mysql;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.alibaba.ververica.cdc.debezium.DebeziumDeserializationSchema;
 import com.alibaba.ververica.cdc.debezium.DebeziumSourceFunction;
+import com.alibaba.ververica.cdc.debezium.internal.DebeziumState;
+import com.alibaba.ververica.cdc.debezium.internal.FlinkOffsetBackingStore;
 import io.debezium.connector.mysql.MySqlConnector;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -50,6 +57,8 @@ public class MySQLSource {
 		private String[] tableList;
 		private Properties dbzProperties;
 		private DebeziumDeserializationSchema<T> deserializer;
+		private String sourceOffsetFile;
+		private Integer sourceOffsetPosition;
 
 		public Builder<T> hostname(String hostname) {
 			this.hostname = hostname;
@@ -138,6 +147,22 @@ public class MySQLSource {
 			return this;
 		}
 
+		/**
+		 * File Name of the MySQL binlog.
+		 */
+		public Builder<T> sourceOffsetFile(String sourceOffsetFile) {
+			this.sourceOffsetFile = sourceOffsetFile;
+			return this;
+		}
+
+		/**
+		 * Position of the MySQL binlog.
+		 */
+		public Builder<T> sourceOffsetPosition(Integer sourceOffsetPosition) {
+			this.sourceOffsetPosition = sourceOffsetPosition;
+			return this;
+		}
+
 		public DebeziumSourceFunction<T> build() {
 			Properties props = new Properties();
 			props.setProperty("connector.class", MySqlConnector.class.getCanonicalName());
@@ -164,14 +189,37 @@ public class MySQLSource {
 			if (serverTimeZone != null) {
 				props.setProperty("database.serverTimezone", serverTimeZone);
 			}
+			if (sourceOffsetFile != null && sourceOffsetPosition != null) {
+				// if binlog offset is specified, 'snapshot.mode=schema_only_recovery' must be configured
+				props.setProperty("snapshot.mode", "schema_only_recovery");
+
+				DebeziumState debeziumState = new DebeziumState();
+				Map<String, String> sourcePartition = new HashMap<>();
+				sourcePartition.put("server", props.getProperty("database.server.name"));
+				debeziumState.setSourcePartition(sourcePartition);
+
+				Map<String, Object> sourceOffset = new HashMap<>();
+				sourceOffset.put("file", sourceOffsetFile);
+				sourceOffset.put("pos", sourceOffsetPosition);
+				debeziumState.setSourceOffset(sourceOffset);
+
+				try {
+					ObjectMapper objectMapper = new ObjectMapper();
+					String offsetJson = objectMapper.writeValueAsString(debeziumState);
+					// if the task is restored from savepoint, it will be overwritten by restoredOffsetState
+					props.setProperty(FlinkOffsetBackingStore.OFFSET_STATE_VALUE, offsetJson);
+					props.setProperty("database.history.exists", "false");
+				} catch (IOException e) {
+					throw new RuntimeException("Can't serialize debezium offset state from Object: " + debeziumState, e);
+				}
+			}
 
 			if (dbzProperties != null) {
 				dbzProperties.forEach(props::put);
 			}
-
 			return new DebeziumSourceFunction<>(
-				deserializer,
-				props);
+					deserializer,
+					props);
 		}
 	}
 }

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSource.java
@@ -58,7 +58,8 @@ public class MySQLTableSource implements ScanTableSource {
 	private final String tableName;
 	private final ZoneId serverTimeZone;
 	private final Properties dbzProperties;
-
+	private final String sourceOffsetFile;
+	private final Integer sourceOffsetPosition;
 	public MySQLTableSource(
 			TableSchema physicalSchema,
 			int port,
@@ -69,7 +70,9 @@ public class MySQLTableSource implements ScanTableSource {
 			String password,
 			ZoneId serverTimeZone,
 			Properties dbzProperties,
-			@Nullable Integer serverId) {
+			@Nullable Integer serverId,
+			@Nullable String sourceOffsetFile,
+			@Nullable Integer sourceOffsetPosition) {
 		this.physicalSchema = physicalSchema;
 		this.port = port;
 		this.hostname = checkNotNull(hostname);
@@ -80,6 +83,8 @@ public class MySQLTableSource implements ScanTableSource {
 		this.serverId = serverId;
 		this.serverTimeZone = serverTimeZone;
 		this.dbzProperties = dbzProperties;
+		this.sourceOffsetFile = sourceOffsetFile;
+		this.sourceOffsetPosition = sourceOffsetPosition;
 	}
 
 	@Override
@@ -113,6 +118,8 @@ public class MySQLTableSource implements ScanTableSource {
 			.debeziumProperties(dbzProperties)
 			.deserializer(deserializer);
 		Optional.ofNullable(serverId).ifPresent(builder::serverId);
+		Optional.ofNullable(sourceOffsetFile).ifPresent(builder::sourceOffsetFile);
+		Optional.ofNullable(sourceOffsetPosition).ifPresent(builder::sourceOffsetPosition);
 		DebeziumSourceFunction<RowData> sourceFunction = builder.build();
 
 		return SourceFunctionProvider.of(sourceFunction, false);
@@ -130,7 +137,9 @@ public class MySQLTableSource implements ScanTableSource {
 			password,
 			serverTimeZone,
 			dbzProperties,
-			serverId
+			serverId,
+			sourceOffsetFile,
+			sourceOffsetPosition
 		);
 	}
 
@@ -152,12 +161,14 @@ public class MySQLTableSource implements ScanTableSource {
 			Objects.equals(serverId, that.serverId) &&
 			Objects.equals(tableName, that.tableName) &&
 			Objects.equals(serverTimeZone, that.serverTimeZone) &&
-			Objects.equals(dbzProperties, that.dbzProperties);
+			Objects.equals(dbzProperties, that.dbzProperties) &&
+			Objects.equals(sourceOffsetFile, that.sourceOffsetFile) &&
+			Objects.equals(sourceOffsetPosition, that.sourceOffsetPosition);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(physicalSchema, port, hostname, database, username, password, serverId, tableName, serverTimeZone, dbzProperties);
+		return Objects.hash(physicalSchema, port, hostname, database, username, password, serverId, tableName, serverTimeZone, dbzProperties, sourceOffsetFile, sourceOffsetPosition);
 	}
 
 	@Override

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSourceFactory.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSourceFactory.java
@@ -113,7 +113,7 @@ public class MySQLTableSourceFactory implements DynamicTableSourceFactory {
 		// Validate the source offset options
 		validateSourceOffset(config);
 		String sourceOffsetFile = config.get(SOURCE_OFFSET_FILE);
-		int sourceOffsetPosition = config.get(SOURCE_OFFSET_POSITION);
+		Integer sourceOffsetPosition = config.getOptional(SOURCE_OFFSET_POSITION).orElse(null);
 		TableSchema physicalSchema = TableSchemaUtils.getPhysicalSchema(context.getCatalogTable().getSchema());
 
 		return new MySQLTableSource(

--- a/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSourceFactoryTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSourceFactoryTest.java
@@ -77,6 +77,8 @@ public class MySQLTableSourceFactoryTest {
 			MY_PASSWORD,
 			ZoneId.of("UTC"),
 			PROPERTIES,
+			null,
+			null,
 			null
 		);
 		assertEquals(expectedSource, actualSource);
@@ -103,7 +105,9 @@ public class MySQLTableSourceFactoryTest {
 			MY_PASSWORD,
 			ZoneId.of("Asia/Shanghai"),
 			dbzProperties,
-			4321
+			4321,
+			null,
+			null
 		);
 		assertEquals(expectedSource, actualSource);
 	}

--- a/flink-connector-postgres-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/postgres/table/PostgreSQLTableFactory.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/postgres/table/PostgreSQLTableFactory.java
@@ -18,9 +18,6 @@
 
 package com.alibaba.ververica.cdc.connectors.postgres.table;
 
-import static com.alibaba.ververica.cdc.debezium.table.DebeziumOptions.DEBEZIUM_OPTIONS_PREFIX;
-import static com.alibaba.ververica.cdc.debezium.table.DebeziumOptions.getDebeziumProperties;
-
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.ReadableConfig;
@@ -33,6 +30,9 @@ import org.apache.flink.table.utils.TableSchemaUtils;
 
 import java.util.HashSet;
 import java.util.Set;
+
+import static com.alibaba.ververica.cdc.debezium.table.DebeziumOptions.DEBEZIUM_OPTIONS_PREFIX;
+import static com.alibaba.ververica.cdc.debezium.table.DebeziumOptions.getDebeziumProperties;
 
 /**
  * Factory for creating configured instance of {@link PostgreSQLTableSource}.


### PR DESCRIPTION
Add two options to support to specific MySQL Binlog position：
  'source-offset-file' = 'mysql-bin.000021',
  'source-offset-pos' = '30292'

usage:
```sql
CREATE TABLE flink_cdc_test (
  order_id INT,
  order_date TIMESTAMP(0),
  customer_name STRING,
  price DECIMAL(10, 5),
  product_id INT,
  order_status BOOLEAN
) WITH (
  'connector' = 'mysql-cdc',
  'hostname' = 'localhost',
  'port' = '3306',
  'username' = 'root',
  'password' = 'root123',
  'database-name' = 'flink',
  'table-name' = 'flink_cdc_test',
  'source-offset-file' = 'mysql-bin.000021',
  'source-offset-pos' = '30292'
);
```