### PR TITLE
feat: add support to jdk 9+

### DIFF
--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/DebeziumSourceFunction.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/DebeziumSourceFunction.java
@@ -52,7 +52,6 @@ import io.debezium.engine.spi.OffsetCommitPolicy;
 import io.debezium.heartbeat.Heartbeat;
 import io.debezium.relational.history.HistoryRecord;
 import org.apache.commons.collections.map.LinkedMap;
-import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +66,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  * The {@link DebeziumSourceFunction} is a streaming data source that pulls captured change data
@@ -359,7 +357,7 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
                         .using(
                                 (success, message, error) -> {
                                     if (!success && error != null) {
-                                        this.reportError(error);
+                                        handover.reportError(error);
                                     }
                                 })
                         .build();

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/DebeziumSourceFunction.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/DebeziumSourceFunction.java
@@ -38,9 +38,9 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.shaded.guava18.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import com.alibaba.ververica.cdc.debezium.internal.DebeziumChangeConsumer;
-import com.alibaba.ververica.cdc.debezium.internal.EventQueueConsumer;
 import com.alibaba.ververica.cdc.debezium.internal.DebeziumOffset;
 import com.alibaba.ververica.cdc.debezium.internal.DebeziumOffsetSerializer;
+import com.alibaba.ververica.cdc.debezium.internal.EventQueueConsumer;
 import com.alibaba.ververica.cdc.debezium.internal.FlinkDatabaseHistory;
 import com.alibaba.ververica.cdc.debezium.internal.FlinkOffsetBackingStore;
 import com.alibaba.ververica.cdc.debezium.internal.Handover;
@@ -113,8 +113,8 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
     private ExecutorService executor;
     private DebeziumEngine<?> engine;
 
-	/** The consumer to fetch records from {@link DebeziumEngine}. */
-	private transient volatile DebeziumChangeConsumer<T> debeziumConsumer;
+    /** The consumer to fetch records from {@link DebeziumEngine}. */
+    private transient volatile DebeziumChangeConsumer<T> debeziumConsumer;
 
     /**
      * The offsets to restore to, if the consumer restores state from a checkpoint.
@@ -142,7 +142,7 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
      */
     private transient String engineInstanceName;
 
-	private transient Handover handover;
+    private transient Handover handover;
 
     public DebeziumSourceFunction(
             DebeziumDeserializationSchema<T> deserializer,
@@ -153,15 +153,14 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
         this.specificOffset = specificOffset;
     }
 
-	@Override
-	public void open(Configuration parameters) throws Exception {
-		super.open(parameters);
-		ThreadFactory threadFactory = new ThreadFactoryBuilder()
-				.setNameFormat("debezium-engine")
-				.build();
-		this.executor = Executors.newSingleThreadExecutor(threadFactory);
-		this.handover = new Handover();
-	}
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        ThreadFactory threadFactory =
+                new ThreadFactoryBuilder().setNameFormat("debezium-engine").build();
+        this.executor = Executors.newSingleThreadExecutor(threadFactory);
+        this.handover = new Handover();
+    }
 
     // ------------------------------------------------------------------------
     //  Checkpoint and restore
@@ -362,29 +361,28 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
                                 })
                         .build();
 
-		// run the engine asynchronously
-		executor.execute(engine);
+        // run the engine asynchronously
+        executor.execute(engine);
 
-		try {
-			// start the real debezium consumer
-			debeziumConsumer.run();
+        try {
+            // start the real debezium consumer
+            debeziumConsumer.run();
 
-			// on a clean exit, wait for the runner thread
-			if (handover.isClosed()) {
-				shutdownEngine();
-				if (executor != null) {
-					executor.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
-				}
-				// rethrow the error from Debezium consumer
-				ExceptionUtils.rethrow(handover.getError());
-			}
-		}
-		catch (InterruptedException e) {
-			// may be the result of a wake-up interruption after an exception.
-			// we ignore this here and only restore the interruption state
-			Thread.currentThread().interrupt();
-		}
-	}
+            // on a clean exit, wait for the runner thread
+            if (handover.isClosed()) {
+                shutdownEngine();
+                if (executor != null) {
+                    executor.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
+                }
+                // rethrow the error from Debezium consumer
+                ExceptionUtils.rethrow(handover.getError());
+            }
+        } catch (InterruptedException e) {
+            // may be the result of a wake-up interruption after an exception.
+            // we ignore this here and only restore the interruption state
+            Thread.currentThread().interrupt();
+        }
+    }
 
     @Override
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
@@ -449,26 +447,24 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
         super.close();
     }
 
-	/**
-	 * Safely and gracefully stop the Debezium engine.
-	 */
-	private void shutdownEngine() {
-		try {
-			if (engine != null) {
-				engine.close();
-			}
-		} catch (IOException e) {
-			ExceptionUtils.rethrow(e);
-		} finally {
-			if (executor != null) {
-				executor.shutdown();
-			}
+    /** Safely and gracefully stop the Debezium engine. */
+    private void shutdownEngine() {
+        try {
+            if (engine != null) {
+                engine.close();
+            }
+        } catch (IOException e) {
+            ExceptionUtils.rethrow(e);
+        } finally {
+            if (executor != null) {
+                executor.shutdown();
+            }
 
-			if (handover != null) {
-				handover.close();
-			}
-		}
-	}
+            if (handover != null) {
+                handover.close();
+            }
+        }
+    }
 
     @Override
     public TypeInformation<T> getProducedType() {

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/DebeziumChangeConsumer.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/DebeziumChangeConsumer.java
@@ -28,7 +28,9 @@ import io.debezium.data.Envelope;
 import io.debezium.embedded.EmbeddedEngineChangeEvent;
 import io.debezium.engine.ChangeEvent;
 import io.debezium.engine.DebeziumEngine;
+import io.debezium.engine.DebeziumEngine.RecordCommitter;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -106,8 +108,10 @@ public class DebeziumChangeConsumer<T> implements Runnable {
 	private void handleBatch() throws Exception {
 		boolean isPhaseChanged = false;
 		while (!isPhaseChanged) {
-			final List<ChangeEvent<SourceRecord, SourceRecord>> events = handover.pollNext();
-			if (CollectionUtils.isNotEmpty(events)) {
+			final Pair<RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>>, List<ChangeEvent<SourceRecord, SourceRecord>>> recordPair = handover.pollNext();
+            final List<ChangeEvent<SourceRecord, SourceRecord>> events = recordPair.getRight();
+            currentCommitter = recordPair.getLeft();
+            if (CollectionUtils.isNotEmpty(events)) {
 				for (ChangeEvent<SourceRecord, SourceRecord> event : events) {
 					SourceRecord record = event.value();
                     if (isHeartbeatEvent(record)) {

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/DebeziumChangeConsumer.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/DebeziumChangeConsumer.java
@@ -21,7 +21,6 @@ package com.alibaba.ververica.cdc.debezium.internal;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.util.Collector;
-import org.apache.flink.util.ExceptionUtils;
 
 import com.alibaba.ververica.cdc.debezium.DebeziumDeserializationSchema;
 import io.debezium.connector.SnapshotRecord;
@@ -29,6 +28,7 @@ import io.debezium.data.Envelope;
 import io.debezium.embedded.EmbeddedEngineChangeEvent;
 import io.debezium.engine.ChangeEvent;
 import io.debezium.engine.DebeziumEngine;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -36,10 +36,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayDeque;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.TimeUnit;
 
 /**
  * A consumer that consumes change messages from {@link DebeziumEngine}.
@@ -72,8 +71,6 @@ public class DebeziumChangeConsumer<T> implements Runnable {
 	 **/
 	private final DebeziumCollector debeziumCollector;
 
-    private final ErrorReporter errorReporter;
-
     private final DebeziumOffset debeziumOffset;
 
     private final DebeziumOffsetSerializer stateSerializer;
@@ -82,7 +79,7 @@ public class DebeziumChangeConsumer<T> implements Runnable {
 
     private boolean isInDbSnapshotPhase;
 
-	private final BlockingQueue<ChangeEvent<SourceRecord, SourceRecord>> changeEventQueue;
+	private final Handover handover;
 
     private DebeziumEngine.RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>>
             currentCommitter;
@@ -93,26 +90,25 @@ public class DebeziumChangeConsumer<T> implements Runnable {
             SourceFunction.SourceContext<T> sourceContext,
             DebeziumDeserializationSchema<T> deserialization,
             boolean isInDbSnapshotPhase,
-            ErrorReporter errorReporter,
             String heartbeatTopicPrefix,
-            BlockingQueue<ChangeEvent<SourceRecord, SourceRecord>> changeEventQueue) {
+			Handover handover) {
         this.sourceContext = sourceContext;
         this.checkpointLock = sourceContext.getCheckpointLock();
         this.deserialization = deserialization;
         this.isInDbSnapshotPhase = isInDbSnapshotPhase;
         this.heartbeatTopicPrefix = heartbeatTopicPrefix;
         this.debeziumCollector = new DebeziumCollector();
-        this.errorReporter = errorReporter;
         this.debeziumOffset = new DebeziumOffset();
         this.stateSerializer = DebeziumOffsetSerializer.INSTANCE;
-        this.changeEventQueue = changeEventQueue;
-    }
+		this.handover = handover;
+	}
 
-	private void handleBatch() {
-		while (true) {
-			try {
-				final ChangeEvent<SourceRecord, SourceRecord> event = changeEventQueue.poll(5L, TimeUnit.SECONDS);
-				if (event != null) {
+	private void handleBatch() throws Exception {
+		boolean isPhaseChanged = false;
+		while (!isPhaseChanged) {
+			final List<ChangeEvent<SourceRecord, SourceRecord>> events = handover.pollNext();
+			if (CollectionUtils.isNotEmpty(events)) {
+				for (ChangeEvent<SourceRecord, SourceRecord> event : events) {
 					SourceRecord record = event.value();
                     if (isHeartbeatEvent(record)) {
                         // keep offset update
@@ -132,13 +128,9 @@ public class DebeziumChangeConsumer<T> implements Runnable {
 
 					if (isInDbSnapshotPhase && !isSnapshotRecord(record)) {
 						isInDbSnapshotPhase = false;
-						break;
+						isPhaseChanged = true;
 					}
 				}
-			} catch (Exception e) {
-				LOG.error("Error happens when consuming change messages.", e);
-				errorReporter.reportError(e);
-				ExceptionUtils.rethrow(e);
 			}
 		}
 	}
@@ -245,15 +237,20 @@ public class DebeziumChangeConsumer<T> implements Runnable {
 
 	@Override
 	public void run() {
-		if (isInDbSnapshotPhase) {
-			synchronized (checkpointLock) {
-				LOG.info("Database snapshot phase can't perform checkpoint, acquired Checkpoint lock.");
-				handleBatch();
+		try {
+			if (isInDbSnapshotPhase) {
+				synchronized (checkpointLock) {
+					LOG.info("Database snapshot phase can't perform checkpoint, acquired Checkpoint lock.");
+					handleBatch();
+				}
+				LOG.info("Received record from streaming binlog phase, released checkpoint lock.");
 			}
-			LOG.info("Received record from streaming binlog phase, released checkpoint lock.");
-		}
 
-		handleBatch();
+			handleBatch();
+		} catch (Throwable t) {
+			LOG.error("Error happens when consuming change messages.", t);
+			handover.reportError(t);
+		}
 	}
 
 	private class DebeziumCollector implements Collector<T> {

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/EventQueueConsumer.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/EventQueueConsumer.java
@@ -27,26 +27,27 @@ import org.apache.kafka.connect.source.SourceRecord;
 
 import java.util.List;
 
-/**
- * Consume debezium change events.
- */
+/** Consume debezium change events. */
 @Internal
-public class EventQueueConsumer implements DebeziumEngine.ChangeConsumer<ChangeEvent<SourceRecord, SourceRecord>> {
+public class EventQueueConsumer
+        implements DebeziumEngine.ChangeConsumer<ChangeEvent<SourceRecord, SourceRecord>> {
 
-	private final Handover handover;
+    private final Handover handover;
 
-	public EventQueueConsumer(Handover handover) {
-		this.handover = handover;
-	}
+    public EventQueueConsumer(Handover handover) {
+        this.handover = handover;
+    }
 
-	@Override
-	public void handleBatch(List<ChangeEvent<SourceRecord, SourceRecord>> events,
-			RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>> recordCommitter) throws InterruptedException {
-		try {
-			handover.produce(recordCommitter, events);
-		} catch (Throwable e) {
-			// this will hold this exception in handover and trigger consumer exit loop
-			handover.reportError(e);
-		}
-	}
+    @Override
+    public void handleBatch(
+            List<ChangeEvent<SourceRecord, SourceRecord>> events,
+            RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>> recordCommitter)
+            throws InterruptedException {
+        try {
+            handover.produce(recordCommitter, events);
+        } catch (Throwable e) {
+            // this will hold this exception in handover and trigger consumer exit loop
+            handover.reportError(e);
+        }
+    }
 }

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/EventQueueConsumer.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/EventQueueConsumer.java
@@ -43,7 +43,7 @@ public class EventQueueConsumer implements DebeziumEngine.ChangeConsumer<ChangeE
 	public void handleBatch(List<ChangeEvent<SourceRecord, SourceRecord>> events,
 			RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>> recordCommitter) throws InterruptedException {
 		try {
-			handover.produce(events);
+			handover.produce(recordCommitter, events);
 		} catch (Throwable e) {
 			// this will hold this exception in handover and trigger consumer exit loop
 			handover.reportError(e);

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/EventQueueConsumer.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/EventQueueConsumer.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.debezium.internal;
+
+import org.apache.flink.annotation.Internal;
+
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.DebeziumEngine;
+import io.debezium.engine.DebeziumEngine.RecordCommitter;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * Consume debezium change events.
+ */
+@Internal
+public class EventQueueConsumer implements DebeziumEngine.ChangeConsumer<ChangeEvent<SourceRecord, SourceRecord>> {
+
+	private final BlockingQueue<ChangeEvent<SourceRecord, SourceRecord>> changeEventQueue;
+
+	public EventQueueConsumer(
+			BlockingQueue<ChangeEvent<SourceRecord, SourceRecord>> changeEventQueue) {
+		this.changeEventQueue = changeEventQueue;
+	}
+
+	@Override
+	public void handleBatch(List<ChangeEvent<SourceRecord, SourceRecord>> events,
+			RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>> recordCommitter) throws InterruptedException {
+		changeEventQueue.addAll(events);
+	}
+}

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/Handover.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/Handover.java
@@ -190,6 +190,15 @@ public class Handover implements Closeable {
     }
 
     /**
+     * Return whether there is an error.
+     *
+     * @return whether there is an error
+     */
+    public boolean hasError() {
+        return this.error != null;
+    }
+
+    /**
      * Closes the handover. Both the {@link #produce(RecordCommitter, List)} method and the {@link
      * #pollNext()} will throw a {@link ClosedException} on any currently blocking and future
      * invocations.
@@ -211,8 +220,8 @@ public class Handover implements Closeable {
         }
     }
 
-    public boolean isClosed() {
-        return error != null;
+    public boolean isCancelled() {
+        return error != null && error instanceof ClosedException;
     }
 
     /**

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/Handover.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/Handover.java
@@ -43,8 +43,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * blocking queue", with some extras around exception reporting, closing, and waking up thread
  * without {@link Thread#interrupt() interrupting} threads.
  *
- * <p>This class is used in the Flink Debezium Engine Consumer to hand over data and exceptions between the
- * thread that runs the DebeziumEngine class and the main thread.
+ * <p>This class is used in the Flink Debezium Engine Consumer to hand over data and exceptions
+ * between the thread that runs the DebeziumEngine class and the main thread.
  *
  * <p>The Handover has the notion of "waking up" the producer thread with a {@link WakeupException}
  * rather than a thread interrupt.
@@ -56,185 +56,194 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class Handover implements Closeable {
 
-	private static final Logger LOG = LoggerFactory.getLogger(Handover.class);
-	private final Object lock = new Object();
+    private static final Logger LOG = LoggerFactory.getLogger(Handover.class);
+    private final Object lock = new Object();
 
-	private Pair<RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>>, List<ChangeEvent<SourceRecord, SourceRecord>>> next;
-	private volatile Throwable error;
-	private boolean wakeupProducer;
+    private Pair<
+                    RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>>,
+                    List<ChangeEvent<SourceRecord, SourceRecord>>>
+            next;
+    private volatile Throwable error;
+    private boolean wakeupProducer;
 
-	/**
-	 * Polls the next element from the Handover, possibly blocking until the next element is
-	 * available. This method behaves similar to polling from a blocking queue.
-	 *
-	 * <p>If an exception was handed in by the producer ({@link #reportError(Throwable)}), then that
-	 * exception is thrown rather than an element being returned.
-	 *
-	 * @return The next element (buffer of records, never null).
-	 * @throws ClosedException Thrown if the Handover was {@link #close() closed}.
-	 * @throws Exception Rethrows exceptions from the {@link #reportError(Throwable)} method.
-	 */
-	@Nonnull
-	public Pair<RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>>, List<ChangeEvent<SourceRecord, SourceRecord>>> pollNext()
-			throws Exception {
-		synchronized (lock) {
-			while (next == null && error == null) {
-				lock.wait();
-			}
+    /**
+     * Polls the next element from the Handover, possibly blocking until the next element is
+     * available. This method behaves similar to polling from a blocking queue.
+     *
+     * <p>If an exception was handed in by the producer ({@link #reportError(Throwable)}), then that
+     * exception is thrown rather than an element being returned.
+     *
+     * @return The next element (buffer of records, never null).
+     * @throws ClosedException Thrown if the Handover was {@link #close() closed}.
+     * @throws Exception Rethrows exceptions from the {@link #reportError(Throwable)} method.
+     */
+    @Nonnull
+    public Pair<
+                    RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>>,
+                    List<ChangeEvent<SourceRecord, SourceRecord>>>
+            pollNext() throws Exception {
+        synchronized (lock) {
+            while (next == null && error == null) {
+                lock.wait();
+            }
 
-			Pair<RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>>, List<ChangeEvent<SourceRecord, SourceRecord>>> n = next;
-			if (n != null) {
-				next = null;
-				lock.notifyAll();
-				return n;
-			} else {
-				ExceptionUtils.rethrow(error, error.getMessage());
+            Pair<
+                            RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>>,
+                            List<ChangeEvent<SourceRecord, SourceRecord>>>
+                    n = next;
+            if (n != null) {
+                next = null;
+                lock.notifyAll();
+                return n;
+            } else {
+                ExceptionUtils.rethrow(error, error.getMessage());
 
-				// this statement cannot be reached since the above method always throws an
-				// exception
-				// this is only here to silence the compiler and any warnings
-				return Pair.of(null, Collections.emptyList());
-			}
-		}
-	}
+                // this statement cannot be reached since the above method always throws an
+                // exception
+                // this is only here to silence the compiler and any warnings
+                return Pair.of(null, Collections.emptyList());
+            }
+        }
+    }
 
-	/**
-	 * Hands over an element from the producer. If the Handover already has an element that was not
-	 * yet picked up by the consumer thread, this call blocks until the consumer picks up that
-	 * previous element.
-	 *
-	 * <p>This behavior is similar to a "size one" blocking queue.
-	 *
-	 * @param committer The next element committer.
-	 * @param element The next element to hand over.
-	 * @throws InterruptedException Thrown, if the thread is interrupted while blocking for the
-	 *         Handover to be empty.
-	 * @throws WakeupException Thrown, if the {@link #wakeupProducer()} method is called while
-	 *         blocking for the Handover to be empty.
-	 * @throws ClosedException Thrown if the Handover was closed or concurrently being closed.
-	 */
-	public void produce(final RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>> committer,
-			final List<ChangeEvent<SourceRecord, SourceRecord>> element)
-			throws InterruptedException, WakeupException, ClosedException {
+    /**
+     * Hands over an element from the producer. If the Handover already has an element that was not
+     * yet picked up by the consumer thread, this call blocks until the consumer picks up that
+     * previous element.
+     *
+     * <p>This behavior is similar to a "size one" blocking queue.
+     *
+     * @param committer The next element committer.
+     * @param element The next element to hand over.
+     * @throws InterruptedException Thrown, if the thread is interrupted while blocking for the
+     *     Handover to be empty.
+     * @throws WakeupException Thrown, if the {@link #wakeupProducer()} method is called while
+     *     blocking for the Handover to be empty.
+     * @throws ClosedException Thrown if the Handover was closed or concurrently being closed.
+     */
+    public void produce(
+            final RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>> committer,
+            final List<ChangeEvent<SourceRecord, SourceRecord>> element)
+            throws InterruptedException, WakeupException, ClosedException {
 
-		checkNotNull(committer);
-		checkNotNull(element);
+        checkNotNull(committer);
+        checkNotNull(element);
 
-		synchronized (lock) {
-			while (next != null && !wakeupProducer) {
-				lock.wait();
-			}
+        synchronized (lock) {
+            while (next != null && !wakeupProducer) {
+                lock.wait();
+            }
 
-			wakeupProducer = false;
+            wakeupProducer = false;
 
-			// if there is still an element, we must have been woken up
-			if (next != null) {
-				throw new WakeupException();
-			}
-			// if there is no error, then this is open and can accept this element
-			else if (error == null) {
-				next = Pair.of(committer, element);
-				lock.notifyAll();
-			}
-			// an error marks this as closed for the producer
-			else {
-				ExceptionUtils.rethrow(error, error.getMessage());
-			}
-		}
-	}
+            // if there is still an element, we must have been woken up
+            if (next != null) {
+                throw new WakeupException();
+            }
+            // if there is no error, then this is open and can accept this element
+            else if (error == null) {
+                next = Pair.of(committer, element);
+                lock.notifyAll();
+            }
+            // an error marks this as closed for the producer
+            else {
+                ExceptionUtils.rethrow(error, error.getMessage());
+            }
+        }
+    }
 
-	/**
-	 * Reports an exception. The consumer will throw the given exception immediately, if it is
-	 * currently blocked in the {@link #pollNext()} method, or the next time it calls that method.
-	 *
-	 * <p>After this method has been called, no call to either {@link #produce(RecordCommitter, List)} or
-	 * {@link #pollNext()} will ever return regularly any more, but will always return
-	 * exceptionally.
-	 *
-	 * <p>If another exception was already reported, this method does nothing.
-	 *
-	 * <p>For the producer, the Handover will appear as if it was {@link #close() closed}.
-	 *
-	 * @param t The exception to report.
-	 */
-	public void reportError(Throwable t) {
-		checkNotNull(t);
+    /**
+     * Reports an exception. The consumer will throw the given exception immediately, if it is
+     * currently blocked in the {@link #pollNext()} method, or the next time it calls that method.
+     *
+     * <p>After this method has been called, no call to either {@link #produce(RecordCommitter,
+     * List)} or {@link #pollNext()} will ever return regularly any more, but will always return
+     * exceptionally.
+     *
+     * <p>If another exception was already reported, this method does nothing.
+     *
+     * <p>For the producer, the Handover will appear as if it was {@link #close() closed}.
+     *
+     * @param t The exception to report.
+     */
+    public void reportError(Throwable t) {
+        checkNotNull(t);
 
-		synchronized (lock) {
-			LOG.error("Reporting error:", t);
-			// do not override the initial exception
-			if (error == null) {
-				error = t;
-			}
-			next = null;
-			lock.notifyAll();
-		}
-	}
+        synchronized (lock) {
+            LOG.error("Reporting error:", t);
+            // do not override the initial exception
+            if (error == null) {
+                error = t;
+            }
+            next = null;
+            lock.notifyAll();
+        }
+    }
 
-	/**
-	 * Return the error in handover.
-	 *
-	 * @return error in handover
-	 */
-	public Throwable getError() {
-		return this.error;
-	}
+    /**
+     * Return the error in handover.
+     *
+     * @return error in handover
+     */
+    public Throwable getError() {
+        return this.error;
+    }
 
-	/**
-	 * Closes the handover. Both the {@link #produce(RecordCommitter, List)} method and the {@link
-	 * #pollNext()} will throw a {@link ClosedException} on any currently blocking and future
-	 * invocations.
-	 *
-	 * <p>If an exception was previously reported via the {@link #reportError(Throwable)} method,
-	 * that exception will not be overridden. The consumer thread will throw that exception upon
-	 * calling {@link #pollNext()}, rather than the {@code ClosedException}.
-	 */
-	@Override
-	public void close() {
-		synchronized (lock) {
-			next = null;
-			wakeupProducer = false;
+    /**
+     * Closes the handover. Both the {@link #produce(RecordCommitter, List)} method and the {@link
+     * #pollNext()} will throw a {@link ClosedException} on any currently blocking and future
+     * invocations.
+     *
+     * <p>If an exception was previously reported via the {@link #reportError(Throwable)} method,
+     * that exception will not be overridden. The consumer thread will throw that exception upon
+     * calling {@link #pollNext()}, rather than the {@code ClosedException}.
+     */
+    @Override
+    public void close() {
+        synchronized (lock) {
+            next = null;
+            wakeupProducer = false;
 
-			if (error == null) {
-				error = new ClosedException();
-			}
-			lock.notifyAll();
-		}
-	}
+            if (error == null) {
+                error = new ClosedException();
+            }
+            lock.notifyAll();
+        }
+    }
 
-	public boolean isClosed() {
-		return error != null;
-	}
+    public boolean isClosed() {
+        return error != null;
+    }
 
-	/**
-	 * Wakes the producer thread up. If the producer thread is currently blocked in the {@link
-	 * #produce(RecordCommitter, List)} method, it will exit the method throwing a {@link
-	 * WakeupException}.
-	 */
-	public void wakeupProducer() {
-		synchronized (lock) {
-			wakeupProducer = true;
-			lock.notifyAll();
-		}
-	}
+    /**
+     * Wakes the producer thread up. If the producer thread is currently blocked in the {@link
+     * #produce(RecordCommitter, List)} method, it will exit the method throwing a {@link
+     * WakeupException}.
+     */
+    public void wakeupProducer() {
+        synchronized (lock) {
+            wakeupProducer = true;
+            lock.notifyAll();
+        }
+    }
 
-	// ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
-	/**
-	 * An exception thrown by the Handover in the {@link #pollNext()} or {@link
-	 * #produce(RecordCommitter, List)} method, after the Handover was closed via {@link #close()}.
-	 */
-	public static final class ClosedException extends Exception {
+    /**
+     * An exception thrown by the Handover in the {@link #pollNext()} or {@link
+     * #produce(RecordCommitter, List)} method, after the Handover was closed via {@link #close()}.
+     */
+    public static final class ClosedException extends Exception {
 
-		private static final long serialVersionUID = 1L;
-	}
+        private static final long serialVersionUID = 1L;
+    }
 
-	/**
-	 * A special exception thrown bv the Handover in the {@link #produce(RecordCommitter, List)} method
-	 * when the producer is woken up from a blocking call via {@link #wakeupProducer()}.
-	 */
-	public static final class WakeupException extends Exception {
+    /**
+     * A special exception thrown bv the Handover in the {@link #produce(RecordCommitter, List)}
+     * method when the producer is woken up from a blocking call via {@link #wakeupProducer()}.
+     */
+    public static final class WakeupException extends Exception {
 
-		private static final long serialVersionUID = 1L;
-	}
+        private static final long serialVersionUID = 1L;
+    }
 }

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/Handover.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/Handover.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.debezium.internal;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.ExceptionUtils;
+
+import io.debezium.engine.ChangeEvent;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The Handover is a utility to hand over data (a buffer of records) and exception from a
+ * <i>producer</i> thread to a <i>consumer</i> thread. It effectively behaves like a "size one
+ * blocking queue", with some extras around exception reporting, closing, and waking up thread
+ * without {@link Thread#interrupt() interrupting} threads.
+ *
+ * <p>This class is used in the Flink Debezium Engine Consumer to hand over data and exceptions between the
+ * thread that runs the DebeziumEngine class and the main thread.
+ *
+ * <p>The Handover has the notion of "waking up" the producer thread with a {@link WakeupException}
+ * rather than a thread interrupt.
+ *
+ * <p>The Handover can also be "closed", signalling from one thread to the other that it the thread
+ * has terminated.
+ */
+@ThreadSafe
+@Internal
+public class Handover implements Closeable {
+
+	private static final Logger LOG = LoggerFactory.getLogger(Handover.class);
+	private final Object lock = new Object();
+
+	private List<ChangeEvent<SourceRecord, SourceRecord>> next;
+	private volatile Throwable error;
+	private boolean wakeupProducer;
+
+	/**
+	 * Polls the next element from the Handover, possibly blocking until the next element is
+	 * available. This method behaves similar to polling from a blocking queue.
+	 *
+	 * <p>If an exception was handed in by the producer ({@link #reportError(Throwable)}), then that
+	 * exception is thrown rather than an element being returned.
+	 *
+	 * @return The next element (buffer of records, never null).
+	 * @throws ClosedException Thrown if the Handover was {@link #close() closed}.
+	 * @throws Exception Rethrows exceptions from the {@link #reportError(Throwable)} method.
+	 */
+	@Nonnull
+	public List<ChangeEvent<SourceRecord, SourceRecord>> pollNext() throws Exception {
+		synchronized (lock) {
+			while (next == null && error == null) {
+				lock.wait();
+			}
+
+			List<ChangeEvent<SourceRecord, SourceRecord>> n = next;
+			if (n != null) {
+				next = null;
+				lock.notifyAll();
+				return n;
+			} else {
+				ExceptionUtils.rethrow(error, error.getMessage());
+
+				// this statement cannot be reached since the above method always throws an
+				// exception
+				// this is only here to silence the compiler and any warnings
+				return Collections.emptyList();
+			}
+		}
+	}
+
+	/**
+	 * Hands over an element from the producer. If the Handover already has an element that was not
+	 * yet picked up by the consumer thread, this call blocks until the consumer picks up that
+	 * previous element.
+	 *
+	 * <p>This behavior is similar to a "size one" blocking queue.
+	 *
+	 * @param element The next element to hand over.
+	 * @throws InterruptedException Thrown, if the thread is interrupted while blocking for the
+	 *         Handover to be empty.
+	 * @throws WakeupException Thrown, if the {@link #wakeupProducer()} method is called while
+	 *         blocking for the Handover to be empty.
+	 * @throws ClosedException Thrown if the Handover was closed or concurrently being closed.
+	 */
+	public void produce(final List<ChangeEvent<SourceRecord, SourceRecord>> element)
+			throws InterruptedException, WakeupException, ClosedException {
+
+		checkNotNull(element);
+
+		synchronized (lock) {
+			while (next != null && !wakeupProducer) {
+				lock.wait();
+			}
+
+			wakeupProducer = false;
+
+			// if there is still an element, we must have been woken up
+			if (next != null) {
+				throw new WakeupException();
+			}
+			// if there is no error, then this is open and can accept this element
+			else if (error == null) {
+				next = element;
+				lock.notifyAll();
+			}
+			// an error marks this as closed for the producer
+			else {
+				ExceptionUtils.rethrow(error, error.getMessage());
+			}
+		}
+	}
+
+	/**
+	 * Reports an exception. The consumer will throw the given exception immediately, if it is
+	 * currently blocked in the {@link #pollNext()} method, or the next time it calls that method.
+	 *
+	 * <p>After this method has been called, no call to either {@link #produce(List)} or
+	 * {@link #pollNext()} will ever return regularly any more, but will always return
+	 * exceptionally.
+	 *
+	 * <p>If another exception was already reported, this method does nothing.
+	 *
+	 * <p>For the producer, the Handover will appear as if it was {@link #close() closed}.
+	 *
+	 * @param t The exception to report.
+	 */
+	public void reportError(Throwable t) {
+		checkNotNull(t);
+
+		synchronized (lock) {
+			LOG.error("Reporting error:", t);
+			// do not override the initial exception
+			if (error == null) {
+				error = t;
+			}
+			next = null;
+			lock.notifyAll();
+		}
+	}
+
+	/**
+	 * Return the error in handover.
+	 *
+	 * @return error in handover
+	 */
+	public Throwable getError() {
+		return this.error;
+	}
+
+	/**
+	 * Closes the handover. Both the {@link #produce(List)} method and the {@link
+	 * #pollNext()} will throw a {@link ClosedException} on any currently blocking and future
+	 * invocations.
+	 *
+	 * <p>If an exception was previously reported via the {@link #reportError(Throwable)} method,
+	 * that exception will not be overridden. The consumer thread will throw that exception upon
+	 * calling {@link #pollNext()}, rather than the {@code ClosedException}.
+	 */
+	@Override
+	public void close() {
+		synchronized (lock) {
+			next = null;
+			wakeupProducer = false;
+
+			if (error == null) {
+				error = new ClosedException();
+			}
+			lock.notifyAll();
+		}
+	}
+
+	public boolean isClosed() {
+		return error != null;
+	}
+
+	/**
+	 * Wakes the producer thread up. If the producer thread is currently blocked in the {@link
+	 * #produce(List)} method, it will exit the method throwing a {@link
+	 * WakeupException}.
+	 */
+	public void wakeupProducer() {
+		synchronized (lock) {
+			wakeupProducer = true;
+			lock.notifyAll();
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * An exception thrown by the Handover in the {@link #pollNext()} or {@link
+	 * #produce(List)} method, after the Handover was closed via {@link #close()}.
+	 */
+	public static final class ClosedException extends Exception {
+
+		private static final long serialVersionUID = 1L;
+	}
+
+	/**
+	 * A special exception thrown bv the Handover in the {@link #produce(List)} method
+	 * when the producer is woken up from a blocking call via {@link #wakeupProducer()}.
+	 */
+	public static final class WakeupException extends Exception {
+
+		private static final long serialVersionUID = 1L;
+	}
+}


### PR DESCRIPTION
#10 I used a queue to store the change event and another consumption thread to consume it, eliminating the use of the `Unsafe` class