### PR TITLE
Support read from specific MySQL Binlog gtid

### DIFF
--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/DebeziumChangeConsumer.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/DebeziumChangeConsumer.java
@@ -54,6 +54,7 @@ public class DebeziumChangeConsumer<T>
 
     public static final String LAST_COMPLETELY_PROCESSED_LSN_KEY = "lsn_proc";
     public static final String LAST_COMMIT_LSN_KEY = "lsn_commit";
+    public static final String GTID_KEY = "gtid";
 
     private final SourceFunction.SourceContext<T> sourceContext;
 
@@ -184,13 +185,13 @@ public class DebeziumChangeConsumer<T>
         }
 
         Struct source = value.getStruct(Envelope.FieldName.SOURCE);
-        if (source.schema().field("gtid") != null) {
-            String gtid = source.getString("gtid");
+        if (source.schema().field(GTID_KEY) != null) {
+            String gtid = source.getString(GTID_KEY);
             Map<String, Object> newSourceOffset = new HashMap<>();
             for (Map.Entry<String, ?> entry : record.sourceOffset().entrySet()) {
                 newSourceOffset.put(entry.getKey(), entry.getValue());
             }
-            newSourceOffset.put("gtid", gtid);
+            newSourceOffset.put(GTID_KEY, gtid);
             return newSourceOffset;
         }
         return record.sourceOffset();

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/DebeziumChangeConsumer.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/DebeziumChangeConsumer.java
@@ -35,7 +35,11 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
 
 /**
  * A consumer that consumes change messages from {@link DebeziumEngine}.
@@ -179,14 +183,14 @@ public class DebeziumChangeConsumer<T>
             return record.sourceOffset();
         }
 
-        Struct source =  value.getStruct(Envelope.FieldName.SOURCE);
+        Struct source = value.getStruct(Envelope.FieldName.SOURCE);
         if (source.schema().field("gtid") != null) {
             String gtid = source.getString("gtid");
             Map<String, Object> newSourceOffset = new HashMap<>();
             for (Map.Entry<String, ?> entry : record.sourceOffset().entrySet()) {
-                newSourceOffset.put(entry.getKey(),entry.getValue());
+                newSourceOffset.put(entry.getKey(), entry.getValue());
             }
-            newSourceOffset.put("gtid",gtid);
+            newSourceOffset.put("gtid", gtid);
             return newSourceOffset;
         }
         return record.sourceOffset();

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/MySQLSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/MySQLSource.java
@@ -21,6 +21,7 @@ package com.alibaba.ververica.cdc.connectors.mysql;
 import com.alibaba.ververica.cdc.connectors.mysql.table.StartupOptions;
 import com.alibaba.ververica.cdc.debezium.DebeziumDeserializationSchema;
 import com.alibaba.ververica.cdc.debezium.DebeziumSourceFunction;
+import com.alibaba.ververica.cdc.debezium.StringDebeziumDeserializationSchema;
 import com.alibaba.ververica.cdc.debezium.internal.DebeziumOffset;
 import io.debezium.connector.mysql.MySqlConnector;
 
@@ -199,6 +200,14 @@ public class MySQLSource {
                     sourceOffset.put("file", startupOptions.specificOffsetFile);
                     sourceOffset.put("pos", startupOptions.specificOffsetPos);
                     specificOffset.setSourceOffset(sourceOffset);
+                    break;
+
+                case SPECIFIC_GTID:
+                    checkNotNull(deserializer);
+                    props.setProperty("snapshot.mode", "never");
+                    deserializer = new SeekBinlogToGtidFilter<>(
+                            startupOptions.specificGtid,
+                            deserializer);
                     break;
 
                 case TIMESTAMP:

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/MySQLSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/MySQLSource.java
@@ -21,7 +21,6 @@ package com.alibaba.ververica.cdc.connectors.mysql;
 import com.alibaba.ververica.cdc.connectors.mysql.table.StartupOptions;
 import com.alibaba.ververica.cdc.debezium.DebeziumDeserializationSchema;
 import com.alibaba.ververica.cdc.debezium.DebeziumSourceFunction;
-import com.alibaba.ververica.cdc.debezium.StringDebeziumDeserializationSchema;
 import com.alibaba.ververica.cdc.debezium.internal.DebeziumOffset;
 import io.debezium.connector.mysql.MySqlConnector;
 
@@ -205,9 +204,8 @@ public class MySQLSource {
                 case SPECIFIC_GTID:
                     checkNotNull(deserializer);
                     props.setProperty("snapshot.mode", "never");
-                    deserializer = new SeekBinlogToGtidFilter<>(
-                            startupOptions.specificGtid,
-                            deserializer);
+                    deserializer =
+                            new SeekBinlogToGtidFilter<>(startupOptions.specificGtid, deserializer);
                     break;
 
                 case TIMESTAMP:

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/SeekBinlogToGtidFilter.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/SeekBinlogToGtidFilter.java
@@ -1,9 +1,10 @@
 package com.alibaba.ververica.cdc.connectors.mysql;
 
-import com.alibaba.ververica.cdc.debezium.DebeziumDeserializationSchema;
-import io.debezium.data.Envelope;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.util.Collector;
+
+import com.alibaba.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import io.debezium.data.Envelope;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
@@ -50,7 +51,9 @@ public class SeekBinlogToGtidFilter<T> implements DebeziumDeserializationSchema<
         } else {
             filtered++;
             if (filtered % 10000 == 0) {
-                LOG.info("Seeking binlog to specific gtid with filtered {} change events.", filtered);
+                LOG.info(
+                        "Seeking binlog to specific gtid with filtered {} change events.",
+                        filtered);
             }
         }
     }

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/SeekBinlogToGtidFilter.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/SeekBinlogToGtidFilter.java
@@ -1,0 +1,62 @@
+package com.alibaba.ververica.cdc.connectors.mysql;
+
+import com.alibaba.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import io.debezium.data.Envelope;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.util.Collector;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link DebeziumDeserializationSchema} which wraps a real {@link DebeziumDeserializationSchema}
+ * to seek binlog to the specific gtid.
+ */
+public class SeekBinlogToGtidFilter<T> implements DebeziumDeserializationSchema<T> {
+    private static final long serialVersionUID = -3168848963265670603L;
+    protected static final Logger LOG = LoggerFactory.getLogger(SeekBinlogToGtidFilter.class);
+    private transient boolean find = false;
+    private transient long filtered = 0L;
+
+    private final String gtid;
+    private final DebeziumDeserializationSchema<T> serializer;
+
+    public SeekBinlogToGtidFilter(String gtid, DebeziumDeserializationSchema<T> serializer) {
+        this.gtid = gtid;
+        this.serializer = serializer;
+    }
+
+    @Override
+    public void deserialize(SourceRecord record, Collector<T> out) throws Exception {
+        if (find) {
+            serializer.deserialize(record, out);
+            return;
+        }
+
+        if (filtered == 0) {
+            LOG.info("Begin to seek binlog to the specific gtid {}.", gtid);
+        }
+
+        Struct value = (Struct) record.value();
+        Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+        String sourceGtid = source.getString("gtid");
+        if (sourceGtid != null && sourceGtid.equals(gtid)) {
+            find = true;
+            LOG.info(
+                    "Successfully seek to the specific gtid {} with filtered {} change events.",
+                    gtid,
+                    filtered);
+        } else {
+            filtered++;
+            if (filtered % 10000 == 0) {
+                LOG.info("Seeking binlog to specific gtid with filtered {} change events.", filtered);
+            }
+        }
+    }
+
+    @Override
+    public TypeInformation<T> getProducedType() {
+        return serializer.getProducedType();
+    }
+}

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/table/StartupMode.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/table/StartupMode.java
@@ -32,5 +32,7 @@ public enum StartupMode {
 
     SPECIFIC_OFFSETS,
 
+    SPECIFIC_GTID,
+
     TIMESTAMP
 }

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/table/StartupOptions.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/table/StartupOptions.java
@@ -28,13 +28,14 @@ public final class StartupOptions {
     public final String specificOffsetFile;
     public final Integer specificOffsetPos;
     public final Long startupTimestampMillis;
+    public final String specificGtid;
 
     /**
      * Performs an initial snapshot on the monitored database tables upon first startup, and
      * continue to read the latest binlog.
      */
     public static StartupOptions initial() {
-        return new StartupOptions(StartupMode.INITIAL, null, null, null);
+        return new StartupOptions(StartupMode.INITIAL, null, null, null, null);
     }
 
     /**
@@ -43,7 +44,7 @@ public final class StartupOptions {
      * binlog is guaranteed to contain the entire history of the database.
      */
     public static StartupOptions earliest() {
-        return new StartupOptions(StartupMode.EARLIEST_OFFSET, null, null, null);
+        return new StartupOptions(StartupMode.EARLIEST_OFFSET, null, null, null, null);
     }
 
     /**
@@ -51,7 +52,7 @@ public final class StartupOptions {
      * the end of the binlog which means only have the changes since the connector was started.
      */
     public static StartupOptions latest() {
-        return new StartupOptions(StartupMode.LATEST_OFFSET, null, null, null);
+        return new StartupOptions(StartupMode.LATEST_OFFSET, null, null, null, null);
     }
 
     /**
@@ -60,7 +61,11 @@ public final class StartupOptions {
      */
     public static StartupOptions specificOffset(String specificOffsetFile, int specificOffsetPos) {
         return new StartupOptions(
-                StartupMode.SPECIFIC_OFFSETS, specificOffsetFile, specificOffsetPos, null);
+                StartupMode.SPECIFIC_OFFSETS, specificOffsetFile, specificOffsetPos, null, null);
+    }
+
+    public static StartupOptions specificGtid(String specificGtid) {
+        return new StartupOptions(StartupMode.SPECIFIC_GTID, null, null, null, specificGtid);
     }
 
     /**
@@ -73,18 +78,20 @@ public final class StartupOptions {
      * @param startupTimestampMillis timestamp for the startup offsets, as milliseconds from epoch.
      */
     public static StartupOptions timestamp(long startupTimestampMillis) {
-        return new StartupOptions(StartupMode.TIMESTAMP, null, null, startupTimestampMillis);
+        return new StartupOptions(StartupMode.TIMESTAMP, null, null, startupTimestampMillis, null);
     }
 
     private StartupOptions(
             StartupMode startupMode,
             String specificOffsetFile,
             Integer specificOffsetPos,
-            Long startupTimestampMillis) {
+            Long startupTimestampMillis,
+            String specificGtid) {
         this.startupMode = startupMode;
         this.specificOffsetFile = specificOffsetFile;
         this.specificOffsetPos = specificOffsetPos;
         this.startupTimestampMillis = startupTimestampMillis;
+        this.specificGtid = specificGtid;
 
         switch (startupMode) {
             case INITIAL:
@@ -94,6 +101,9 @@ public final class StartupOptions {
             case SPECIFIC_OFFSETS:
                 checkNotNull(specificOffsetFile, "specificOffsetFile shouldn't be null");
                 checkNotNull(specificOffsetPos, "specificOffsetPos shouldn't be null");
+                break;
+            case SPECIFIC_GTID:
+                checkNotNull(specificGtid, "specificGtid shouldn't be null");
                 break;
             case TIMESTAMP:
                 checkNotNull(startupTimestampMillis, "startupTimestampMillis shouldn't be null");


### PR DESCRIPTION
Support read from specific MySQL Binlog gtid.
When reading a highly available MySQL Cluster, a master-slave switch or IP drift occurs and the checkpoint is not updated in a timely way, resulting in a failure to start reading from the checkpoint file due to a change in GTIDs.Since our checkpoints are spaced far apart, this is likely to affect us.
We added the GTID field in the checkpoint file to facilitate our clients to get the accurate GTID.