### PR TITLE
[debezium] Bump debezium version to 1.5.2.Final

### DIFF
--- a/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/MySQLSourceTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/MySQLSourceTest.java
@@ -117,7 +117,11 @@ public class MySQLSourceTest extends MySQLTestBase {
             List<SourceRecord> records = drain(sourceContext, 9);
             assertEquals(9, records.size());
             for (int i = 0; i < records.size(); i++) {
-                assertRead(records.get(i), "id", 101 + i);
+                if (this.useLegacyImplementation) {
+                    assertInsert(records.get(i), "id", 101 + i);
+                } else {
+                    assertRead(records.get(i), "id", 101 + i);
+                }
             }
 
             statement.execute(
@@ -759,6 +763,11 @@ public class MySQLSourceTest extends MySQLTestBase {
         Properties debeziumProps = new Properties();
         if (useLegacyImplementation) {
             debeziumProps.put("internal.implementation", "legacy");
+            // check legacy mysql record type
+            debeziumProps.put("transforms", "snapshotasinsert");
+            debeziumProps.put(
+                    "transforms.snapshotasinsert.type",
+                    "io.debezium.connector.mysql.transforms.ReadToInsertEvent");
         }
 
         return MySQLSource.<SourceRecord>builder()

--- a/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLConnectorITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLConnectorITCase.java
@@ -31,11 +31,14 @@ import com.alibaba.ververica.cdc.connectors.mysql.utils.UniqueDatabase;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -45,6 +48,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 /** Integration tests for MySQL binlog SQL source. */
+@RunWith(Parameterized.class)
 public class MySQLConnectorITCase extends MySQLTestBase {
 
     private final UniqueDatabase inventoryDatabase =
@@ -59,8 +63,18 @@ public class MySQLConnectorITCase extends MySQLTestBase {
             StreamTableEnvironment.create(
                     env,
                     EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build());
+    private final String implementation;
 
     @ClassRule public static LegacyRowResource usesLegacyRows = LegacyRowResource.INSTANCE;
+
+    public MySQLConnectorITCase(String implementation) {
+        this.implementation = implementation;
+    }
+
+    @Parameterized.Parameters(name = "implementation: {0}")
+    public static Collection<String> parameters() {
+        return Arrays.asList("non-legacy", "legacy");
+    }
 
     @Before
     public void before() {
@@ -86,14 +100,16 @@ public class MySQLConnectorITCase extends MySQLTestBase {
                                 + " 'username' = '%s',"
                                 + " 'password' = '%s',"
                                 + " 'database-name' = '%s',"
-                                + " 'table-name' = '%s'"
+                                + " 'table-name' = '%s',"
+                                + " 'debezium.internal.implementation' = '%s'"
                                 + ")",
                         MYSQL_CONTAINER.getHost(),
                         MYSQL_CONTAINER.getDatabasePort(),
                         inventoryDatabase.getUsername(),
                         inventoryDatabase.getPassword(),
                         inventoryDatabase.getDatabaseName(),
-                        "products");
+                        "products",
+                        implementation);
         String sinkDDL =
                 "CREATE TABLE sink ("
                         + " name STRING,"
@@ -212,14 +228,16 @@ public class MySQLConnectorITCase extends MySQLTestBase {
                                 + " 'username' = '%s',"
                                 + " 'password' = '%s',"
                                 + " 'database-name' = '%s',"
-                                + " 'table-name' = '%s'"
+                                + " 'table-name' = '%s',"
+                                + " 'debezium.internal.implementation' = '%s'"
                                 + ")",
                         MYSQL_CONTAINER.getHost(),
                         MYSQL_CONTAINER.getDatabasePort(),
                         fullTypesDatabase.getUsername(),
                         fullTypesDatabase.getPassword(),
                         fullTypesDatabase.getDatabaseName(),
-                        "full_types");
+                        "full_types",
+                        implementation);
         String sinkDDL =
                 "CREATE TABLE sink (\n"
                         + "    id INT NOT NULL,\n"
@@ -332,7 +350,8 @@ public class MySQLConnectorITCase extends MySQLTestBase {
                                 + " 'table-name' = '%s',"
                                 + " 'scan.startup.mode' = 'specific-offset',"
                                 + " 'scan.startup.specific-offset.file' = '%s',"
-                                + " 'scan.startup.specific-offset.pos' = '%s'"
+                                + " 'scan.startup.specific-offset.pos' = '%s',"
+                                + " 'debezium.internal.implementation' = '%s'"
                                 + ")",
                         MYSQL_CONTAINER.getHost(),
                         MYSQL_CONTAINER.getDatabasePort(),
@@ -341,7 +360,8 @@ public class MySQLConnectorITCase extends MySQLTestBase {
                         inventoryDatabase.getDatabaseName(),
                         "products",
                         offset.f0,
-                        offset.f1);
+                        offset.f1,
+                        implementation);
         String sinkDDL =
                 "CREATE TABLE sink "
                         + " WITH ("
@@ -401,14 +421,16 @@ public class MySQLConnectorITCase extends MySQLTestBase {
                                 + " 'password' = '%s',"
                                 + " 'database-name' = '%s',"
                                 + " 'table-name' = '%s',"
-                                + " 'scan.startup.mode' = 'earliest-offset'"
+                                + " 'scan.startup.mode' = 'earliest-offset',"
+                                + " 'debezium.internal.implementation' = '%s'"
                                 + ")",
                         MYSQL_CONTAINER.getHost(),
                         MYSQL_CONTAINER.getDatabasePort(),
                         inventoryDatabase.getUsername(),
                         inventoryDatabase.getPassword(),
                         inventoryDatabase.getDatabaseName(),
-                        "products");
+                        "products",
+                        implementation);
         String sinkDDL =
                 "CREATE TABLE sink "
                         + " WITH ("
@@ -477,14 +499,16 @@ public class MySQLConnectorITCase extends MySQLTestBase {
                                 + " 'password' = '%s',"
                                 + " 'database-name' = '%s',"
                                 + " 'table-name' = '%s',"
-                                + " 'scan.startup.mode' = 'latest-offset'"
+                                + " 'scan.startup.mode' = 'latest-offset',"
+                                + " 'debezium.internal.implementation' = '%s'"
                                 + ")",
                         MYSQL_CONTAINER.getHost(),
                         MYSQL_CONTAINER.getDatabasePort(),
                         inventoryDatabase.getUsername(),
                         inventoryDatabase.getPassword(),
                         inventoryDatabase.getDatabaseName(),
-                        "products");
+                        "products",
+                        implementation);
         String sinkDDL =
                 "CREATE TABLE sink "
                         + " WITH ("
@@ -542,7 +566,8 @@ public class MySQLConnectorITCase extends MySQLTestBase {
                                 + " 'database-name' = '%s',"
                                 + " 'table-name' = '%s',"
                                 + " 'scan.startup.mode' = 'timestamp',"
-                                + " 'scan.startup.timestamp-millis' = '%s'"
+                                + " 'scan.startup.timestamp-millis' = '%s',"
+                                + " 'debezium.internal.implementation' = '%s'"
                                 + ")",
                         MYSQL_CONTAINER.getHost(),
                         MYSQL_CONTAINER.getDatabasePort(),
@@ -550,7 +575,8 @@ public class MySQLConnectorITCase extends MySQLTestBase {
                         inventoryDatabase.getPassword(),
                         inventoryDatabase.getDatabaseName(),
                         "products",
-                        System.currentTimeMillis());
+                        System.currentTimeMillis(),
+                        implementation);
         String sinkDDL =
                 "CREATE TABLE sink "
                         + " WITH ("

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@ under the License.
 
     <properties>
         <flink.version>1.13.0</flink.version>
-        <debezium.version>1.4.1.Final</debezium.version>
+        <debezium.version>1.5.2.Final</debezium.version>
         <testcontainers.version>1.15.1</testcontainers.version>
         <java.version>1.8</java.version>
         <scala.binary.version>2.11</scala.binary.version>


### PR DESCRIPTION
It has been a long time since the release of debezium-1.5.2-final. In this release, a new capturing implementation for the Debezium MySQL connector has been created, which is almost in parity with previous implementation, with the exception of the experimental parallel snapshotting feature. If users enounter any problems, they can the **_legacy_**  implementation of the MySQL connector by setting the `internal.implementation=legacy` connector configuration option.

The other breaking changes about MySQL connector is when MySQL connector emits snapshot messages it marks the record as the `c` operation but it marks as the `r` operation. Our implementation doesn't relies on this and the change only breaks the test `MySQLSourceTest#testConsumingAllEvents`. 

Other breaking changes are about oracle connectors. For more details, please refer to [release notes](https://debezium.io/releases/1.5/release-notes).