### PR TITLE
Support read from specific MySQL Binlog position

### DIFF
--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/FlinkDatabaseHistory.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/FlinkDatabaseHistory.java
@@ -64,6 +64,7 @@ public class FlinkDatabaseHistory extends AbstractDatabaseHistory {
 
 	private ConcurrentLinkedQueue<HistoryRecord> records;
 	private String instanceName;
+	private boolean databaseexists;
 
 	/**
 	 * Registers the given HistoryRecords into global variable under the given instance name,
@@ -104,6 +105,7 @@ public class FlinkDatabaseHistory extends AbstractDatabaseHistory {
 			throw new IllegalStateException(
 				String.format("Couldn't find engine instance %s in the global records.", instanceName));
 		}
+		this.databaseexists = config.getBoolean("database.history.exists", true);
 	}
 
 	@Override
@@ -129,7 +131,7 @@ public class FlinkDatabaseHistory extends AbstractDatabaseHistory {
 
 	@Override
 	public boolean exists() {
-		return true;
+		return databaseexists;
 	}
 
 	@Override

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/options/MySQLOffsetOptions.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/options/MySQLOffsetOptions.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mysql.options;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Offset option for MySql.
+ */
+public class MySQLOffsetOptions {
+
+	@Nullable
+	private final String sourceOffsetFile;
+	@Nullable
+	private final Integer sourceOffsetPosition;
+
+	private MySQLOffsetOptions(@Nullable String sourceOffsetFile, @Nullable Integer sourceOffsetPosition) {
+		this.sourceOffsetFile = sourceOffsetFile;
+		this.sourceOffsetPosition = sourceOffsetPosition;
+	}
+
+	@Nullable
+	public String getSourceOffsetFile() {
+		return sourceOffsetFile;
+	}
+
+	@Nullable
+	public Integer getSourceOffsetPosition() {
+		return sourceOffsetPosition;
+	}
+
+	@Override
+	public String toString() {
+		return "MySQLOffsetOptions{" +
+				"sourceOffsetFile='" + sourceOffsetFile + '\'' +
+				", sourceOffsetPosition='" + sourceOffsetPosition + '\'' +
+				'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		MySQLOffsetOptions that = (MySQLOffsetOptions) o;
+		return Objects.equals(sourceOffsetFile, that.sourceOffsetFile) &&
+				Objects.equals(sourceOffsetPosition, that.sourceOffsetPosition);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(sourceOffsetFile, sourceOffsetPosition);
+	}
+
+	/**
+	 * Creates a builder of {@link MySQLOffsetOptions}.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for {@link MySQLOffsetOptions}.
+	 */
+	public static class Builder {
+
+		private String sourceOffsetFile;
+		private Integer sourceOffsetPosition;
+
+		/**
+		 * Sets the MySql source offset file name.
+		 */
+		public Builder sourceOffsetFile(String sourceOffsetFile) {
+			this.sourceOffsetFile = sourceOffsetFile;
+			return this;
+		}
+
+		/**
+		 * Sets the MySql source offset position.
+		 */
+		public Builder sourceOffsetPosition(Integer sourceOffsetPosition) {
+			this.sourceOffsetPosition = sourceOffsetPosition;
+			return this;
+		}
+
+		/**
+		 * Creates an instance of {@link MySQLOffsetOptions}.
+		 */
+		public MySQLOffsetOptions build() {
+			return new MySQLOffsetOptions(sourceOffsetFile, sourceOffsetPosition);
+		}
+	}
+}

--- a/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSourceFactoryTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSourceFactoryTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.utils.TableSchemaUtils;
 import org.apache.flink.util.ExceptionUtils;
 
+import com.alibaba.ververica.cdc.connectors.mysql.options.MySQLOffsetOptions;
 import org.junit.Test;
 
 import java.time.ZoneId;
@@ -77,7 +78,8 @@ public class MySQLTableSourceFactoryTest {
 			MY_PASSWORD,
 			ZoneId.of("UTC"),
 			PROPERTIES,
-			null
+			null,
+			MySQLOffsetOptions.builder().build()
 		);
 		assertEquals(expectedSource, actualSource);
 	}
@@ -103,7 +105,8 @@ public class MySQLTableSourceFactoryTest {
 			MY_PASSWORD,
 			ZoneId.of("Asia/Shanghai"),
 			dbzProperties,
-			4321
+			4321,
+			MySQLOffsetOptions.builder().build()
 		);
 		assertEquals(expectedSource, actualSource);
 	}


### PR DESCRIPTION
Fix #21，
Support read from specific MySQL Binlog position

Add optional flag `source-offset-file` and `source-offset-pos` to specify the source offsets in mysql-cdc.
 `source-offset-file` means the binlog-file name, `source-offset-pos` means the position of the binlog.
two steps to get the binlog-file and position:  
1. open the mysql command-cli, ：
```
show binary logs; // list the binlog-file
```
2. get the position：
```
show binlog events in 'mysql-bin.xxxxxx'; // get the position
```

usage in flink sql:
```
CREATE TABLE flink_cdc_test (
  order_id INT,
  order_date TIMESTAMP(0),
  customer_name STRING,
  price DECIMAL(10, 5),
  product_id INT,
  order_status BOOLEAN
) WITH (
  'connector' = 'mysql-cdc',
  'hostname' = 'localhost',
  'port' = '3306',
  'username' = 'root',
  'password' = 'root123',
  'database-name' = 'flink',
  'table-name' = 'flink_cdc_test',
  'source-offset-file' = 'mysql-bin.000021',
  'source-offset-pos' = '30292'
);
```