### PR TITLE
[ISSUE-11] MongoDB cdc connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This README is meant as a brief walkthrough on the core features with Flink CDC 
 | --- | --- |
 | MySQL | Database: 5.7, 8.0.x <br/>JDBC Driver: 8.0.16 |
 | PostgreSQL | Database: 9.6, 10, 11, 12 <br/>JDBC Driver: 42.2.12|
+| MongoDB | Database: 4.0, 4.2 <br/> MongoDB Driver: 4.2.0 |
 
 ## Features
 

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -228,7 +228,7 @@ public final class RowDataDebeziumDeserializeSchema
 
     private long convertToLong(Object dbzObj, Schema schema) {
         if (dbzObj instanceof Integer) {
-            return (long) dbzObj;
+            return ((Integer) dbzObj).longValue();
         } else if (dbzObj instanceof Long) {
             return (long) dbzObj;
         } else {
@@ -238,7 +238,7 @@ public final class RowDataDebeziumDeserializeSchema
 
     private double convertToDouble(Object dbzObj, Schema schema) {
         if (dbzObj instanceof Float) {
-            return (double) dbzObj;
+            return ((Float) dbzObj).doubleValue();
         } else if (dbzObj instanceof Double) {
             return (double) dbzObj;
         } else {

--- a/flink-connector-mongodb-cdc/pom.xml
+++ b/flink-connector-mongodb-cdc/pom.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>flink-cdc-connectors</artifactId>
+        <groupId>com.alibaba.ververica</groupId>
+        <version>1.4-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>flink-connector-mongodb-cdc</artifactId>
+    <name>flink-connector-mongodb-cdc</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <!-- Debezium dependencies -->
+        <dependency>
+            <groupId>com.alibaba.ververica</groupId>
+            <artifactId>flink-connector-debezium</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>kafka-log4j-appender</artifactId>
+                    <groupId>org.apache.kafka</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Mongo kafka connect dependencies -->
+        <dependency>
+            <groupId>org.mongodb.kafka</groupId>
+            <artifactId>mongo-kafka-connect</artifactId>
+            <version>1.4.0</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>mongodb-driver-sync</artifactId>
+                    <groupId>org.mongodb</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>connect-api</artifactId>
+                    <groupId>org.apache.kafka</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>4.2.0</version>
+        </dependency>
+
+        <!-- test dependencies on Flink -->
+        <dependency>
+            <groupId>com.alibaba.ververica</groupId>
+            <artifactId>flink-connector-test-util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-tests</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- test dependencies on TestContainers -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>2.4.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- tests will have log4j as the default logging framework available -->
+
+        <!-- Logging API -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Enforce single fork execution due to heavy mini cluster use in the tests -->
+                    <forkCount>1</forkCount>
+                    <argLine>-Xms256m -Xmx2048m -Dlog4j.configurationFile=${log4j.configuration}
+                        -Dmvn.forkNumber=${surefire.forkNumber} -XX:-UseGCOverheadLimit
+                    </argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/MongoDBDebeziumSourceFunction.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/MongoDBDebeziumSourceFunction.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mongodb;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import com.alibaba.ververica.cdc.connectors.mongodb.internal.MongoDBConnectorDebeziumChangeConsumer;
+import com.alibaba.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import com.alibaba.ververica.cdc.debezium.DebeziumSourceFunction;
+import com.alibaba.ververica.cdc.debezium.internal.DebeziumChangeConsumer;
+import com.alibaba.ververica.cdc.debezium.internal.DebeziumOffset;
+
+import javax.annotation.Nullable;
+
+import java.util.Properties;
+
+/**
+ * The {@link MongoDBDebeziumSourceFunction} is a streaming data source that pulls captured change
+ * data from databases into Flink.
+ *
+ * <p>The source function participates in checkpointing and guarantees that no data is lost during a
+ * failure, and that the computation processes elements "exactly once".
+ *
+ * <p>Note: currently, the source function can't run in multiple parallel instances.
+ *
+ * <p>Please refer to MongoDB Kafka Connector's documentation for the available configuration
+ * properties: https://docs.mongodb.com/kafka-connector/current/kafka-source
+ */
+@PublicEvolving
+public class MongoDBDebeziumSourceFunction<T> extends DebeziumSourceFunction<T> {
+
+    private static final long serialVersionUID = -2840579426476622716L;
+
+    public MongoDBDebeziumSourceFunction(
+            DebeziumDeserializationSchema<T> deserializer,
+            Properties properties,
+            @Nullable DebeziumOffset specificOffset) {
+        super(deserializer, properties, specificOffset);
+    }
+
+    @Override
+    protected DebeziumChangeConsumer<T> createConsumer(
+            SourceContext<T> sourceContext, boolean isInDbSnapshotPhase) {
+        return new MongoDBConnectorDebeziumChangeConsumer<>(
+                sourceContext, deserializer, isInDbSnapshotPhase, this::reportError);
+    }
+}

--- a/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/MongoDBSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/MongoDBSource.java
@@ -1,0 +1,330 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mongodb;
+
+import com.alibaba.ververica.cdc.connectors.mongodb.internal.MongoDBConnectorSourceConnector;
+import com.alibaba.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import com.alibaba.ververica.cdc.debezium.DebeziumSourceFunction;
+import com.mongodb.client.model.changestream.FullDocument;
+import com.mongodb.kafka.connect.source.MongoSourceConfig;
+import com.mongodb.kafka.connect.source.MongoSourceConfig.ErrorTolerance;
+import com.mongodb.kafka.connect.source.MongoSourceConfig.OutputFormat;
+
+import java.util.Locale;
+import java.util.Properties;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A builder to build a SourceFunction which can read snapshot and continue to consume change stream
+ * events.
+ */
+public class MongoDBSource {
+
+    public static final String OUTPUT_FORMAT_SCHEMA =
+            OutputFormat.SCHEMA.name().toLowerCase(Locale.ROOT);
+
+    public static final String ERROR_TOLERANCE_NONE = ErrorTolerance.NONE.value();
+
+    public static final String ERROR_TOLERANCE_ALL = ErrorTolerance.ALL.value();
+
+    public static final String FULL_DOCUMENT_UPDATE_LOOKUP = FullDocument.UPDATE_LOOKUP.getValue();
+
+    public static final int POLL_MAX_BATCH_SIZE_DEFAULT = 1000;
+
+    public static final int POLL_AWAIT_TIME_MILLIS_DEFAULT = 1500;
+
+    public static <T> Builder<T> builder() {
+        return new Builder<>();
+    }
+
+    /** Builder class of {@link MongoDBSource}. */
+    public static class Builder<T> {
+
+        private String connectionUri;
+        private String database;
+        private String collection;
+        private String pipeline;
+        private Integer batchSize;
+        private Integer pollAwaitTimeMillis = POLL_AWAIT_TIME_MILLIS_DEFAULT;
+        private Integer pollMaxBatchSize = POLL_MAX_BATCH_SIZE_DEFAULT;
+        private Boolean copyExisting = true;
+        private Integer copyExistingMaxThreads;
+        private Integer copyExistingQueueSize;
+        private String copyExistingPipeline;
+        private Boolean errorsLogEnable;
+        private String errorsTolerance;
+        private Integer heartbeatIntervalMillis;
+        private DebeziumDeserializationSchema<T> deserializer;
+
+        /**
+         * connection.uri
+         *
+         * <p>A valid MongoDB connection URI string eg. mongodb://username:password@localhost/
+         *
+         * <p>Accepted Values: A valid MongoDB connection URI string
+         */
+        public Builder<T> connectionUri(String connectionUri) {
+            this.connectionUri = connectionUri;
+            return this;
+        }
+
+        /** Name of the database to watch for changes. */
+        public Builder<T> database(String database) {
+            this.database = database;
+            return this;
+        }
+
+        /** Name of the collection in the database to watch for changes. */
+        public Builder<T> collection(String collection) {
+            this.collection = collection;
+            return this;
+        }
+
+        /**
+         * An array of objects describing the pipeline operations to run. eg. [{"$match":
+         * {"operationType": "insert"}}, {"$addFields": {"Kafka": "Rules!"}}]
+         */
+        public Builder<T> pipeline(String pipeline) {
+            this.pipeline = pipeline;
+            return this;
+        }
+
+        /**
+         * batch.size
+         *
+         * <p>The cursor batch size. Default: 0
+         */
+        public Builder<T> batchSize(Integer batchSize) {
+            checkArgument(batchSize >= 0);
+            this.batchSize = batchSize;
+            return this;
+        }
+
+        /**
+         * poll.await.time.ms
+         *
+         * <p>The amount of time to wait before checking for new results on the change stream.
+         * Default: 3000
+         */
+        public Builder<T> pollAwaitTimeMillis(int pollAwaitTimeMillis) {
+            checkArgument(pollAwaitTimeMillis > 0);
+            this.pollAwaitTimeMillis = pollAwaitTimeMillis;
+            return this;
+        }
+
+        /**
+         * poll.max.batch.size
+         *
+         * <p>Maximum number of change stream documents to include in a single batch when polling
+         * for new data. This setting can be used to limit the amount of data buffered internally in
+         * the connector. Default: 1000
+         */
+        public Builder<T> pollMaxBatchSize(int pollMaxBatchSize) {
+            checkArgument(pollMaxBatchSize > 0);
+            this.pollMaxBatchSize = pollMaxBatchSize;
+            return this;
+        }
+
+        /**
+         * copy.existing
+         *
+         * <p>Copy existing data from source collections and convert them to Change Stream events on
+         * their respective topics. Any changes to the data that occur during the copy process are
+         * applied once the copy is completed.
+         */
+        public Builder<T> copyExisting(boolean copyExisting) {
+            this.copyExisting = copyExisting;
+            return this;
+        }
+
+        /**
+         * copy.existing.max.threads
+         *
+         * <p>The number of threads to use when performing the data copy. Defaults to the number of
+         * processors. Default: defaults to the number of processors
+         */
+        public Builder<T> copyExistingMaxThreads(Integer copyExistingMaxThreads) {
+            checkArgument(copyExistingMaxThreads > 0);
+            this.copyExistingMaxThreads = copyExistingMaxThreads;
+            return this;
+        }
+
+        /**
+         * copy.existing.queue.size
+         *
+         * <p>The max size of the queue to use when copying data. Default: 16000
+         */
+        public Builder<T> copyExistingQueueSize(Integer copyExistingQueueSize) {
+            checkArgument(copyExistingQueueSize > 0);
+            this.copyExistingQueueSize = copyExistingQueueSize;
+            return this;
+        }
+
+        /**
+         * copy.existing.pipeline eg. [ { "$match": { "closed": "false" } } ]
+         *
+         * <p>An array of JSON objects describing the pipeline operations to run when copying
+         * existing data. This can improve the use of indexes by the copying manager and make
+         * copying more efficient.
+         */
+        public Builder<T> copyExistingPipeline(String copyExistingPipeline) {
+            this.copyExistingPipeline = copyExistingPipeline;
+            return this;
+        }
+
+        /**
+         * errors.log.enable
+         *
+         * <p>Whether details of failed operations should be written to the log file. When set to
+         * true, both errors that are tolerated (determined by the errors.tolerance setting) and not
+         * tolerated are written. When set to false, errors that are tolerated are omitted.
+         */
+        public Builder<T> errorsLogEnable(boolean errorsLogEnable) {
+            this.errorsLogEnable = errorsLogEnable;
+            return this;
+        }
+
+        /**
+         * errors.tolerance
+         *
+         * <p>Whether to continue processing messages if an error is encountered. When set to none,
+         * the connector reports an error and blocks further processing of the rest of the records
+         * when it encounters an error. When set to all, the connector silently ignores any bad
+         * messages.
+         *
+         * <p>Default: "none" Accepted Values: "none" or "all"
+         */
+        public Builder<T> errorsTolerance(String errorsTolerance) {
+            this.errorsTolerance = errorsTolerance;
+            return this;
+        }
+
+        /**
+         * heartbeat.interval.ms
+         *
+         * <p>The length of time in milliseconds between sending heartbeat messages. Heartbeat
+         * messages contain the post batch resume token and are sent when no source records have
+         * been published in the specified interval. This improves the resumability of the connector
+         * for low volume namespaces. Use 0 to disable.
+         */
+        public Builder<T> heartbeatIntervalMillis(int heartbeatIntervalMillis) {
+            checkArgument(heartbeatIntervalMillis >= 0);
+            this.heartbeatIntervalMillis = heartbeatIntervalMillis;
+            return this;
+        }
+
+        /**
+         * The deserializer used to convert from consumed {@link
+         * org.apache.kafka.connect.source.SourceRecord}.
+         */
+        public Builder<T> deserializer(DebeziumDeserializationSchema<T> deserializer) {
+            this.deserializer = deserializer;
+            return this;
+        }
+
+        /**
+         * The properties of mongodb kafka connector.
+         * https://docs.mongodb.com/kafka-connector/current/kafka-source
+         */
+        public DebeziumSourceFunction<T> build() {
+            Properties props = new Properties();
+
+            props.setProperty(
+                    "connector.class", MongoDBConnectorSourceConnector.class.getCanonicalName());
+            props.setProperty("name", "mongodb_binlog_source");
+
+            props.setProperty(MongoSourceConfig.CONNECTION_URI_CONFIG, checkNotNull(connectionUri));
+            props.setProperty(MongoSourceConfig.DATABASE_CONFIG, checkNotNull(database));
+            props.setProperty(MongoSourceConfig.COLLECTION_CONFIG, checkNotNull(collection));
+
+            props.setProperty(MongoSourceConfig.FULL_DOCUMENT_CONFIG, FULL_DOCUMENT_UPDATE_LOOKUP);
+            props.setProperty(
+                    MongoSourceConfig.PUBLISH_FULL_DOCUMENT_ONLY_CONFIG,
+                    String.valueOf(Boolean.FALSE));
+
+            props.setProperty(
+                    MongoSourceConfig.OUTPUT_SCHEMA_INFER_VALUE_CONFIG,
+                    String.valueOf(Boolean.FALSE));
+            props.setProperty(MongoSourceConfig.OUTPUT_FORMAT_KEY_CONFIG, OUTPUT_FORMAT_SCHEMA);
+            props.setProperty(MongoSourceConfig.OUTPUT_FORMAT_VALUE_CONFIG, OUTPUT_FORMAT_SCHEMA);
+
+            if (pipeline != null) {
+                props.setProperty(MongoSourceConfig.PIPELINE_CONFIG, pipeline);
+            }
+
+            if (batchSize != null) {
+                props.setProperty(MongoSourceConfig.BATCH_SIZE_CONFIG, String.valueOf(batchSize));
+            }
+
+            if (pollAwaitTimeMillis != null) {
+                props.setProperty(
+                        MongoSourceConfig.POLL_AWAIT_TIME_MS_CONFIG,
+                        String.valueOf(pollAwaitTimeMillis));
+            }
+
+            if (pollMaxBatchSize != null) {
+                props.setProperty(
+                        MongoSourceConfig.POLL_MAX_BATCH_SIZE_CONFIG,
+                        String.valueOf(pollMaxBatchSize));
+            }
+
+            if (errorsLogEnable != null) {
+                props.setProperty(
+                        MongoSourceConfig.ERRORS_LOG_ENABLE_CONFIG,
+                        String.valueOf(errorsLogEnable));
+            }
+
+            if (errorsTolerance != null) {
+                props.setProperty(MongoSourceConfig.ERRORS_TOLERANCE_CONFIG, errorsTolerance);
+            }
+
+            if (copyExisting != null) {
+                props.setProperty(
+                        MongoSourceConfig.COPY_EXISTING_CONFIG, String.valueOf(copyExisting));
+            }
+
+            if (copyExistingMaxThreads != null) {
+                props.setProperty(
+                        MongoSourceConfig.COPY_EXISTING_MAX_THREADS_CONFIG,
+                        String.valueOf(copyExistingMaxThreads));
+            }
+
+            if (copyExistingQueueSize != null) {
+                props.setProperty(
+                        MongoSourceConfig.COPY_EXISTING_QUEUE_SIZE_CONFIG,
+                        String.valueOf(copyExistingQueueSize));
+            }
+
+            if (copyExistingPipeline != null) {
+                props.setProperty(
+                        MongoSourceConfig.COPY_EXISTING_PIPELINE_CONFIG, copyExistingPipeline);
+            }
+
+            if (heartbeatIntervalMillis != null) {
+                props.setProperty(
+                        MongoSourceConfig.HEARTBEAT_INTERVAL_MS_CONFIG,
+                        String.valueOf(heartbeatIntervalMillis));
+            }
+
+            return new MongoDBDebeziumSourceFunction<>(deserializer, props, null);
+        }
+    }
+}

--- a/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/internal/MongoDBConnectorDebeziumChangeConsumer.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/internal/MongoDBConnectorDebeziumChangeConsumer.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mongodb.internal;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+
+import com.alibaba.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import com.alibaba.ververica.cdc.debezium.internal.DebeziumChangeConsumer;
+import com.alibaba.ververica.cdc.debezium.internal.ErrorReporter;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.bson.json.JsonReader;
+
+/**
+ * A consumer that consumes mongodb change messages from {@link io.debezium.engine.DebeziumEngine}.
+ *
+ * @param <T> The type of elements produced by the consumer.
+ */
+@Internal
+public class MongoDBConnectorDebeziumChangeConsumer<T> extends DebeziumChangeConsumer<T> {
+
+    private static final String HEARTBEAT_TOPIC_NAME_DEFAULT = "__mongodb_heartbeats";
+
+    private static final String COPY_KEY = "copy";
+
+    private static final String CLUSTER_TIME_FIELD = "clusterTime";
+
+    private static final String TRUE = "true";
+
+    public MongoDBConnectorDebeziumChangeConsumer(
+            SourceFunction.SourceContext<T> sourceContext,
+            DebeziumDeserializationSchema<T> deserialization,
+            boolean isInDbSnapshotPhase,
+            ErrorReporter errorReporter) {
+        super(
+                sourceContext,
+                deserialization,
+                isInDbSnapshotPhase,
+                errorReporter,
+                HEARTBEAT_TOPIC_NAME_DEFAULT);
+    }
+
+    @Override
+    protected boolean isSnapshotRecord(SourceRecord record) {
+        return TRUE.equals(record.sourceOffset().get(COPY_KEY));
+    }
+
+    @Override
+    protected Long getMessageTimestamp(SourceRecord record) {
+        if (isHeartbeatEvent(record)) {
+            return System.currentTimeMillis();
+        }
+
+        Schema schema = record.valueSchema();
+        Struct value = (Struct) record.value();
+
+        if (schema.field(CLUSTER_TIME_FIELD) == null) {
+            return null;
+        }
+
+        String clusterTime = value.getString(CLUSTER_TIME_FIELD);
+        if (clusterTime == null) {
+            return null;
+        }
+
+        return new JsonReader(clusterTime).readTimestamp().getTime() * 1000L;
+    }
+}

--- a/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/internal/MongoDBConnectorSourceConnector.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/internal/MongoDBConnectorSourceConnector.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mongodb.internal;
+
+import com.mongodb.kafka.connect.MongoSourceConnector;
+import org.apache.kafka.connect.connector.Task;
+
+/** SourceConnector uses {@link MongoDBConnectorSourceTask}. */
+public class MongoDBConnectorSourceConnector extends MongoSourceConnector {
+    @Override
+    public Class<? extends Task> taskClass() {
+        return MongoDBConnectorSourceTask.class;
+    }
+}

--- a/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/internal/MongoDBConnectorSourceTask.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/internal/MongoDBConnectorSourceTask.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mongodb.internal;
+
+import com.mongodb.kafka.connect.source.MongoSourceTask;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTask;
+import org.apache.kafka.connect.source.SourceTaskContext;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Source Task that holds mongodb kafka connector's source task to perceive the end of the snapshot
+ * phase.
+ */
+public class MongoDBConnectorSourceTask extends SourceTask {
+
+    private static final String COPY_KEY = "copy";
+
+    private static final String TRUE = "true";
+
+    private final MongoSourceTask delegate;
+
+    private final Field isCopyingField;
+
+    private SourceRecord lastSnapshotRecord;
+
+    private boolean isInSnapshotPhase = false;
+
+    public MongoDBConnectorSourceTask() throws NoSuchFieldException {
+        this.delegate = new MongoSourceTask();
+        this.isCopyingField = MongoSourceTask.class.getDeclaredField("isCopying");
+    }
+
+    @Override
+    public String version() {
+        return delegate.version();
+    }
+
+    @Override
+    public void initialize(SourceTaskContext context) {
+        this.delegate.initialize(context);
+        this.context = context;
+    }
+
+    @Override
+    public void start(Map<String, String> props) {
+        delegate.start(props);
+        isInSnapshotPhase = isCopying();
+    }
+
+    @Override
+    public void commit() throws InterruptedException {
+        delegate.commit();
+    }
+
+    @Override
+    public void commitRecord(SourceRecord record) throws InterruptedException {
+        delegate.commitRecord(record);
+    }
+
+    @Override
+    public void commitRecord(SourceRecord record, RecordMetadata metadata)
+            throws InterruptedException {
+        delegate.commitRecord(record, metadata);
+    }
+
+    @Override
+    public List<SourceRecord> poll() throws InterruptedException {
+        List<SourceRecord> sourceRecords = delegate.poll();
+
+        if (!isInSnapshotPhase) {
+            return sourceRecords;
+        }
+
+        if (sourceRecords == null || sourceRecords.isEmpty()) {
+            // No changing stream event comes and source task is finished copying, then exit the
+            // snapshot phase
+            if (!isCopying()) {
+                SourceRecord markedLastSnapshotRecord = markLastSnapshotRecord(lastSnapshotRecord);
+                lastSnapshotRecord = null;
+                isInSnapshotPhase = false;
+                return Collections.singletonList(markedLastSnapshotRecord);
+            }
+            return sourceRecords;
+        }
+
+        LinkedList<SourceRecord> linkedRecords = new LinkedList<>();
+        for (SourceRecord current : sourceRecords) {
+            if (isSnapshotRecord(current)) {
+                if (lastSnapshotRecord != null) {
+                    linkedRecords.add(lastSnapshotRecord);
+                }
+                lastSnapshotRecord = current;
+            } else {
+                // Received non-snapshot record, then exit the snapshot phase
+                if (lastSnapshotRecord != null) {
+                    linkedRecords.add(markLastSnapshotRecord(lastSnapshotRecord));
+                    lastSnapshotRecord = null;
+                    isInSnapshotPhase = false;
+                }
+                linkedRecords.add(current);
+            }
+        }
+
+        return linkedRecords;
+    }
+
+    @Override
+    public void stop() {
+        delegate.stop();
+    }
+
+    private SourceRecord markLastSnapshotRecord(SourceRecord record) {
+        if (record == null) {
+            return null;
+        }
+        Map<String, Object> markedOffset = new HashMap<>(record.sourceOffset());
+        markedOffset.put(COPY_KEY, "last");
+
+        return new SourceRecord(
+                record.sourcePartition(),
+                markedOffset,
+                record.topic(),
+                record.kafkaPartition(),
+                record.keySchema(),
+                record.key(),
+                record.valueSchema(),
+                record.value());
+    }
+
+    private boolean isSnapshotRecord(SourceRecord sourceRecord) {
+        return TRUE.equals(sourceRecord.sourceOffset().get(COPY_KEY));
+    }
+
+    private boolean isCopying() {
+        isCopyingField.setAccessible(true);
+        try {
+            return ((AtomicBoolean) isCopyingField.get(delegate)).get();
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException("can not access isCopying field of SourceTask", e);
+        }
+    }
+}

--- a/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/table/MongoDBConnectorDeserializationSchema.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/table/MongoDBConnectorDeserializationSchema.java
@@ -1,0 +1,724 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mongodb.table;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Collector;
+
+import com.alibaba.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import com.mongodb.client.model.changestream.OperationType;
+import com.mongodb.internal.HexUtils;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.bson.BsonBinary;
+import org.bson.BsonBinarySubType;
+import org.bson.BsonDateTime;
+import org.bson.BsonDocument;
+import org.bson.BsonMaxKey;
+import org.bson.BsonMinKey;
+import org.bson.BsonRegularExpression;
+import org.bson.BsonTimestamp;
+import org.bson.BsonUndefined;
+import org.bson.BsonValue;
+import org.bson.types.Decimal128;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Deserialization schema from Mongodb ChangeStreamDocument to Flink Table/SQL internal data
+ * structure {@link RowData}.
+ */
+public class MongoDBConnectorDeserializationSchema
+        implements DebeziumDeserializationSchema<RowData> {
+
+    private static final long serialVersionUID = 1750787080613035184L;
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(MongoDBConnectorDeserializationSchema.class);
+
+    private static final String FULL_DOCUMENT_FIELD = "fullDocument";
+
+    private static final String DOCUMENT_KEY_FIELD = "documentKey";
+
+    private static final String OPERATION_TYPE_FIELD = "operationType";
+
+    private static final ZoneId SYSTEM_DEFAULT_ZONE = ZoneId.systemDefault();
+
+    /** TypeInformation of the produced {@link RowData}. */
+    private final TypeInformation<RowData> resultTypeInfo;
+
+    /**
+     * Runtime converter that converts {@link
+     * com.mongodb.client.model.changestream.ChangeStreamDocument}s into objects of Flink SQL
+     * internal data structures.
+     */
+    private final DeserializationRuntimeConverter runtimeConverter;
+
+    public MongoDBConnectorDeserializationSchema(
+            RowType rowType, TypeInformation<RowData> resultTypeInfo) {
+        this.runtimeConverter = createConverter(rowType);
+        this.resultTypeInfo = resultTypeInfo;
+    }
+
+    @Override
+    public void deserialize(SourceRecord record, Collector<RowData> out) throws Exception {
+        Struct value = (Struct) record.value();
+        Schema valueSchema = record.valueSchema();
+
+        OperationType op = operationTypeFor(record);
+        BsonDocument documentKey =
+                checkNotNull(extractBsonDocument(value, valueSchema, DOCUMENT_KEY_FIELD));
+        BsonDocument fullDocument = extractBsonDocument(value, valueSchema, FULL_DOCUMENT_FIELD);
+
+        switch (op) {
+            case INSERT:
+                GenericRowData insert = extractRowData(fullDocument);
+                insert.setRowKind(RowKind.INSERT);
+                out.collect(insert);
+                break;
+            case DELETE:
+                GenericRowData delete = extractRowData(documentKey);
+                delete.setRowKind(RowKind.DELETE);
+                out.collect(delete);
+                break;
+            case UPDATE:
+                // It’s null if another operation deletes the document
+                // before the lookup operation happens.
+                if (fullDocument == null) {
+                    LOG.info("Ignored change record of type {} cause full document is empty", op);
+                    break;
+                }
+                GenericRowData updateAfter = extractRowData(fullDocument);
+                updateAfter.setRowKind(RowKind.UPDATE_AFTER);
+                out.collect(updateAfter);
+                break;
+            case REPLACE:
+                GenericRowData replaceAfter = extractRowData(fullDocument);
+                replaceAfter.setRowKind(RowKind.UPDATE_AFTER);
+                out.collect(replaceAfter);
+                break;
+            case INVALIDATE:
+            case DROP:
+            case DROP_DATABASE:
+            case RENAME:
+            case OTHER:
+            default:
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Ignored change record of type {}, with full record {}", op, record);
+                }
+                break;
+        }
+    }
+
+    private GenericRowData extractRowData(BsonDocument document) throws Exception {
+        checkNotNull(document);
+        return (GenericRowData) runtimeConverter.convert(document);
+    }
+
+    private BsonDocument extractBsonDocument(Struct value, Schema valueSchema, String fieldName) {
+        if (valueSchema.field(fieldName) != null) {
+            String docString = value.getString(fieldName);
+            if (docString != null) {
+                return BsonDocument.parse(value.getString(fieldName));
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public TypeInformation<RowData> getProducedType() {
+        return resultTypeInfo;
+    }
+
+    private OperationType operationTypeFor(SourceRecord record) {
+        Struct value = (Struct) record.value();
+        return OperationType.fromString(value.getString(OPERATION_TYPE_FIELD));
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Runtime Converters
+    // -------------------------------------------------------------------------------------
+
+    /**
+     * Runtime converter that converts objects of MongoDB Connect into objects of Flink Table & SQL
+     * internal data structures.
+     */
+    @FunctionalInterface
+    private interface DeserializationRuntimeConverter extends Serializable {
+        Object convert(BsonValue docObj) throws Exception;
+    }
+
+    /** Creates a runtime converter which is null safe. */
+    private DeserializationRuntimeConverter createConverter(LogicalType type) {
+        return wrapIntoNullableConverter(createNotNullConverter(type));
+    }
+
+    /** Creates a runtime converter which assuming input object is not null. */
+    private DeserializationRuntimeConverter createNotNullConverter(LogicalType type) {
+        switch (type.getTypeRoot()) {
+            case NULL:
+                return (docObj) -> null;
+            case BOOLEAN:
+                return this::convertToBoolean;
+            case TINYINT:
+                return this::convertToTinyInt;
+            case SMALLINT:
+                return this::convertToSmallInt;
+            case INTEGER:
+            case INTERVAL_YEAR_MONTH:
+                return this::convertToInt;
+            case BIGINT:
+            case INTERVAL_DAY_TIME:
+                return this::convertToLong;
+            case DATE:
+                return this::convertToDate;
+            case TIME_WITHOUT_TIME_ZONE:
+                return this::convertToTime;
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                return this::convertToTimestamp;
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return this::convertToLocalTimeZoneTimestamp;
+            case FLOAT:
+                return this::convertToFloat;
+            case DOUBLE:
+                return this::convertToDouble;
+            case CHAR:
+            case VARCHAR:
+                return this::convertToString;
+            case BINARY:
+            case VARBINARY:
+                return this::convertToBinary;
+            case DECIMAL:
+                return createDecimalConverter((DecimalType) type);
+            case ROW:
+                return createRowConverter((RowType) type);
+            case ARRAY:
+                return createArrayConverter((ArrayType) type);
+            case MAP:
+                return createMapConverter((MapType) type);
+            case MULTISET:
+            case RAW:
+            default:
+                throw new UnsupportedOperationException("Unsupported type: " + type);
+        }
+    }
+
+    private boolean convertToBoolean(BsonValue docObj) {
+        if (docObj.isBoolean()) {
+            return docObj.asBoolean().getValue();
+        }
+        if (docObj.isInt32()) {
+            return docObj.asInt32().getValue() == 1;
+        }
+        if (docObj.isInt64()) {
+            return docObj.asInt64().getValue() == 1L;
+        }
+        if (docObj.isString()) {
+            return Boolean.parseBoolean(docObj.asString().getValue());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to boolean from unexpected value '"
+                        + docObj
+                        + "' of type "
+                        + docObj.getBsonType());
+    }
+
+    private byte convertToTinyInt(BsonValue docObj) {
+        if (docObj.isBoolean()) {
+            return docObj.asBoolean().getValue() ? (byte) 1 : (byte) 0;
+        }
+        if (docObj.isInt32()) {
+            return (byte) docObj.asInt32().getValue();
+        }
+        if (docObj.isInt64()) {
+            return (byte) docObj.asInt64().getValue();
+        }
+        if (docObj.isString()) {
+            return Byte.parseByte(docObj.asString().getValue());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to tinyint from unexpected value '"
+                        + docObj
+                        + "' of type "
+                        + docObj.getBsonType());
+    }
+
+    private short convertToSmallInt(BsonValue docObj) {
+        if (docObj.isBoolean()) {
+            return docObj.asBoolean().getValue() ? (short) 1 : (short) 0;
+        }
+        if (docObj.isInt32()) {
+            return (short) docObj.asInt32().getValue();
+        }
+        if (docObj.isInt64()) {
+            return (short) docObj.asInt64().getValue();
+        }
+        if (docObj.isString()) {
+            return Short.parseShort(docObj.asString().getValue());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to smallint from unexpected value '"
+                        + docObj
+                        + "' of type "
+                        + docObj.getBsonType());
+    }
+
+    private int convertToInt(BsonValue docObj) {
+        if (docObj.isNumber()) {
+            return docObj.asNumber().intValue();
+        }
+        if (docObj.isDecimal128()) {
+            Decimal128 decimal128Value = docObj.asDecimal128().decimal128Value();
+            if (decimal128Value.isFinite()) {
+                return decimal128Value.intValue();
+            } else if (decimal128Value.isNegative()) {
+                return Integer.MIN_VALUE;
+            } else {
+                return Integer.MAX_VALUE;
+            }
+        }
+        if (docObj.isBoolean()) {
+            return docObj.asBoolean().getValue() ? 1 : 0;
+        }
+        if (docObj.isString()) {
+            return Integer.parseInt(docObj.asString().getValue());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to integer from unexpected value '"
+                        + docObj
+                        + "' of type "
+                        + docObj.getBsonType());
+    }
+
+    private long convertToLong(BsonValue docObj) {
+        if (docObj.isNumber()) {
+            return docObj.asNumber().longValue();
+        }
+        if (docObj.isDecimal128()) {
+            Decimal128 decimal128Value = docObj.asDecimal128().decimal128Value();
+            if (decimal128Value.isFinite()) {
+                return decimal128Value.longValue();
+            } else if (decimal128Value.isNegative()) {
+                return Long.MIN_VALUE;
+            } else {
+                return Long.MAX_VALUE;
+            }
+        }
+        if (docObj.isBoolean()) {
+            return docObj.asBoolean().getValue() ? 1L : 0L;
+        }
+        if (docObj.isString()) {
+            return Long.parseLong(docObj.asString().getValue());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to long from unexpected value '"
+                        + docObj
+                        + "' of type "
+                        + docObj.getBsonType());
+    }
+
+    private double convertToDouble(BsonValue docObj) {
+        if (docObj.isNumber()) {
+            return docObj.asNumber().doubleValue();
+        }
+        if (docObj.isDecimal128()) {
+            Decimal128 decimal128Value = docObj.asDecimal128().decimal128Value();
+            if (decimal128Value.isFinite()) {
+                return decimal128Value.doubleValue();
+            } else if (decimal128Value.isNegative()) {
+                return -Double.MAX_VALUE;
+            } else {
+                return Double.MAX_VALUE;
+            }
+        }
+        if (docObj.isBoolean()) {
+            return docObj.asBoolean().getValue() ? 1 : 0;
+        }
+        if (docObj.isString()) {
+            return Double.parseDouble(docObj.asString().getValue());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to double from unexpected value '"
+                        + docObj
+                        + "' of type "
+                        + docObj.getBsonType());
+    }
+
+    private float convertToFloat(BsonValue docObj) {
+        if (docObj.isInt32()) {
+            return docObj.asInt32().getValue();
+        }
+        if (docObj.isInt64()) {
+            return docObj.asInt64().getValue();
+        }
+        if (docObj.isDouble()) {
+            return ((Double) docObj.asDouble().getValue()).floatValue();
+        }
+        if (docObj.isDecimal128()) {
+            Decimal128 decimal128Value = docObj.asDecimal128().decimal128Value();
+            if (decimal128Value.isFinite()) {
+                return decimal128Value.floatValue();
+            } else if (decimal128Value.isNegative()) {
+                return -Float.MAX_VALUE;
+            } else {
+                return Float.MAX_VALUE;
+            }
+        }
+        if (docObj.isBoolean()) {
+            return docObj.asBoolean().getValue() ? 1f : 0f;
+        }
+        if (docObj.isString()) {
+            return Float.parseFloat(docObj.asString().getValue());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to float from unexpected value '"
+                        + docObj
+                        + "' of type "
+                        + docObj.getBsonType());
+    }
+
+    private LocalDate convertInstantToLocalDate(Instant instant) {
+        return convertInstantToLocalDateTime(instant).toLocalDate();
+    }
+
+    private LocalTime convertInstantToLocalTime(Instant instant) {
+        return convertInstantToLocalDateTime(instant).toLocalTime();
+    }
+
+    private LocalDateTime convertInstantToLocalDateTime(Instant instant) {
+        return instant.atZone(SYSTEM_DEFAULT_ZONE).toLocalDateTime();
+    }
+
+    private Instant convertToInstant(BsonTimestamp bsonTimestamp) {
+        return Instant.ofEpochSecond(bsonTimestamp.getTime() * 1000L);
+    }
+
+    private Instant convertToInstant(BsonDateTime bsonDateTime) {
+        return Instant.ofEpochMilli(bsonDateTime.getValue());
+    }
+
+    /**
+     * A conversion from DateType to int describes the number of days since epoch.
+     *
+     * @see org.apache.flink.table.types.logical.DateType
+     */
+    private int convertToDate(BsonValue docObj) {
+        if (docObj.isDateTime()) {
+            Instant instant = convertToInstant(docObj.asDateTime());
+            return (int) convertInstantToLocalDate(instant).toEpochDay();
+        }
+        if (docObj.isTimestamp()) {
+            Instant instant = convertToInstant(docObj.asTimestamp());
+            return (int) convertInstantToLocalDate(instant).toEpochDay();
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to date from unexpected value '"
+                        + docObj
+                        + "' of type "
+                        + docObj.getBsonType());
+    }
+
+    /**
+     * A conversion from TimeType to int describes the number of milliseconds of the day.
+     *
+     * @see org.apache.flink.table.types.logical.TimeType
+     */
+    private int convertToTime(BsonValue docObj) {
+        if (docObj.isDateTime()) {
+            Instant instant = convertToInstant(docObj.asDateTime());
+            return convertInstantToLocalTime(instant).toSecondOfDay() * 1000;
+        }
+        if (docObj.isTimestamp()) {
+            Instant instant = convertToInstant(docObj.asTimestamp());
+            return convertInstantToLocalTime(instant).toSecondOfDay() * 1000;
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to time from unexpected value '"
+                        + docObj
+                        + "' of type "
+                        + docObj.getBsonType());
+    }
+
+    private TimestampData convertToTimestamp(BsonValue docObj) {
+        if (docObj.isDateTime()) {
+            return TimestampData.fromEpochMillis(docObj.asDateTime().getValue());
+        }
+        if (docObj.isTimestamp()) {
+            return TimestampData.fromEpochMillis(docObj.asTimestamp().getTime() * 1000L);
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to timestamp from unexpected value '"
+                        + docObj
+                        + "' of type "
+                        + docObj.getBsonType());
+    }
+
+    private TimestampData convertToLocalTimeZoneTimestamp(BsonValue docObj) {
+        if (docObj.isDateTime()) {
+            return TimestampData.fromEpochMillis(docObj.asDateTime().getValue());
+        }
+        if (docObj.isTimestamp()) {
+            return TimestampData.fromEpochMillis(docObj.asTimestamp().getTime() * 1000L);
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to timestamp with local timezone from unexpected value '"
+                        + docObj
+                        + "' of type "
+                        + docObj.getBsonType());
+    }
+
+    private byte[] convertToBinary(BsonValue docObj) {
+        if (docObj.isBinary()) {
+            return docObj.asBinary().getData();
+        }
+        throw new UnsupportedOperationException(
+                "Unsupported BYTES value type: " + docObj.getClass().getSimpleName());
+    }
+
+    private StringData convertToString(BsonValue docObj) {
+        if (docObj.isString()) {
+            return StringData.fromString(docObj.asString().getValue());
+        }
+        if (docObj.isBinary()) {
+            BsonBinary bsonBinary = docObj.asBinary();
+            if (BsonBinarySubType.isUuid(bsonBinary.getType())) {
+                return StringData.fromString(bsonBinary.asUuid().toString());
+            }
+            return StringData.fromString(HexUtils.toHex(bsonBinary.getData()));
+        }
+        if (docObj.isObjectId()) {
+            return StringData.fromString(docObj.asObjectId().getValue().toHexString());
+        }
+        if (docObj.isInt32()) {
+            return StringData.fromString(String.valueOf(docObj.asInt32().getValue()));
+        }
+        if (docObj.isInt64()) {
+            return StringData.fromString(String.valueOf(docObj.asInt64().getValue()));
+        }
+        if (docObj.isDouble()) {
+            return StringData.fromString(String.valueOf(docObj.asDouble().getValue()));
+        }
+        if (docObj.isDecimal128()) {
+            return StringData.fromString(docObj.asDecimal128().getValue().toString());
+        }
+        if (docObj.isBoolean()) {
+            return StringData.fromString(String.valueOf(docObj.asBoolean().getValue()));
+        }
+        if (docObj.isDateTime()) {
+            Instant instant = convertToInstant(docObj.asDateTime());
+            return StringData.fromString(
+                    convertInstantToLocalDateTime(instant).format(ISO_OFFSET_DATE_TIME));
+        }
+        if (docObj.isTimestamp()) {
+            Instant instant = convertToInstant(docObj.asTimestamp());
+            return StringData.fromString(
+                    convertInstantToLocalDateTime(instant).format(ISO_OFFSET_DATE_TIME));
+        }
+        if (docObj.isRegularExpression()) {
+            BsonRegularExpression regex = docObj.asRegularExpression();
+            return StringData.fromString(
+                    String.format("/%s/%s", regex.getPattern(), regex.getOptions()));
+        }
+        if (docObj.isJavaScript()) {
+            return StringData.fromString(docObj.asJavaScript().getCode());
+        }
+        if (docObj.isJavaScriptWithScope()) {
+            return StringData.fromString(docObj.asJavaScriptWithScope().getCode());
+        }
+        if (docObj.isSymbol()) {
+            return StringData.fromString(docObj.asSymbol().getSymbol());
+        }
+        if (docObj.isDBPointer()) {
+            return StringData.fromString(docObj.asDBPointer().getId().toHexString());
+        }
+        if (docObj instanceof BsonMinKey || docObj instanceof BsonMaxKey) {
+            return StringData.fromString(docObj.getBsonType().name());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to string from unexpected value '"
+                        + docObj
+                        + "' of type "
+                        + docObj.getBsonType());
+    }
+
+    private DeserializationRuntimeConverter createDecimalConverter(DecimalType decimalType) {
+        final int precision = decimalType.getPrecision();
+        final int scale = decimalType.getScale();
+        return (docObj) -> {
+            BigDecimal bigDecimal;
+            if (docObj.isString()) {
+                bigDecimal = new BigDecimal(docObj.asString().getValue());
+            } else if (docObj.isDecimal128()) {
+                Decimal128 decimal128Value = docObj.asDecimal128().decimal128Value();
+                if (decimal128Value.isFinite()) {
+                    bigDecimal = docObj.asDecimal128().decimal128Value().bigDecimalValue();
+                } else if (decimal128Value.isNegative()) {
+                    bigDecimal = BigDecimal.valueOf(-Double.MAX_VALUE);
+                } else {
+                    bigDecimal = BigDecimal.valueOf(Double.MAX_VALUE);
+                }
+            } else if (docObj.isDouble()) {
+                bigDecimal = BigDecimal.valueOf(docObj.asDouble().doubleValue());
+            } else if (docObj.isInt32()) {
+                bigDecimal = BigDecimal.valueOf(docObj.asInt32().getValue());
+            } else if (docObj.isInt64()) {
+                bigDecimal = BigDecimal.valueOf(docObj.asInt64().getValue());
+            } else {
+                throw new IllegalArgumentException(
+                        "Unable to convert to decimal from unexpected value '"
+                                + docObj
+                                + "' of type "
+                                + docObj.getBsonType());
+            }
+            return DecimalData.fromBigDecimal(bigDecimal, precision, scale);
+        };
+    }
+
+    private DeserializationRuntimeConverter createRowConverter(RowType rowType) {
+        final DeserializationRuntimeConverter[] fieldConverters =
+                rowType.getFields().stream()
+                        .map(RowType.RowField::getType)
+                        .map(this::createConverter)
+                        .toArray(DeserializationRuntimeConverter[]::new);
+        final String[] fieldNames = rowType.getFieldNames().toArray(new String[0]);
+
+        return (docObj) -> {
+            if (!docObj.isDocument()) {
+                throw new IllegalArgumentException(
+                        "Unable to convert to rowType from unexpected value '"
+                                + docObj
+                                + "' of type "
+                                + docObj.getBsonType());
+            }
+
+            BsonDocument document = docObj.asDocument();
+            int arity = fieldNames.length;
+            GenericRowData row = new GenericRowData(arity);
+            for (int i = 0; i < arity; i++) {
+                String fieldName = fieldNames[i];
+                BsonValue fieldValue = document.get(fieldName);
+                Object convertedField = convertField(fieldConverters[i], fieldValue);
+                row.setField(i, convertedField);
+            }
+            return row;
+        };
+    }
+
+    private DeserializationRuntimeConverter createArrayConverter(ArrayType arrayType) {
+        final Class<?> elementClass =
+                LogicalTypeUtils.toInternalConversionClass(arrayType.getElementType());
+        final DeserializationRuntimeConverter elementConverter =
+                createConverter(arrayType.getElementType());
+
+        return (docObj) -> {
+            if (!docObj.isArray()) {
+                throw new IllegalArgumentException(
+                        "Unable to convert to arrayType from unexpected value '"
+                                + docObj
+                                + "' of type "
+                                + docObj.getBsonType());
+            }
+
+            List<BsonValue> in = docObj.asArray();
+            final Object[] elementArray = (Object[]) Array.newInstance(elementClass, in.size());
+            for (int i = 0; i < in.size(); i++) {
+                elementArray[i] = elementConverter.convert(in.get(i));
+            }
+            return new GenericArrayData(elementArray);
+        };
+    }
+
+    private DeserializationRuntimeConverter createMapConverter(MapType mapType) {
+        LogicalType keyType = mapType.getKeyType();
+        checkArgument(keyType.supportsInputConversion(String.class));
+
+        LogicalType valueType = mapType.getValueType();
+        DeserializationRuntimeConverter valueConverter = createConverter(valueType);
+
+        return (docObj) -> {
+            if (!docObj.isDocument()) {
+                throw new IllegalArgumentException(
+                        "Unable to convert to rowType from unexpected value '"
+                                + docObj
+                                + "' of type "
+                                + docObj.getBsonType());
+            }
+
+            BsonDocument document = docObj.asDocument();
+            Map<StringData, Object> map = new HashMap<>();
+            for (String key : document.keySet()) {
+                map.put(
+                        StringData.fromString(key),
+                        convertField(valueConverter, document.get(key)));
+            }
+            return new GenericMapData(map);
+        };
+    }
+
+    private Object convertField(
+            DeserializationRuntimeConverter fieldConverter, BsonValue fieldValue) throws Exception {
+        if (fieldValue == null) {
+            return null;
+        } else {
+            return fieldConverter.convert(fieldValue);
+        }
+    }
+
+    private DeserializationRuntimeConverter wrapIntoNullableConverter(
+            DeserializationRuntimeConverter converter) {
+        return (docObj) -> {
+            if (docObj == null || docObj.isNull() || docObj instanceof BsonUndefined) {
+                return null;
+            }
+            if (docObj.isDecimal128() && docObj.asDecimal128().getValue().isNaN()) {
+                return null;
+            }
+            return converter.convert(docObj);
+        };
+    }
+}

--- a/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mongodb.table;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+
+import com.alibaba.ververica.cdc.connectors.mongodb.MongoDBSource;
+import com.alibaba.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import com.alibaba.ververica.cdc.debezium.DebeziumSourceFunction;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link DynamicTableSource} that describes how to create a MongoDB change stream events source
+ * from a logical description.
+ */
+public class MongoDBTableSource implements ScanTableSource {
+
+    private final TableSchema physicalSchema;
+    private final String uri;
+    private final String database;
+    private final String collection;
+    private final Boolean errorsLogEnable;
+    private final String errorsTolerance;
+    private final Boolean copyExisting;
+    private final String copyExistingPipeline;
+    private final Integer copyExistingMaxThreads;
+    private final Integer copyExistingQueueSize;
+    private final Integer pollMaxBatchSize;
+    private final Integer pollAwaitTimeMillis;
+    private final Integer heartbeatIntervalMillis;
+
+    public MongoDBTableSource(
+            TableSchema physicalSchema,
+            String uri,
+            String database,
+            String collection,
+            @Nullable String errorsTolerance,
+            @Nullable Boolean errorsLogEnable,
+            @Nullable Boolean copyExisting,
+            @Nullable String copyExistingPipeline,
+            @Nullable Integer copyExistingMaxThreads,
+            @Nullable Integer copyExistingQueueSize,
+            @Nullable Integer pollMaxBatchSize,
+            @Nullable Integer pollAwaitTimeMillis,
+            @Nullable Integer heartbeatIntervalMillis) {
+        this.physicalSchema = physicalSchema;
+        this.uri = checkNotNull(uri);
+        this.database = checkNotNull(database);
+        this.collection = checkNotNull(collection);
+        this.errorsTolerance = errorsTolerance;
+        this.errorsLogEnable = errorsLogEnable;
+        this.copyExisting = copyExisting;
+        this.copyExistingPipeline = copyExistingPipeline;
+        this.copyExistingMaxThreads = copyExistingMaxThreads;
+        this.copyExistingQueueSize = copyExistingQueueSize;
+        this.pollMaxBatchSize = pollMaxBatchSize;
+        this.pollAwaitTimeMillis = pollAwaitTimeMillis;
+        this.heartbeatIntervalMillis = heartbeatIntervalMillis;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        return ChangelogMode.newBuilder()
+                .addContainedKind(RowKind.INSERT)
+                .addContainedKind(RowKind.UPDATE_AFTER)
+                .addContainedKind(RowKind.DELETE)
+                .build();
+    }
+
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext scanContext) {
+        RowType rowType = (RowType) physicalSchema.toRowDataType().getLogicalType();
+        TypeInformation<RowData> typeInfo =
+                scanContext.createTypeInformation(physicalSchema.toRowDataType());
+
+        DebeziumDeserializationSchema<RowData> deserializer =
+                new MongoDBConnectorDeserializationSchema(rowType, typeInfo);
+
+        MongoDBSource.Builder<RowData> builder =
+                MongoDBSource.<RowData>builder()
+                        .connectionUri(uri)
+                        .database(database)
+                        .collection(collection)
+                        .deserializer(deserializer);
+
+        Optional.ofNullable(errorsLogEnable).ifPresent(builder::errorsLogEnable);
+        Optional.ofNullable(errorsTolerance).ifPresent(builder::errorsTolerance);
+        Optional.ofNullable(copyExisting).ifPresent(builder::copyExisting);
+        Optional.ofNullable(copyExistingPipeline).ifPresent(builder::copyExistingPipeline);
+        Optional.ofNullable(copyExistingMaxThreads).ifPresent(builder::copyExistingMaxThreads);
+        Optional.ofNullable(copyExistingQueueSize).ifPresent(builder::copyExistingQueueSize);
+        Optional.ofNullable(pollMaxBatchSize).ifPresent(builder::pollMaxBatchSize);
+        Optional.ofNullable(pollAwaitTimeMillis).ifPresent(builder::pollAwaitTimeMillis);
+        Optional.ofNullable(heartbeatIntervalMillis).ifPresent(builder::heartbeatIntervalMillis);
+
+        DebeziumSourceFunction<RowData> sourceFunction = builder.build();
+
+        return SourceFunctionProvider.of(sourceFunction, false);
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        return new MongoDBTableSource(
+                physicalSchema,
+                uri,
+                database,
+                collection,
+                errorsTolerance,
+                errorsLogEnable,
+                copyExisting,
+                copyExistingPipeline,
+                copyExistingMaxThreads,
+                copyExistingQueueSize,
+                pollMaxBatchSize,
+                pollAwaitTimeMillis,
+                heartbeatIntervalMillis);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MongoDBTableSource that = (MongoDBTableSource) o;
+        return Objects.equals(physicalSchema, that.physicalSchema)
+                && Objects.equals(uri, that.uri)
+                && Objects.equals(database, that.database)
+                && Objects.equals(collection, that.collection)
+                && Objects.equals(errorsTolerance, that.errorsTolerance)
+                && Objects.equals(errorsLogEnable, that.errorsLogEnable)
+                && Objects.equals(copyExisting, that.copyExisting)
+                && Objects.equals(copyExistingPipeline, that.copyExistingPipeline)
+                && Objects.equals(copyExistingMaxThreads, that.copyExistingMaxThreads)
+                && Objects.equals(copyExistingQueueSize, that.copyExistingQueueSize)
+                && Objects.equals(pollMaxBatchSize, that.pollMaxBatchSize)
+                && Objects.equals(pollAwaitTimeMillis, that.pollAwaitTimeMillis)
+                && Objects.equals(heartbeatIntervalMillis, that.heartbeatIntervalMillis);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                physicalSchema,
+                uri,
+                database,
+                collection,
+                errorsTolerance,
+                errorsLogEnable,
+                copyExisting,
+                copyExistingPipeline,
+                copyExistingMaxThreads,
+                copyExistingQueueSize,
+                pollMaxBatchSize,
+                pollAwaitTimeMillis,
+                heartbeatIntervalMillis);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "MongoDB-CDC";
+    }
+}

--- a/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mongodb.table;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.constraints.UniqueConstraint;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.utils.TableSchemaUtils;
+
+import com.alibaba.ververica.cdc.debezium.table.DebeziumOptions;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.alibaba.ververica.cdc.connectors.mongodb.MongoDBSource.ERROR_TOLERANCE_NONE;
+import static com.alibaba.ververica.cdc.connectors.mongodb.MongoDBSource.POLL_AWAIT_TIME_MILLIS_DEFAULT;
+import static com.alibaba.ververica.cdc.connectors.mongodb.MongoDBSource.POLL_MAX_BATCH_SIZE_DEFAULT;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/** Factory for creating configured instance of {@link MongoDBTableSource}. */
+public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
+
+    private static final String IDENTIFIER = "mongodb-cdc";
+
+    private static final String DOCUMENT_ID_FIELD = "_id";
+
+    private static final ConfigOption<String> URI =
+            ConfigOptions.key("uri")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("A MongoDB connection URI string.");
+
+    private static final ConfigOption<String> DATABASE =
+            ConfigOptions.key("database")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Name of the database to watch for changes.");
+
+    private static final ConfigOption<String> COLLECTION =
+            ConfigOptions.key("collection")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Name of the collection in the database to watch for changes.");
+
+    private static final ConfigOption<String> ERRORS_TOLERANCE =
+            ConfigOptions.key("errors.tolerance")
+                    .stringType()
+                    .defaultValue(ERROR_TOLERANCE_NONE)
+                    .withDescription(
+                            "Whether to continue processing messages if an error is encountered. "
+                                    + "When set to none, the connector reports an error and blocks further processing "
+                                    + "of the rest of the records when it encounters an error. "
+                                    + "When set to all, the connector silently ignores any bad messages."
+                                    + "Accepted Values: 'none' or 'all'. Default 'none'.");
+
+    private static final ConfigOption<Boolean> ERRORS_LOG_ENABLE =
+            ConfigOptions.key("errors.log.enable")
+                    .booleanType()
+                    .defaultValue(Boolean.TRUE)
+                    .withDescription(
+                            "Whether details of failed operations should be written to the log file. "
+                                    + "When set to true, both errors that are tolerated (determined by the errors.tolerance setting) "
+                                    + "and not tolerated are written. When set to false, errors that are tolerated are omitted.");
+
+    private static final ConfigOption<Boolean> COPY_EXISTING =
+            ConfigOptions.key("copy.existing")
+                    .booleanType()
+                    .defaultValue(Boolean.TRUE)
+                    .withDescription(
+                            "Copy existing data from source collections and convert them "
+                                    + "to Change Stream events on their respective topics. Any changes to the data "
+                                    + "that occur during the copy process are applied once the copy is completed.");
+
+    private static final ConfigOption<String> COPY_EXISTING_PIPELINE =
+            ConfigOptions.key("copy.existing.pipeline")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "An array of JSON objects describing the pipeline operations "
+                                    + "to run when copying existing data. "
+                                    + "This can improve the use of indexes by the copying manager and make copying more efficient.");
+
+    private static final ConfigOption<Integer> COPY_EXISTING_MAX_THREADS =
+            ConfigOptions.key("copy.existing.max.threads")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The number of threads to use when performing the data copy."
+                                    + " Defaults to the number of processors.");
+
+    private static final ConfigOption<Integer> COPY_EXISTING_QUEUE_SIZE =
+            ConfigOptions.key("copy.existing.queue.size")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The max size of the queue to use when copying data. Defaults to 16000.");
+
+    private static final ConfigOption<Integer> POLL_MAX_BATCH_SIZE =
+            ConfigOptions.key("poll.max.batch.size")
+                    .intType()
+                    .defaultValue(POLL_MAX_BATCH_SIZE_DEFAULT)
+                    .withDescription(
+                            "Maximum number of change stream documents "
+                                    + "to include in a single batch when polling for new data. "
+                                    + "This setting can be used to limit the amount of data buffered internally in the connector. "
+                                    + "Defaults to 1000.");
+
+    private static final ConfigOption<Integer> POLL_AWAIT_TIME_MILLIS =
+            ConfigOptions.key("poll.await.time.ms")
+                    .intType()
+                    .defaultValue(POLL_AWAIT_TIME_MILLIS_DEFAULT)
+                    .withDescription(
+                            "The amount of time to wait before checking for new results on the change stream."
+                                    + "Defaults: 1500.");
+
+    private static final ConfigOption<Integer> HEARTBEAT_INTERVAL_MILLIS =
+            ConfigOptions.key("heartbeat.interval.ms")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The length of time in milliseconds between sending heartbeat messages."
+                                    + "Heartbeat messages contain the post batch resume token and are sent when no source records "
+                                    + "have been published in the specified interval. This improves the resumability of the connector "
+                                    + "for low volume namespaces. Use 0 to disable. Defaults to 0.");
+
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        final FactoryUtil.TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(this, context);
+        helper.validateExcept(DebeziumOptions.DEBEZIUM_OPTIONS_PREFIX);
+
+        final ReadableConfig config = helper.getOptions();
+        String uri = config.get(URI);
+        String database = config.get(DATABASE);
+        String collection = config.get(COLLECTION);
+
+        String errorTolerance = config.get(ERRORS_TOLERANCE);
+        Boolean errorLogEnable = config.get(ERRORS_LOG_ENABLE);
+
+        Integer pollMaxBatchSize = config.get(POLL_MAX_BATCH_SIZE);
+        Integer pollAwaitTimeMillis = config.get(POLL_AWAIT_TIME_MILLIS);
+
+        Integer heartbeatIntervalMillis =
+                config.getOptional(HEARTBEAT_INTERVAL_MILLIS).orElse(null);
+
+        Boolean copyExisting = config.get(COPY_EXISTING);
+        String copyExistingPipeline = config.getOptional(COPY_EXISTING_PIPELINE).orElse(null);
+        Integer copyExistingMaxThreads = config.getOptional(COPY_EXISTING_MAX_THREADS).orElse(null);
+        Integer copyExistingQueueSize = config.getOptional(COPY_EXISTING_QUEUE_SIZE).orElse(null);
+
+        TableSchema physicalSchema =
+                TableSchemaUtils.getPhysicalSchema(context.getCatalogTable().getSchema());
+        checkArgument(physicalSchema.getPrimaryKey().isPresent(), "Primary key must be present");
+        checkPrimaryKey(physicalSchema.getPrimaryKey().get(), "Primary key must be _id field");
+
+        return new MongoDBTableSource(
+                physicalSchema,
+                uri,
+                database,
+                collection,
+                errorTolerance,
+                errorLogEnable,
+                copyExisting,
+                copyExistingPipeline,
+                copyExistingMaxThreads,
+                copyExistingQueueSize,
+                pollMaxBatchSize,
+                pollAwaitTimeMillis,
+                heartbeatIntervalMillis);
+    }
+
+    private void checkPrimaryKey(UniqueConstraint pk, String message) {
+        checkArgument(
+                pk.getColumns().size() == 1 && pk.getColumns().contains(DOCUMENT_ID_FIELD),
+                message);
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(URI);
+        options.add(DATABASE);
+        options.add(COLLECTION);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(ERRORS_TOLERANCE);
+        options.add(ERRORS_LOG_ENABLE);
+        options.add(COPY_EXISTING);
+        options.add(COPY_EXISTING_PIPELINE);
+        options.add(COPY_EXISTING_MAX_THREADS);
+        options.add(COPY_EXISTING_QUEUE_SIZE);
+        options.add(POLL_MAX_BATCH_SIZE);
+        options.add(POLL_AWAIT_TIME_MILLIS);
+        options.add(HEARTBEAT_INTERVAL_MILLIS);
+        return options;
+    }
+}

--- a/flink-connector-mongodb-cdc/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connector-mongodb-cdc/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+com.alibaba.ververica.cdc.connectors.mongodb.table.MongoDBTableSourceFactory

--- a/flink-connector-mongodb-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mongodb/MongoDBSourceTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mongodb/MongoDBSourceTest.java
@@ -1,0 +1,627 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mongodb;
+
+import org.apache.flink.api.common.state.BroadcastState;
+import org.apache.flink.api.common.state.KeyedStateStore;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.OperatorStateStore;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContextSynchronousImpl;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
+
+import com.alibaba.ververica.cdc.connectors.utils.TestSourceContext;
+import com.alibaba.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import com.alibaba.ververica.cdc.debezium.DebeziumSourceFunction;
+import com.jayway.jsonpath.JsonPath;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Updates;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import static com.alibaba.ververica.cdc.connectors.mongodb.utils.MongoDBAssertUtils.assertDelete;
+import static com.alibaba.ververica.cdc.connectors.mongodb.utils.MongoDBAssertUtils.assertInsert;
+import static com.alibaba.ververica.cdc.connectors.mongodb.utils.MongoDBAssertUtils.assertObjectIdEquals;
+import static com.alibaba.ververica.cdc.connectors.mongodb.utils.MongoDBAssertUtils.assertReplace;
+import static com.alibaba.ververica.cdc.connectors.mongodb.utils.MongoDBAssertUtils.assertUpdate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link MongoDBSource} which also heavily tests {@link DebeziumSourceFunction}. */
+public class MongoDBSourceTest extends MongoDBTestBase {
+
+    @BeforeClass
+    public static void before() {
+        executeCommandFile("inventory");
+    }
+
+    @Test
+    public void testConsumingAllEvents() throws Exception {
+        DebeziumSourceFunction<SourceRecord> source = createMongoDBSource();
+        TestSourceContext<SourceRecord> sourceContext = new TestSourceContext<>();
+
+        MongoCollection<Document> products =
+                getMongoDatabase("inventory").getCollection("products");
+
+        setupSource(source);
+
+        // start the source
+        final CheckedThread runThread =
+                new CheckedThread() {
+                    @Override
+                    public void go() throws Exception {
+                        source.run(sourceContext);
+                    }
+                };
+        runThread.start();
+
+        List<SourceRecord> records = drain(sourceContext, 9);
+        assertEquals(9, records.size());
+
+        assertTrue(
+                waitForCheckpointLock(sourceContext.getCheckpointLock(), Duration.ofSeconds(15)));
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Simple INSERT
+        // ---------------------------------------------------------------------------------------------------------------
+        products.insertOne(productDocOf(null, "description", "Toy robot", 1.304));
+        records = drain(sourceContext, 1);
+        assertInsert(records.get(0), true);
+
+        products.insertOne(productDocOf("000000000000000000001001", "roy", "old robot", 1234.56));
+        records = drain(sourceContext, 1);
+        assertInsert(records.get(0), true);
+        assertObjectIdEquals("000000000000000000001001", records.get(0));
+
+        // -------------------------------------------------------------------------------------------------------------
+        // Changing the description of a row should result in 1 events: UPDATE
+        // -------------------------------------------------------------------------------------------------------------
+        products.updateOne(
+                Filters.eq("_id", new ObjectId("000000000000000000001001")),
+                Updates.set("description", "really old robot"));
+        records = drain(sourceContext, 1);
+        assertUpdate(records.get(0), "000000000000000000001001");
+
+        // -------------------------------------------------------------------------------------------------------------
+        // Replace the document of a row should result in 1 events: UPDATE
+        // -------------------------------------------------------------------------------------------------------------
+        products.replaceOne(
+                Filters.eq("_id", new ObjectId("000000000000000000001001")),
+                productDocOf(
+                        "000000000000000000001001", "roy_replace", "old robot replace", 1234.57));
+        records = drain(sourceContext, 1);
+        assertReplace(records.get(0), "000000000000000000001001");
+
+        // -------------------------------------------------------------------------------------------------------------
+        // Simple DELETE
+        // -------------------------------------------------------------------------------------------------------------
+        products.deleteOne(Filters.eq("_id", new ObjectId("000000000000000000001001")));
+        records = drain(sourceContext, 1);
+        assertDelete(records.get(0), "000000000000000000001001");
+
+        // cleanup
+        source.cancel();
+        source.close();
+        runThread.sync();
+    }
+
+    @Test
+    public void testCheckpointAndRestore() throws Exception {
+        final TestingListState<byte[]> offsetState = new TestingListState<>();
+        final TestingListState<String> historyState = new TestingListState<>();
+        {
+            // ---------------------------------------------------------------------------
+            // Step-1: start the source from empty state
+            // ---------------------------------------------------------------------------
+            final DebeziumSourceFunction<SourceRecord> source = createMongoDBSource();
+            // we use blocking context to block the source to emit before last snapshot record
+            final BlockingSourceContext<SourceRecord> sourceContext =
+                    new BlockingSourceContext<>(8);
+            // setup source with empty state
+            setupSource(source, false, offsetState, historyState, true, 0, 1);
+
+            final CheckedThread runThread =
+                    new CheckedThread() {
+                        @Override
+                        public void go() throws Exception {
+                            source.run(sourceContext);
+                        }
+                    };
+            runThread.start();
+
+            // wait until consumer is started
+            List<SourceRecord> records = drain(sourceContext, 2);
+            int received = records.size();
+            assertEquals(2, received);
+
+            // we can't perform checkpoint during DB snapshot
+            assertFalse(
+                    waitForCheckpointLock(
+                            sourceContext.getCheckpointLock(), Duration.ofSeconds(3)));
+
+            // unblock the source context to continue the processing
+            sourceContext.blocker.release();
+            // wait until the source finishes the database snapshot
+            records = drain(sourceContext, 9 - received);
+            assertEquals(9, records.size() + received);
+
+            // state is still empty
+            assertEquals(0, offsetState.list.size());
+            assertEquals(0, historyState.list.size());
+
+            // ---------------------------------------------------------------------------
+            // Step-2: trigger checkpoint-1 after snapshot finished
+            // ---------------------------------------------------------------------------
+            synchronized (sourceContext.getCheckpointLock()) {
+                // trigger checkpoint-1
+                source.snapshotState(new StateSnapshotContextSynchronousImpl(101, 101));
+            }
+
+            assertEquals(1, offsetState.list.size());
+
+            String state = new String(offsetState.list.get(0), StandardCharsets.UTF_8);
+            assertTrue(state.contains("sourcePartition"));
+            assertTrue(state.contains("sourceOffset"));
+
+            // ---------------------------------------------------------------------------
+            // Step-3: trigger checkpoint-2 after snapshot finished and streaming data received
+            // ---------------------------------------------------------------------------
+            MongoCollection<Document> products =
+                    getMongoDatabase("inventory").getCollection("products");
+
+            products.updateOne(
+                    Filters.eq("_id", new ObjectId("100000000000000000000102")),
+                    Updates.set("description", "really old robot 1002"));
+            records = drain(sourceContext, 1);
+            assertUpdate(records.get(0), "100000000000000000000102");
+
+            synchronized (sourceContext.getCheckpointLock()) {
+                // trigger checkpoint-2
+                source.snapshotState(new StateSnapshotContextSynchronousImpl(102, 102));
+            }
+
+            assertEquals(1, offsetState.list.size());
+
+            state = new String(offsetState.list.get(0), StandardCharsets.UTF_8);
+            assertTrue(state.contains("sourcePartition"));
+            assertTrue(state.contains("sourceOffset"));
+            String resumeToken = JsonPath.read(state, "$.sourceOffset._id");
+            assertTrue(resumeToken.contains("_data"));
+
+            source.cancel();
+            source.close();
+            runThread.sync();
+        }
+
+        {
+            // ---------------------------------------------------------------------------
+            // Step-3: restore the source from state
+            // ---------------------------------------------------------------------------
+            final DebeziumSourceFunction<SourceRecord> source2 = createMongoDBSource();
+            final TestSourceContext<SourceRecord> sourceContext2 = new TestSourceContext<>();
+            setupSource(source2, true, offsetState, historyState, true, 0, 1);
+            final CheckedThread runThread2 =
+                    new CheckedThread() {
+                        @Override
+                        public void go() throws Exception {
+                            source2.run(sourceContext2);
+                        }
+                    };
+            runThread2.start();
+
+            // make sure there is no more events
+            assertFalse(waitForAvailableRecords(Duration.ofSeconds(5), sourceContext2));
+
+            MongoCollection<Document> products =
+                    getMongoDatabase("inventory").getCollection("products");
+
+            products.insertOne(
+                    productDocOf("000000000000000000001002", "robot", "Toy robot", 1.304));
+
+            List<SourceRecord> records = drain(sourceContext2, 1);
+            assertEquals(1, records.size());
+            assertInsert(records.get(0), true);
+            assertObjectIdEquals("000000000000000000001002", records.get(0));
+
+            // ---------------------------------------------------------------------------
+            // Step-4: trigger checkpoint-2 during DML operations
+            // ---------------------------------------------------------------------------
+            synchronized (sourceContext2.getCheckpointLock()) {
+                // trigger checkpoint-1
+                source2.snapshotState(new StateSnapshotContextSynchronousImpl(138, 138));
+            }
+
+            assertEquals(1, offsetState.list.size());
+            String state = new String(offsetState.list.get(0), StandardCharsets.UTF_8);
+            assertTrue(state.contains("sourcePartition"));
+            assertTrue(state.contains("sourceOffset"));
+            String resumeToken = JsonPath.read(state, "$.sourceOffset._id");
+            assertTrue(resumeToken.contains("_data"));
+
+            // execute 2 more DMLs to have more change log
+            products.insertOne(
+                    productDocOf("000000000000000000001003", "roy", "old robot", 1234.56));
+            products.updateOne(
+                    Filters.eq("_id", new ObjectId("000000000000000000001002")),
+                    Updates.set("weight", 1345.67));
+
+            // cancel the source
+            source2.cancel();
+            source2.close();
+            runThread2.sync();
+        }
+
+        {
+            // ---------------------------------------------------------------------------
+            // Step-5: restore the source from checkpoint-2
+            // ---------------------------------------------------------------------------
+            final DebeziumSourceFunction<SourceRecord> source3 = createMongoDBSource();
+            final TestSourceContext<SourceRecord> sourceContext3 = new TestSourceContext<>();
+            setupSource(source3, true, offsetState, historyState, true, 0, 1);
+
+            // restart the source
+            final CheckedThread runThread3 =
+                    new CheckedThread() {
+                        @Override
+                        public void go() throws Exception {
+                            source3.run(sourceContext3);
+                        }
+                    };
+            runThread3.start();
+
+            // consume the unconsumed binlog
+            List<SourceRecord> records = drain(sourceContext3, 2);
+            assertInsert(records.get(0), true);
+            assertObjectIdEquals("000000000000000000001003", records.get(0));
+            assertUpdate(records.get(1), "000000000000000000001002");
+
+            // make sure there is no more events
+            assertFalse(waitForAvailableRecords(Duration.ofSeconds(3), sourceContext3));
+
+            MongoCollection<Document> products =
+                    getMongoDatabase("inventory").getCollection("products");
+
+            products.deleteOne(Filters.eq("_id", new ObjectId("000000000000000000001002")));
+            records = drain(sourceContext3, 1);
+            assertDelete(records.get(0), "000000000000000000001002");
+
+            products.deleteOne(Filters.eq("_id", new ObjectId("000000000000000000001003")));
+            records = drain(sourceContext3, 1);
+            assertDelete(records.get(0), "000000000000000000001003");
+
+            // ---------------------------------------------------------------------------
+            // Step-6: trigger checkpoint-2 to make sure we can continue to to further checkpoints
+            // ---------------------------------------------------------------------------
+            synchronized (sourceContext3.getCheckpointLock()) {
+                // checkpoint 3
+                source3.snapshotState(new StateSnapshotContextSynchronousImpl(233, 233));
+            }
+
+            assertEquals(1, offsetState.list.size());
+            String state = new String(offsetState.list.get(0), StandardCharsets.UTF_8);
+            assertTrue(state.contains("sourcePartition"));
+            assertTrue(state.contains("sourceOffset"));
+            String resumeToken = JsonPath.read(state, "$.sourceOffset._id");
+            assertTrue(resumeToken.contains("_data"));
+
+            source3.cancel();
+            source3.close();
+            runThread3.sync();
+        }
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Utilities
+    // ------------------------------------------------------------------------------------------
+
+    private DebeziumSourceFunction<SourceRecord> createMongoDBSource() {
+        return MongoDBSource.<SourceRecord>builder()
+                .connectionUri(
+                        MONGODB_CONTAINER.getConnectionString(FLINK_USER, FLINK_USER_PASSWORD))
+                .database("inventory")
+                .collection("products")
+                .deserializer(new ForwardDeserializeSchema())
+                .build();
+    }
+
+    private <T> List<T> drain(TestSourceContext<T> sourceContext, int expectedRecordCount)
+            throws Exception {
+        List<T> allRecords = new ArrayList<>();
+        LinkedBlockingQueue<StreamRecord<T>> queue = sourceContext.getCollectedOutputs();
+        while (allRecords.size() < expectedRecordCount) {
+            StreamRecord<T> record = queue.poll(100, TimeUnit.SECONDS);
+            if (record != null) {
+                allRecords.add(record.getValue());
+            } else {
+                throw new RuntimeException(
+                        "Can't receive " + expectedRecordCount + " elements before timeout.");
+            }
+        }
+
+        return allRecords;
+    }
+
+    private boolean waitForCheckpointLock(Object checkpointLock, Duration timeout)
+            throws Exception {
+        final Semaphore semaphore = new Semaphore(0);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.execute(
+                () -> {
+                    synchronized (checkpointLock) {
+                        semaphore.release();
+                    }
+                });
+        boolean result = semaphore.tryAcquire(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        executor.shutdownNow();
+        return result;
+    }
+
+    /**
+     * Wait for a maximum amount of time until the first record is available.
+     *
+     * @param timeout the maximum amount of time to wait; must not be negative
+     * @return {@code true} if records are available, or {@code false} if the timeout occurred and
+     *     no records are available
+     */
+    private boolean waitForAvailableRecords(Duration timeout, TestSourceContext<?> sourceContext)
+            throws InterruptedException {
+        long now = System.currentTimeMillis();
+        long stop = now + timeout.toMillis();
+        while (System.currentTimeMillis() < stop) {
+            if (!sourceContext.getCollectedOutputs().isEmpty()) {
+                break;
+            }
+            Thread.sleep(10); // save CPU
+        }
+        return !sourceContext.getCollectedOutputs().isEmpty();
+    }
+
+    private static <T> void setupSource(DebeziumSourceFunction<T> source) throws Exception {
+        setupSource(
+                source, false, null, null,
+                true, // enable checkpointing; auto commit should be ignored
+                0, 1);
+    }
+
+    private static <T, S1, S2> void setupSource(
+            DebeziumSourceFunction<T> source,
+            boolean isRestored,
+            ListState<S1> restoredOffsetState,
+            ListState<S2> restoredHistoryState,
+            boolean isCheckpointingEnabled,
+            int subtaskIndex,
+            int totalNumSubtasks)
+            throws Exception {
+
+        // run setup procedure in operator life cycle
+        source.setRuntimeContext(
+                new MockStreamingRuntimeContext(
+                        isCheckpointingEnabled, totalNumSubtasks, subtaskIndex));
+        source.initializeState(
+                new MockFunctionInitializationContext(
+                        isRestored,
+                        new MockOperatorStateStore(restoredOffsetState, restoredHistoryState)));
+        source.open(new Configuration());
+    }
+
+    /**
+     * A simple implementation of {@link DebeziumDeserializationSchema} which just forward the
+     * {@link SourceRecord}.
+     */
+    public static class ForwardDeserializeSchema
+            implements DebeziumDeserializationSchema<SourceRecord> {
+
+        private static final long serialVersionUID = 2975058057832211228L;
+
+        @Override
+        public void deserialize(SourceRecord record, Collector<SourceRecord> out) throws Exception {
+            out.collect(record);
+        }
+
+        @Override
+        public TypeInformation<SourceRecord> getProducedType() {
+            return TypeInformation.of(SourceRecord.class);
+        }
+    }
+
+    private static class MockOperatorStateStore implements OperatorStateStore {
+
+        private final ListState<?> restoredOffsetListState;
+        private final ListState<?> restoredHistoryListState;
+
+        private MockOperatorStateStore(
+                ListState<?> restoredOffsetListState, ListState<?> restoredHistoryListState) {
+            this.restoredOffsetListState = restoredOffsetListState;
+            this.restoredHistoryListState = restoredHistoryListState;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <S> ListState<S> getUnionListState(ListStateDescriptor<S> stateDescriptor)
+                throws Exception {
+            if (stateDescriptor.getName().equals(DebeziumSourceFunction.OFFSETS_STATE_NAME)) {
+                return (ListState<S>) restoredOffsetListState;
+            } else if (stateDescriptor
+                    .getName()
+                    .equals(DebeziumSourceFunction.HISTORY_RECORDS_STATE_NAME)) {
+                return (ListState<S>) restoredHistoryListState;
+            } else {
+                throw new IllegalStateException("Unknown state.");
+            }
+        }
+
+        @Override
+        public <K, V> BroadcastState<K, V> getBroadcastState(
+                MapStateDescriptor<K, V> stateDescriptor) throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <S> ListState<S> getListState(ListStateDescriptor<S> stateDescriptor)
+                throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<String> getRegisteredStateNames() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<String> getRegisteredBroadcastStateNames() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class MockFunctionInitializationContext
+            implements FunctionInitializationContext {
+
+        private final boolean isRestored;
+        private final OperatorStateStore operatorStateStore;
+
+        private MockFunctionInitializationContext(
+                boolean isRestored, OperatorStateStore operatorStateStore) {
+            this.isRestored = isRestored;
+            this.operatorStateStore = operatorStateStore;
+        }
+
+        @Override
+        public boolean isRestored() {
+            return isRestored;
+        }
+
+        @Override
+        public OperatorStateStore getOperatorStateStore() {
+            return operatorStateStore;
+        }
+
+        @Override
+        public KeyedStateStore getKeyedStateStore() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class BlockingSourceContext<T> extends TestSourceContext<T> {
+
+        private final Semaphore blocker = new Semaphore(0);
+        private final int expectedCount;
+        private int currentCount = 0;
+
+        private BlockingSourceContext(int expectedCount) {
+            this.expectedCount = expectedCount;
+        }
+
+        @Override
+        public void collect(T t) {
+            super.collect(t);
+            currentCount++;
+            if (currentCount == expectedCount) {
+                try {
+                    // block the source to emit records
+                    blocker.acquire();
+                } catch (InterruptedException e) {
+                    // ignore
+                }
+            }
+        }
+    }
+
+    private static final class TestingListState<T> implements ListState<T> {
+
+        private final List<T> list = new ArrayList<>();
+        private boolean clearCalled = false;
+
+        @Override
+        public void clear() {
+            list.clear();
+            clearCalled = true;
+        }
+
+        @Override
+        public Iterable<T> get() throws Exception {
+            return list;
+        }
+
+        @Override
+        public void add(T value) throws Exception {
+            Preconditions.checkNotNull(value, "You cannot add null to a ListState.");
+            list.add(value);
+        }
+
+        public List<T> getList() {
+            return list;
+        }
+
+        boolean isClearCalled() {
+            return clearCalled;
+        }
+
+        @Override
+        public void update(List<T> values) throws Exception {
+            clear();
+
+            addAll(values);
+        }
+
+        @Override
+        public void addAll(List<T> values) throws Exception {
+            if (values != null) {
+                values.forEach(
+                        v -> Preconditions.checkNotNull(v, "You cannot add null to a ListState."));
+
+                list.addAll(values);
+            }
+        }
+    }
+
+    private Document productDocOf(String id, String name, String description, Double weight) {
+        Document document = new Document();
+        if (id != null) {
+            document.put("_id", new ObjectId(id));
+        }
+        document.put("name", name);
+        document.put("description", description);
+        document.put("weight", weight);
+        return document;
+    }
+}

--- a/flink-connector-mongodb-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mongodb/MongoDBTestBase.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mongodb/MongoDBTestBase.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mongodb;
+
+import org.apache.flink.test.util.AbstractTestBase;
+
+import com.alibaba.ververica.cdc.connectors.mongodb.utils.MongoDBContainer;
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoDatabase;
+import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.lifecycle.Startables;
+
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Basic class for testing MongoDB source, this contains a MongoDB container which enables binlog.
+ */
+public class MongoDBTestBase extends AbstractTestBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDBTestBase.class);
+    private static final Pattern COMMENT_PATTERN = Pattern.compile("^(.*)//.*$");
+
+    protected static final String FLINK_USER = "flinkuser";
+    protected static final String FLINK_USER_PASSWORD = "flinkpw";
+
+    protected static final String MONGO_SUPER_USER = "superuser";
+    protected static final String MONGO_SUPER_PASSWORD = "superpw";
+
+    protected static final MongoDBContainer MONGODB_CONTAINER =
+            new MongoDBContainer().withLogConsumer(new Slf4jLogConsumer(LOG));
+
+    protected static MongoClient mongodbClient;
+
+    @BeforeClass
+    public static void startContainers() {
+        LOG.info("Starting containers...");
+        Startables.deepStart(Stream.of(MONGODB_CONTAINER)).join();
+        executeCommandFile("setup");
+        initialClient();
+        LOG.info("Containers are started.");
+    }
+
+    private static void initialClient() {
+        MongoClientSettings settings =
+                MongoClientSettings.builder()
+                        .applyConnectionString(
+                                new ConnectionString(
+                                        MONGODB_CONTAINER.getConnectionString(
+                                                MONGO_SUPER_USER, MONGO_SUPER_PASSWORD)))
+                        .build();
+        mongodbClient = MongoClients.create(settings);
+    }
+
+    protected static MongoDatabase getMongoDatabase(String dbName) {
+        return mongodbClient.getDatabase(dbName);
+    }
+
+    /** Executes a mongo command file. */
+    protected static void executeCommandFile(String cmdFile) {
+        final String ddlFile = String.format("ddl/%s.js", cmdFile);
+        final URL ddlTestFile = MongoDBTestBase.class.getClassLoader().getResource(ddlFile);
+        assertNotNull("Cannot locate " + ddlFile, ddlTestFile);
+
+        try {
+            String command =
+                    Files.readAllLines(Paths.get(ddlTestFile.toURI())).stream()
+                            .map(String::trim)
+                            .filter(x -> !x.startsWith("//") && !x.isEmpty())
+                            .map(
+                                    x -> {
+                                        final Matcher m = COMMENT_PATTERN.matcher(x);
+                                        return m.matches() ? m.group(1) : x;
+                                    })
+                            .collect(Collectors.joining("\n"));
+
+            MONGODB_CONTAINER.executeCommand(command);
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flink-connector-mongodb-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mongodb/table/MongoDBConnectorITCase.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mongodb/table/MongoDBConnectorITCase.java
@@ -1,0 +1,358 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mongodb.table;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+
+import com.alibaba.ververica.cdc.connectors.mongodb.MongoDBTestBase;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Updates;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/** Integration tests for MongoDB change stream event SQL source. */
+public class MongoDBConnectorITCase extends MongoDBTestBase {
+
+    private final StreamExecutionEnvironment env =
+            StreamExecutionEnvironment.getExecutionEnvironment();
+    private final StreamTableEnvironment tEnv =
+            StreamTableEnvironment.create(
+                    env,
+                    EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build());
+
+    @Before
+    public void before() {
+        TestValuesTableFactory.clearAllData();
+        env.setParallelism(1);
+    }
+
+    @Test
+    public void testConsumingAllEvents() throws ExecutionException, InterruptedException {
+        executeCommandFile("inventory");
+
+        String sourceDDL =
+                String.format(
+                        "CREATE TABLE mongodb_source ("
+                                + " _id STRING NOT NULL,"
+                                + " name STRING,"
+                                + " description STRING,"
+                                + " weight DECIMAL(10,3),"
+                                + " PRIMARY KEY (_id) NOT ENFORCED"
+                                + ") WITH ("
+                                + " 'connector' = 'mongodb-cdc',"
+                                + " 'uri' = '%s',"
+                                + " 'database' = '%s',"
+                                + " 'collection' = '%s'"
+                                + ")",
+                        MONGODB_CONTAINER.getConnectionString(FLINK_USER, FLINK_USER_PASSWORD),
+                        "inventory",
+                        "products");
+
+        String sinkDDL =
+                "CREATE TABLE sink ("
+                        + " name STRING,"
+                        + " weightSum DECIMAL(10,3),"
+                        + " PRIMARY KEY (name) NOT ENFORCED"
+                        + ") WITH ("
+                        + " 'connector' = 'values',"
+                        + " 'sink-insert-only' = 'false',"
+                        + " 'sink-expected-messages-num' = '20'"
+                        + ")";
+        tEnv.executeSql(sourceDDL);
+        tEnv.executeSql(sinkDDL);
+
+        // async submit job
+        TableResult result =
+                tEnv.executeSql(
+                        "INSERT INTO sink SELECT name, SUM(weight) FROM mongodb_source GROUP BY name");
+
+        waitForSnapshotStarted("sink");
+
+        MongoCollection<Document> products =
+                getMongoDatabase("inventory").getCollection("products");
+
+        products.updateOne(
+                Filters.eq("_id", new ObjectId("100000000000000000000106")),
+                Updates.set("description", "18oz carpenter hammer"));
+
+        products.updateOne(
+                Filters.eq("_id", new ObjectId("100000000000000000000107")),
+                Updates.set("weight", 5.1));
+
+        products.insertOne(
+                productDocOf(
+                        "100000000000000000000110",
+                        "jacket",
+                        "water resistent white wind breaker",
+                        0.2));
+
+        products.insertOne(
+                productDocOf("100000000000000000000111", "scooter", "Big 2-wheel scooter", 5.18));
+
+        products.updateOne(
+                Filters.eq("_id", new ObjectId("100000000000000000000110")),
+                Updates.combine(
+                        Updates.set("description", "new water resistent white wind breaker"),
+                        Updates.set("weight", 0.5)));
+
+        products.updateOne(
+                Filters.eq("_id", new ObjectId("100000000000000000000111")),
+                Updates.set("weight", 5.17));
+
+        products.deleteOne(Filters.eq("_id", new ObjectId("100000000000000000000111")));
+
+        waitForSinkSize("sink", 20);
+
+        // The final database table looks like this:
+        //
+        // > SELECT * FROM products;
+        // +-----+--------------------+---------------------------------------------------------+--------+
+        // | id  | name               | description                                             |
+        // weight |
+        // +-----+--------------------+---------------------------------------------------------+--------+
+        // | 101 | scooter            | Small 2-wheel scooter                                   |
+        // 3.14 |
+        // | 102 | car battery        | 12V car battery                                         |
+        // 8.1 |
+        // | 103 | 12-pack drill bits | 12-pack of drill bits with sizes ranging from #40 to #3 |
+        // 0.8 |
+        // | 104 | hammer             | 12oz carpenter's hammer                                 |
+        // 0.75 |
+        // | 105 | hammer             | 14oz carpenter's hammer                                 |
+        // 0.875 |
+        // | 106 | hammer             | 18oz carpenter hammer                                   |
+        //   1 |
+        // | 107 | rocks              | box of assorted rocks                                   |
+        // 5.1 |
+        // | 108 | jacket             | water resistent black wind breaker                      |
+        // 0.1 |
+        // | 109 | spare tire         | 24 inch spare tire                                      |
+        // 22.2 |
+        // | 110 | jacket             | new water resistent white wind breaker                  |
+        // 0.5 |
+        // +-----+--------------------+---------------------------------------------------------+--------+
+
+        String[] expected =
+                new String[] {
+                    "scooter,3.140",
+                    "car battery,8.100",
+                    "12-pack drill bits,0.800",
+                    "hammer,2.625",
+                    "rocks,5.100",
+                    "jacket,0.600",
+                    "spare tire,22.200"
+                };
+
+        List<String> actual = TestValuesTableFactory.getResults("sink");
+        assertThat(actual, containsInAnyOrder(expected));
+
+        result.getJobClient().get().cancel().get();
+    }
+
+    @Test
+    public void testAllTypes() throws Throwable {
+        executeCommandFile("column_type_test");
+
+        String sourceDDL =
+                String.format(
+                        "CREATE TABLE full_types (\n"
+                                + "    _id STRING,\n"
+                                + "    stringField STRING,\n"
+                                + "    uuidField STRING,\n"
+                                + "    md5Field STRING,\n"
+                                + "    dateField DATE,\n"
+                                + "    dateBefore1970 DATE,\n"
+                                + "    timestampField TIMESTAMP,\n"
+                                + "    booleanField BOOLEAN,\n"
+                                + "    decimal128Field DECIMAL ,\n"
+                                + "    doubleField DOUBLE,\n"
+                                + "    int32field INT,\n"
+                                + "    int64Field BIGINT,\n"
+                                + "    documentField ROW<a STRING,b BIGINT>,\n"
+                                + "    mapField MAP<STRING,MAP<STRING,INT>>,\n"
+                                + "    arrayField ARRAY<STRING>,\n"
+                                + "    doubleArrayField ARRAY<DOUBLE>,\n"
+                                + "    documentArrayField ARRAY<ROW<a STRING,b BIGINT>>,\n"
+                                + "    minKeyField STRING,\n"
+                                + "    maxKeyField STRING,\n"
+                                + "    regexField STRING,\n"
+                                + "    undefinedField STRING,\n"
+                                + "    nullField STRING,\n"
+                                + "    binaryField BINARY,\n"
+                                + "    javascriptField STRING,\n"
+                                + "    dbReferenceField ROW<$ref STRING,$id STRING>,\n"
+                                + "    PRIMARY KEY (_id) NOT ENFORCED"
+                                + ") WITH ("
+                                + " 'connector' = 'mongodb-cdc',"
+                                + " 'uri' = '%s',"
+                                + " 'database' = '%s',"
+                                + " 'collection' = '%s'"
+                                + ")",
+                        MONGODB_CONTAINER.getConnectionString(FLINK_USER, FLINK_USER_PASSWORD),
+                        "column_type_test",
+                        "full_types");
+
+        String sinkDDL =
+                "CREATE TABLE sink (\n"
+                        + "    _id STRING,\n"
+                        + "    stringField STRING,\n"
+                        + "    uuidField STRING,\n"
+                        + "    md5Field STRING,\n"
+                        + "    dateField DATE,\n"
+                        + "    dateBefore1970 DATE,\n"
+                        + "    timestampField TIMESTAMP,\n"
+                        + "    booleanField BOOLEAN,\n"
+                        + "    decimal128Field DECIMAL ,\n"
+                        + "    doubleField DOUBLE,\n"
+                        + "    int32field INT,\n"
+                        + "    int64Field BIGINT,\n"
+                        + "    documentField ROW<a STRING,b BIGINT>,\n"
+                        + "    mapField MAP<STRING,MAP<STRING,INT>>,\n"
+                        + "    arrayField ARRAY<STRING>,\n"
+                        + "    doubleArrayField ARRAY<DOUBLE>,\n"
+                        + "    documentArrayField ARRAY<ROW<a STRING,b BIGINT>>,\n"
+                        + "    minKeyField STRING,\n"
+                        + "    maxKeyField STRING,\n"
+                        + "    regexField STRING,\n"
+                        + "    undefinedField STRING,\n"
+                        + "    nullField STRING,\n"
+                        + "    binaryField BINARY,\n"
+                        + "    javascriptField STRING,\n"
+                        + "    dbReferenceField ROW<$ref STRING,$id STRING>\n"
+                        + ") WITH ("
+                        + " 'connector' = 'values',"
+                        + " 'sink-insert-only' = 'false'"
+                        + ")";
+        tEnv.executeSql(sourceDDL);
+        tEnv.executeSql(sinkDDL);
+
+        // async submit job
+        TableResult result =
+                tEnv.executeSql(
+                        "INSERT INTO sink SELECT _id,\n"
+                                + "stringField,\n"
+                                + "uuidField,\n"
+                                + "md5Field,\n"
+                                + "dateField,\n"
+                                + "dateBefore1970,\n"
+                                + "timestampField,\n"
+                                + "booleanField,\n"
+                                + "decimal128Field,\n"
+                                + "doubleField,\n"
+                                + "int32field,\n"
+                                + "int64Field,\n"
+                                + "documentField,\n"
+                                + "mapField,\n"
+                                + "arrayField,\n"
+                                + "doubleArrayField,\n"
+                                + "documentArrayField,\n"
+                                + "minKeyField,\n"
+                                + "maxKeyField,\n"
+                                + "regexField,\n"
+                                + "undefinedField,\n"
+                                + "nullField,\n"
+                                + "binaryField,\n"
+                                + "javascriptField,\n"
+                                + "dbReferenceField\n"
+                                + "FROM full_types");
+
+        waitForSnapshotStarted("sink");
+
+        MongoCollection<Document> fullTypes =
+                getMongoDatabase("column_type_test").getCollection("full_types");
+
+        fullTypes.updateOne(
+                Filters.eq("_id", new ObjectId("5d505646cf6d4fe581014ab2")),
+                Updates.set("int64Field", 510L));
+
+        waitForSinkSize("sink", 3);
+
+        List<String> expected =
+                Arrays.asList(
+                        "+I(5d505646cf6d4fe581014ab2,hello,0bd1e27e-2829-4b47-8e21-dfef93da44e1,"
+                                + "2078693f4c61ce3073b01be69ab76428,2019-08-12,1960-08-12,"
+                                + "2019-08-11T17:47:44,true,11,10.5,10,50,hello,50,{inner_map={key=234}},"
+                                + "[hello, world],[1.0, 1.1, null],[hello0,51, hello1,53],MIN_KEY,MAX_KEY,"
+                                + "/^H/i,null,null,[1, 2, 3],function () { x++; },ref_doc,5d505646cf6d4fe581014ab3)",
+                        "-U(5d505646cf6d4fe581014ab2,hello,0bd1e27e-2829-4b47-8e21-dfef93da44e1,"
+                                + "2078693f4c61ce3073b01be69ab76428,2019-08-12,1960-08-12,"
+                                + "2019-08-11T17:47:44,true,11,10.5,10,50,hello,50,{inner_map={key=234}},"
+                                + "[hello, world],[1.0, 1.1, null],[hello0,51, hello1,53],MIN_KEY,MAX_KEY,"
+                                + "/^H/i,null,null,[1, 2, 3],function () { x++; },ref_doc,5d505646cf6d4fe581014ab3)",
+                        "+U(5d505646cf6d4fe581014ab2,hello,0bd1e27e-2829-4b47-8e21-dfef93da44e1,"
+                                + "2078693f4c61ce3073b01be69ab76428,2019-08-12,1960-08-12,"
+                                + "2019-08-11T17:47:44,true,11,10.5,10,510,hello,50,{inner_map={key=234}},"
+                                + "[hello, world],[1.0, 1.1, null],[hello0,51, hello1,53],MIN_KEY,MAX_KEY,"
+                                + "/^H/i,null,null,[1, 2, 3],function () { x++; },ref_doc,5d505646cf6d4fe581014ab3)");
+        List<String> actual = TestValuesTableFactory.getRawResults("sink");
+        assertEquals(expected, actual);
+
+        result.getJobClient().get().cancel().get();
+    }
+
+    private static void waitForSnapshotStarted(String sinkName) throws InterruptedException {
+        while (sinkSize(sinkName) == 0) {
+            Thread.sleep(100);
+        }
+    }
+
+    private static void waitForSinkSize(String sinkName, int expectedSize)
+            throws InterruptedException {
+        while (sinkSize(sinkName) < expectedSize) {
+            Thread.sleep(100);
+        }
+    }
+
+    private static int sinkSize(String sinkName) {
+        synchronized (TestValuesTableFactory.class) {
+            try {
+                return TestValuesTableFactory.getRawResults(sinkName).size();
+            } catch (IllegalArgumentException e) {
+                // job is not started yet
+                return 0;
+            }
+        }
+    }
+
+    private Document productDocOf(String id, String name, String description, Double weight) {
+        Document document = new Document();
+        if (id != null) {
+            document.put("_id", new ObjectId(id));
+        }
+        document.put("name", name);
+        document.put("description", description);
+        document.put("weight", weight);
+        return document;
+    }
+}

--- a/flink-connector-mongodb-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mongodb.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.utils.TableSchemaUtils;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.alibaba.ververica.cdc.connectors.mongodb.MongoDBSource.ERROR_TOLERANCE_ALL;
+import static com.alibaba.ververica.cdc.connectors.mongodb.MongoDBSource.POLL_AWAIT_TIME_MILLIS_DEFAULT;
+import static com.alibaba.ververica.cdc.connectors.mongodb.MongoDBSource.POLL_MAX_BATCH_SIZE_DEFAULT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/** Test for {@link MongoDBTableSource} created by {@link MongoDBTableSourceFactory}. */
+public class MongoDBTableFactoryTest {
+    private static final TableSchema SCHEMA =
+            TableSchema.builder()
+                    .field("_id", DataTypes.STRING().notNull())
+                    .field("bbb", DataTypes.STRING().notNull())
+                    .field("ccc", DataTypes.DOUBLE())
+                    .field("ddd", DataTypes.DECIMAL(31, 18))
+                    .field("eee", DataTypes.TIMESTAMP(3))
+                    .primaryKey("_id")
+                    .build();
+
+    private static final String MY_URI =
+            "mongodb://flinkuser:flinkpw@localhost:27017,localhost:27018";
+    private static final String MY_DATABASE = "myDB";
+    private static final String MY_TABLE = "myTable";
+    private static final String ERROR_TOLERANCE = "none";
+    private static final Boolean ERROR_LOGS_ENABLE = true;
+    private static final Boolean COPY_EXISTING = true;
+
+    @Test
+    public void testCommonProperties() {
+        Map<String, String> properties = getAllOptions();
+
+        // validation for source
+        DynamicTableSource actualSource = createTableSource(properties);
+        MongoDBTableSource expectedSource =
+                new MongoDBTableSource(
+                        TableSchemaUtils.getPhysicalSchema(SCHEMA),
+                        MY_URI,
+                        MY_DATABASE,
+                        MY_TABLE,
+                        ERROR_TOLERANCE,
+                        ERROR_LOGS_ENABLE,
+                        COPY_EXISTING,
+                        null,
+                        null,
+                        null,
+                        POLL_MAX_BATCH_SIZE_DEFAULT,
+                        POLL_AWAIT_TIME_MILLIS_DEFAULT,
+                        null);
+        assertEquals(expectedSource, actualSource);
+    }
+
+    @Test
+    public void testOptionalProperties() {
+        Map<String, String> options = getAllOptions();
+        options.put("errors.tolerance", "all");
+        options.put("errors.log.enable", "false");
+        options.put("copy.existing", "false");
+        options.put("copy.existing.pipeline", "[ { \"$match\": { \"closed\": \"false\" } } ]");
+        options.put("copy.existing.max.threads", "1");
+        options.put("copy.existing.queue.size", "101");
+        options.put("poll.max.batch.size", "102");
+        options.put("poll.await.time.ms", "103");
+        options.put("heartbeat.interval.ms", "104");
+        DynamicTableSource actualSource = createTableSource(options);
+
+        MongoDBTableSource expectedSource =
+                new MongoDBTableSource(
+                        TableSchemaUtils.getPhysicalSchema(SCHEMA),
+                        MY_URI,
+                        MY_DATABASE,
+                        MY_TABLE,
+                        ERROR_TOLERANCE_ALL,
+                        false,
+                        false,
+                        "[ { \"$match\": { \"closed\": \"false\" } } ]",
+                        1,
+                        101,
+                        102,
+                        103,
+                        104);
+        assertEquals(expectedSource, actualSource);
+    }
+
+    @Test
+    public void testValidation() {
+        // validate unsupported option
+        try {
+            Map<String, String> properties = getAllOptions();
+            properties.put("unknown", "abc");
+
+            createTableSource(properties);
+            fail("exception expected");
+        } catch (Throwable t) {
+            assertTrue(
+                    ExceptionUtils.findThrowableWithMessage(t, "Unsupported options:\n\nunknown")
+                            .isPresent());
+        }
+    }
+
+    private Map<String, String> getAllOptions() {
+        Map<String, String> options = new HashMap<>();
+        options.put("connector", "mongodb-cdc");
+        options.put("uri", MY_URI);
+        options.put("database", MY_DATABASE);
+        options.put("collection", MY_TABLE);
+        return options;
+    }
+
+    private static DynamicTableSource createTableSource(Map<String, String> options) {
+        return FactoryUtil.createTableSource(
+                null,
+                ObjectIdentifier.of("default", "default", "t1"),
+                new CatalogTableImpl(SCHEMA, options, "mock source"),
+                new Configuration(),
+                MongoDBTableFactoryTest.class.getClassLoader(),
+                false);
+    }
+}

--- a/flink-connector-mongodb-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mongodb/utils/MongoDBAssertUtils.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mongodb/utils/MongoDBAssertUtils.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mongodb.utils;
+
+import com.jayway.jsonpath.JsonPath;
+import com.mongodb.client.model.changestream.OperationType;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/** MongoDB test assert utils. */
+public class MongoDBAssertUtils {
+
+    public static void assertObjectIdEquals(String expect, SourceRecord actual) {
+        String actualOid = ((Struct) actual.value()).getString("documentKey");
+        assertEquals(expect, JsonPath.read(actualOid, "$._id.$oid"));
+    }
+
+    public static void assertInsert(SourceRecord record, boolean keyExpected) {
+        if (keyExpected) {
+            assertNotNull(record.key());
+            assertNotNull(record.keySchema());
+        } else {
+            assertNull(record.key());
+            assertNull(record.keySchema());
+        }
+
+        assertNotNull(record.valueSchema());
+        Struct value = (Struct) record.value();
+        assertNotNull(value);
+        assertEquals(OperationType.INSERT.getValue(), value.getString("operationType"));
+        assertNotNull(value.get("fullDocument"));
+        assertNotNull(value.get("documentKey"));
+    }
+
+    public static void assertUpdate(SourceRecord record) {
+        assertNotNull(record.key());
+        assertNotNull(record.keySchema());
+
+        assertNotNull(record.valueSchema());
+        Struct value = (Struct) record.value();
+        assertNotNull(value);
+        assertEquals(OperationType.UPDATE.getValue(), value.getString("operationType"));
+        assertNotNull(value.get("documentKey"));
+        assertNotNull(value.get("fullDocument"));
+    }
+
+    public static void assertUpdate(SourceRecord record, String idValue) {
+        assertUpdate(record);
+        assertObjectIdEquals(idValue, record);
+    }
+
+    public static void assertReplace(SourceRecord record) {
+        assertNotNull(record.key());
+        assertNotNull(record.keySchema());
+
+        assertNotNull(record.valueSchema());
+        Struct value = (Struct) record.value();
+        assertNotNull(value);
+        assertEquals(OperationType.REPLACE.getValue(), value.getString("operationType"));
+        assertNotNull(value.get("documentKey"));
+        assertNotNull(value.get("fullDocument"));
+    }
+
+    public static void assertReplace(SourceRecord record, String idValue) {
+        assertReplace(record);
+        assertObjectIdEquals(idValue, record);
+    }
+
+    public static void assertDelete(SourceRecord record) {
+        assertNotNull(record.key());
+        assertNotNull(record.keySchema());
+
+        assertNotNull(record.valueSchema());
+        Struct value = (Struct) record.value();
+        assertNotNull(value);
+        assertEquals(OperationType.DELETE.getValue(), value.getString("operationType"));
+        assertNotNull(value.get("documentKey"));
+    }
+
+    public static void assertDelete(SourceRecord record, String idValue) {
+        assertDelete(record);
+        assertObjectIdEquals(idValue, record);
+    }
+}

--- a/flink-connector-mongodb-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mongodb/utils/MongoDBContainer.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mongodb/utils/MongoDBContainer.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mongodb.utils;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.Enumeration;
+
+/** Mongodb test replica container. */
+public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDBContainer.class);
+
+    private static final String REPLICA_SET_NAME = "rs0";
+
+    private static final String DOCKER_IMAGE_NAME = "mongo:4.0.3";
+
+    private static final int MONGODB_PORT = 27017;
+
+    public MongoDBContainer() {
+        super(DOCKER_IMAGE_NAME);
+        withExposedPorts(MONGODB_PORT);
+        withCommand("--replSet", REPLICA_SET_NAME);
+        waitingFor(Wait.forLogMessage(".*waiting for connections on port.*", 1));
+    }
+
+    public String getLocalHost() {
+        try {
+            Enumeration<NetworkInterface> networkInterfaces =
+                    NetworkInterface.getNetworkInterfaces();
+            while (networkInterfaces.hasMoreElements()) {
+                NetworkInterface ni = networkInterfaces.nextElement();
+
+                if (ni.isLoopback() || ni.isVirtual() || ni.isPointToPoint() || !ni.isUp()) {
+                    continue;
+                }
+
+                Enumeration<InetAddress> addresses = ni.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    InetAddress address = addresses.nextElement();
+                    if (address.isSiteLocalAddress()) {
+                        return address.getHostAddress();
+                    }
+                }
+            }
+
+            return InetAddress.getLocalHost().getHostAddress();
+        } catch (Exception e) {
+            throw new IllegalStateException("Cannot get local ip address", e);
+        }
+    }
+
+    public String getConnectionString(String username, String password) {
+        return String.format(
+                "mongodb://%s:%s@%s:%d",
+                username, password, getLocalHost(), getMappedPort(MONGODB_PORT));
+    }
+
+    public void executeCommand(String command) {
+        try {
+            LOG.info("Executing mongo command: {}", command);
+            ExecResult execResult = execInContainer("mongo", "--eval", command);
+            LOG.info(execResult.getStdout());
+            if (execResult.getExitCode() != 0) {
+                throw new IllegalStateException("Execute mongo command failed");
+            }
+        } catch (InterruptedException | IOException e) {
+            throw new IllegalStateException("Execute mongo command failed", e);
+        }
+    }
+
+    @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        initReplicaSet();
+    }
+
+    private void initReplicaSet() {
+        LOG.info("Initializing a single node node replica set...");
+        executeCommand(
+                String.format(
+                        "rs.initiate({ _id : '%s', members: [{ _id: 0, host: '%s:%d'}]})",
+                        REPLICA_SET_NAME, getLocalHost(), getMappedPort(MONGODB_PORT)));
+
+        LOG.info("Waiting for single node node replica set initialized...");
+        executeCommand(
+                String.format(
+                        "var attempt = 0; "
+                                + "while"
+                                + "(%s) "
+                                + "{ "
+                                + "if (attempt > %d) {quit(1);} "
+                                + "print('%s ' + attempt); sleep(100);  attempt++; "
+                                + " }",
+                        "db.runCommand( { isMaster: 1 } ).ismaster==false",
+                        60,
+                        "An attempt to await for a single node replica set initialization:"));
+    }
+}

--- a/flink-connector-mongodb-cdc/src/test/resources/ddl/column_type_test.js
+++ b/flink-connector-mongodb-cdc/src/test/resources/ddl/column_type_test.js
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// ----------------------------------------------------------------------------------------------------------------
+// DATABASE:  column_type_test
+// ----------------------------------------------------------------------------------------------------------------
+
+db.getSiblingDB('column_type_test').getCollection('full_types').insertOne({
+    "_id": ObjectId("5d505646cf6d4fe581014ab2"),
+    "stringField": "hello",
+    "uuidField": UUID("0bd1e27e-2829-4b47-8e21-dfef93da44e1"),
+    "md5Field": MD5("2078693f4c61ce3073b01be69ab76428"),
+    "dateField": ISODate("2019-08-11T17:54:14.692Z"),
+    "dateBefore1970": ISODate("1960-08-11T17:54:14.692Z"),
+    "timestampField": Timestamp(1565545664,1),
+    "booleanField": true,
+    "decimal128Field": NumberDecimal("10.99"),
+    "doubleField": 10.5,
+    "int32field": NumberInt("10"),
+    "int64Field": NumberLong("50"),
+    "documentField": {"a":"hello", "b": NumberLong("50")},
+    "mapField": {
+        "inner_map": {
+            "key": NumberLong("234")
+        }
+    },
+    "arrayField": ["hello","world"],
+    "doubleArrayField": [1.0, 1.1, null],
+    "documentArrayField": [{"a":"hello0", "b": NumberLong("51")}, {"a":"hello1", "b": NumberLong("53")}],
+    "minKeyField": ﻿MinKey(),
+    "maxKeyField":  MaxKey(),
+    "regexField": /^H/i,
+    "undefinedField": undefined,
+    "nullField": null,
+    "binaryField": BinData(0,"AQID"),
+    "javascriptField": (function() { x++; }),
+    "dbReferenceField": DBRef("ref_doc", ObjectId("5d505646cf6d4fe581014ab3"))
+});

--- a/flink-connector-mongodb-cdc/src/test/resources/ddl/inventory.js
+++ b/flink-connector-mongodb-cdc/src/test/resources/ddl/inventory.js
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+db.getSiblingDB('inventory').getCollection('products').insertMany([
+{"_id": ObjectId("100000000000000000000101"), "name": "scooter", "description": "Small 2-wheel scooter", "weight": 3.14},
+{"_id": ObjectId("100000000000000000000102"), "name": "car battery", "description": "12V car battery", "weight": 8.1},
+{"_id": ObjectId("100000000000000000000103"), "name": "12-pack drill bits", "description": "12-pack of drill bits with sizes ranging from #40 to #3", "weight": 0.8},
+{"_id": ObjectId("100000000000000000000104"), "name": "hammer", "description": "12oz carpenter''s hammer", "weight": 0.75},
+{"_id": ObjectId("100000000000000000000105"), "name": "hammer", "description": "12oz carpenter''s hammer", "weight": 0.875},
+{"_id": ObjectId("100000000000000000000106"), "name": "hammer", "description": "12oz carpenter''s hammer", "weight": 1.0},
+{"_id": ObjectId("100000000000000000000107"), "name": "rocks", "description": "box of assorted rocks", "weight": 5.3},
+{"_id": ObjectId("100000000000000000000108"), "name": "jacket", "description": "water resistent black wind breaker", "weight": 0.1},
+{"_id": ObjectId("100000000000000000000109"), "name": "spare tire", "description": "24 inch spare tire", "weight": 22.2}
+]);

--- a/flink-connector-mongodb-cdc/src/test/resources/ddl/setup.js
+++ b/flink-connector-mongodb-cdc/src/test/resources/ddl/setup.js
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// In production you would almost certainly limit the replication user must be on the follower (slave) machine,
+// to prevent other clients accessing the log from other machines. For example, 'replicator'@'follower.acme.com'.
+// However, in this database we'll grant 2 users different privileges:
+//
+// 1) 'flinkuser' - all privileges required by the snapshot reader AND oplog reader (used for testing)
+// 2) 'superuser' - all privileges
+//
+
+
+db.getSiblingDB('admin').createUser(
+   {
+     user: 'superuser',
+     pwd: 'superpw',
+     roles: [ { role: 'root', db: 'admin' } ]
+   }
+)
+
+db.getSiblingDB('admin').createUser(
+ {
+   user: 'flinkuser',
+   pwd: 'flinkpw',
+   roles: [
+      { role: 'read', db: 'admin' },
+      { role: 'readAnyDatabase', db: 'admin' }
+   ]
+ }
+)
+
+rs.status()

--- a/flink-connector-mongodb-cdc/src/test/resources/log4j2-test.properties
+++ b/flink-connector-mongodb-cdc/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level=INFO
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c - %m%n

--- a/flink-sql-connector-mongodb-cdc/pom.xml
+++ b/flink-sql-connector-mongodb-cdc/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>flink-cdc-connectors</artifactId>
+        <groupId>com.alibaba.ververica</groupId>
+        <version>1.4-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>flink-sql-connector-mongodb-cdc</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.ververica</groupId>
+            <artifactId>flink-connector-mongodb-cdc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadeTestJar>false</shadeTestJar>
+                            <artifactSet>
+                                <includes>
+                                    <include>*:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>org.apache.kafka:*</artifact>
+                                    <excludes>
+                                        <exclude>kafka/kafka-version.properties</exclude>
+                                        <exclude>LICENSE</exclude>
+                                        <!-- Does not contain anything relevant.
+                                            Cites a binary dependency on jersey, but this is neither reflected in the
+                                            dependency graph, nor are any jersey files bundled. -->
+                                        <exclude>NOTICE</exclude>
+                                        <exclude>common/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flink-sql-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/DummyDocs.java
+++ b/flink-sql-connector-mongodb-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mongodb/DummyDocs.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.connectors.mongodb;
+
+/** This is used to generate a dummy docs jar for this module to pass OSS repository rule. */
+public class DummyDocs {}

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,10 @@ under the License.
         <module>flink-connector-test-util</module>
         <module>flink-connector-mysql-cdc</module>
         <module>flink-connector-postgres-cdc</module>
+        <module>flink-connector-mongodb-cdc</module>
         <module>flink-sql-connector-mysql-cdc</module>
         <module>flink-sql-connector-postgres-cdc</module>
+        <module>flink-sql-connector-mongodb-cdc</module>
         <module>flink-format-changelog-json</module>
     </modules>
 


### PR DESCRIPTION
## Support MongoDB CDC connector #11 

### 实现方式
利用Debezium Embedded Engine，驱动MongoDB Kafaka Connector。
MongoDB Kafaka Connector是MongoDB官方提供的一个Kafaka Connector实现，订阅ChangeStreamEvent来实现变更数据订阅。

该PR并没有采用Debezium提供的MongoDB Connector，原因如下：

MongoDB的oplog中UPDATE事件并没有保留变更之前的数据状态，仅保留了变更字段的信息，无法将MongoDB变更记录转换成Flink标准的变更流(+I -U +U -D)。只能将其转换为UPSERT流(+I +U -D)，经过一次ChangelogNormalize转换成标准的变更流。

但是Update After的变更记录需要变更后完整的RowData，而Debezium原生Connector采用dump oplog的方式，并不能很好支持。MongoDB官方提供的 Kafaka Connector采用ChangeStreamEvent的订阅方式，可以开启FullDocument配置，采集该行记录的最新的完整信息(对单行记录的连续修改，可能导致单次的变更结果并不准确，但是能保证最终一致)。

___________________

### 使用示例

#### 前置条件
- MongoDB以副本集或分片方式集群部署，版本大于3.6
- MongoDB用户对db admin需要changeStream权限，需要采集的db有读权限，[参见roles文档](https://docs.mongodb.com/v4.0/reference/built-in-roles/#database-user-roles)

创建用户示例:
```javascript
use admin;
db.createUser(
 {
   user: "flinkuser",
   pwd: "flinkpw",
   roles: [
      { role: "read", db: "admin" },
      { role: "readAnyDatabase", db: "admin" }
   ]
 }
);
```

flink sql示例：
```sql
CREATE TABLE mongodb_source (
   _id STRING PRIMARY KEY, #由于采用Upsert流，必须强制声明_id为主键
   name STRING,
   description STRING,
   weight DECIMAL(10,3)
) WITH (
   'connector' = 'mongodb-cdc',
   'uri' = 'mongodb://flinkuser:flinkpw@127.0.0.1:27017',
   'database' = 'inventory',
   'collection' = 'products'
);

SELECT _id, name, description, weight FROM mongodb_source;
```

flink datastream示例：
```java
import com.alibaba.ververica.cdc.debezium.StringDebeziumDeserializationSchema;
import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
import org.apache.flink.streaming.api.functions.source.SourceFunction;

public class MongoDBSourceExample {
    public static void main(String[] args) throws Exception {
        SourceFunction<String> sourceFunction = MongoDBSource.<String>builder()
                .connectionUri("mongodb://127.0.0.1:27017")
                .database("inventory")
                .collection("products")
                .deserializer(new StringDebeziumDeserializationSchema())
                .build();

        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();

        env.addSource(sourceFunction)
                .print().setParallelism(1); // use parallelism 1 for sink to keep message ordering

        env.execute();
    }
}
```
___________________

### 参数说明
[详细请参考](https://docs.mongodb.com/kafka-connector/master/kafka-source/)
| Name | Description | Required | Default | 
| --- | --- | --- | --- |
| uri | A MongoDB connection URI string. | true | - |
| database | Name of the database to watch for changes. | true | - |
| collection | Name of the collection in the database to watch for changes. | true | - |
| errors.tolerance| Whether to continue processing messages if an error is encountered.  | false | none |
| errors.log.enable | Whether details of failed operations should be written to the log file.  | false | true |
| copy.existing | Whether copy existing data from source collections | false | true |
| copy.existing.pipeline | An array of JSON objects describing the pipeline operations to run when copying existing data.| false | - |
| copy.existing.max.threads | The number of threads to use when performing the data copy. | false | Processors Count |
| copy.existing.queue.size |  The max size of the queue to use when copying data. | false |16000|
| poll.max.batch.size | Maximum number of change stream documents to include in a single batch when polling for new data. |  false | 1000 |
| poll.await.time.ms | The amount of time to wait before checking for new results on the change stream. | false | 1500 |
| heartbeat.interval.ms | The length of time in milliseconds between sending heartbeat messages. Use 0 to disable. | false | 0 |

___________________

### 参考文档
[MongoDB Kafaka Connector](https://docs.mongodb.com/kafka-connector/master/kafka-source/)
[MongoDB Change Streams](https://docs.mongodb.com/manual/changeStreams/)

___________________