### PR TITLE
[fix bugs] fixed NPE issues when take a snapshot for an empty table.

### DIFF
--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/DebeziumSourceFunction.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/DebeziumSourceFunction.java
@@ -265,7 +265,7 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
             }
         } else {
             byte[] currentState = consumer.snapshotCurrentState();
-            if (currentState == null) {
+            if (currentState == null && restoredOffsetState != null) {
                 // the consumer has been initialized, but has not yet received any data,
                 // which means we need to return the originally restored offsets
                 serializedOffset = restoredOffsetState.getBytes(StandardCharsets.UTF_8);

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/DebeziumOffsetSerializer.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/DebeziumOffsetSerializer.java
@@ -20,6 +20,7 @@ package com.alibaba.ververica.cdc.debezium.internal;
 
 import org.apache.flink.annotation.Internal;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
@@ -38,6 +39,7 @@ public class DebeziumOffsetSerializer {
 
     public DebeziumOffset deserialize(byte[] bytes) throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(DeserializationFeature.USE_LONG_FOR_INTS);
         return objectMapper.readValue(bytes, DebeziumOffset.class);
     }
 }


### PR DESCRIPTION
when take a snapshot for an empty table, both currentState and restoredOffsetState will be null and will throw an NullPointerException.