### PR TITLE
[common] Fix schema history run out of memory

### DIFF
--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/DebeziumSourceFunction.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/DebeziumSourceFunction.java
@@ -545,14 +545,14 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
                 return FlinkDatabaseHistory.class;
             } else {
                 throw new IllegalStateException(
-                        "Use the legacy implementation of the database history but FlnkDatabaseHistory can't load the state.");
+                        "The configured option 'debezium.internal.implementation' is 'legacy', but the state of source is incompatible with this implementation, you should remove the the option.");
             }
         } else if (FlinkDatabaseSchemaHistory.isCompatible(
                 StateUtils.retrieveHistory(engineInstanceName))) {
-            // tries the non-legacy and checks the state is compatible
+            // tries the non-legacy first
             return FlinkDatabaseSchemaHistory.class;
         } else if (isCompatibleWithLegacy) {
-            // starts from the state created before
+            // fallback to legacy if possible
             return FlinkDatabaseHistory.class;
         } else {
             // impossible
@@ -562,8 +562,9 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
 
     // ---------------------------------------------------------------------------------------
 
-    /** Utils to get/put/remove the history. */
+    /** Utils to get/put/remove the history of schema. */
     public static final class StateUtils {
+
         public static void registerHistory(
                 String engineName, Collection<HistoryRecord> engineHistory) {
             HISTORY.put(engineName, engineHistory);

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/FlinkDatabaseHistory.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/FlinkDatabaseHistory.java
@@ -18,18 +18,17 @@
 
 package com.alibaba.ververica.cdc.debezium.internal;
 
+import com.alibaba.ververica.cdc.debezium.DebeziumSourceFunction.StateUtils;
 import io.debezium.config.Configuration;
+import io.debezium.document.Document;
+import io.debezium.document.Value;
 import io.debezium.relational.history.AbstractDatabaseHistory;
-import io.debezium.relational.history.DatabaseHistory;
 import io.debezium.relational.history.DatabaseHistoryException;
 import io.debezium.relational.history.DatabaseHistoryListener;
-import io.debezium.relational.history.FileDatabaseHistory;
 import io.debezium.relational.history.HistoryRecord;
 import io.debezium.relational.history.HistoryRecordComparator;
-import io.debezium.relational.history.KafkaDatabaseHistory;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Collection;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Consumer;
 
@@ -45,53 +44,13 @@ public class FlinkDatabaseHistory extends AbstractDatabaseHistory {
 
     public static final String DATABASE_HISTORY_INSTANCE_NAME = "database.history.instance.name";
 
-    /**
-     * We will synchronize the records into Flink's state during snapshot. We have to use a global
-     * variable to communicate with Flink's source function, because Debezium will construct the
-     * instance of {@link DatabaseHistory} itself. Maybe we can improve this in the future.
-     *
-     * <p>NOTE: we just use Flink's state as a durable persistent storage as a replacement of {@link
-     * FileDatabaseHistory} and {@link KafkaDatabaseHistory}. It doesn't need to guarantee the
-     * exactly-once semantic for the history records. The history records shouldn't be super large,
-     * because we only monitor the schema changes for one single table.
-     *
-     * @see
-     *     com.alibaba.ververica.cdc.debezium.DebeziumSourceFunction#snapshotState(org.apache.flink.runtime.state.FunctionSnapshotContext)
-     */
-    public static final Map<String, ConcurrentLinkedQueue<HistoryRecord>> ALL_RECORDS =
-            new HashMap<>();
-
     private ConcurrentLinkedQueue<HistoryRecord> records;
     private String instanceName;
 
-    /**
-     * Registers the given HistoryRecords into global variable under the given instance name, in
-     * order to be accessed by instance of {@link FlinkDatabaseHistory}.
-     */
-    public static void registerHistoryRecords(
-            String instanceName, ConcurrentLinkedQueue<HistoryRecord> historyRecords) {
-        synchronized (FlinkDatabaseHistory.ALL_RECORDS) {
-            FlinkDatabaseHistory.ALL_RECORDS.put(instanceName, historyRecords);
-        }
-    }
-
-    /**
-     * Registers an empty HistoryRecords into global variable under the given instance name, in
-     * order to be accessed by instance of {@link FlinkDatabaseHistory}.
-     */
-    public static void registerEmptyHistoryRecord(String instanceName) {
-        registerHistoryRecords(instanceName, new ConcurrentLinkedQueue<>());
-    }
-
     /** Gets the registered HistoryRecords under the given instance name. */
-    public static ConcurrentLinkedQueue<HistoryRecord> getRegisteredHistoryRecord(
-            String instanceName) {
-        synchronized (ALL_RECORDS) {
-            if (ALL_RECORDS.containsKey(instanceName)) {
-                return ALL_RECORDS.get(instanceName);
-            }
-        }
-        return null;
+    private ConcurrentLinkedQueue<HistoryRecord> getRegisteredHistoryRecord(String instanceName) {
+        Collection<HistoryRecord> historyRecords = StateUtils.retrieveHistory(instanceName);
+        return new ConcurrentLinkedQueue<>(historyRecords);
     }
 
     @Override
@@ -103,23 +62,16 @@ public class FlinkDatabaseHistory extends AbstractDatabaseHistory {
         super.configure(config, comparator, listener, useCatalogBeforeSchema);
         this.instanceName = config.getString(DATABASE_HISTORY_INSTANCE_NAME);
         this.records = getRegisteredHistoryRecord(instanceName);
-        if (records == null) {
-            throw new IllegalStateException(
-                    String.format(
-                            "Couldn't find engine instance %s in the global records.",
-                            instanceName));
-        }
+
+        // register the change into state
+        // every change should be visible to the source function
+        StateUtils.registerHistory(instanceName, records);
     }
 
     @Override
     public void stop() {
         super.stop();
-        if (instanceName != null) {
-            synchronized (ALL_RECORDS) {
-                // clear memory
-                ALL_RECORDS.remove(instanceName);
-            }
-        }
+        StateUtils.removeHistory(instanceName);
     }
 
     @Override
@@ -145,5 +97,22 @@ public class FlinkDatabaseHistory extends AbstractDatabaseHistory {
     @Override
     public String toString() {
         return "Flink Database History";
+    }
+
+    /** Determine the {@link FlinkDatabaseHistory} is compatible with the specified state. */
+    public static boolean isCompatible(Collection<HistoryRecord> records) {
+        for (HistoryRecord record : records) {
+            // check the source/position/ddl is not null
+            if (isNullValue(record.document(), HistoryRecord.Fields.POSITION)
+                    || isNullValue(record.document(), HistoryRecord.Fields.SOURCE)
+                    || isNullValue(record.document(), HistoryRecord.Fields.DDL_STATEMENTS)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isNullValue(Document document, CharSequence field) {
+        return document.getField(field).getValue().equals(Value.nullValue());
     }
 }

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/FlinkDatabaseHistory.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/FlinkDatabaseHistory.java
@@ -63,7 +63,7 @@ public class FlinkDatabaseHistory extends AbstractDatabaseHistory {
         this.instanceName = config.getString(DATABASE_HISTORY_INSTANCE_NAME);
         this.records = getRegisteredHistoryRecord(instanceName);
 
-        // register the change into state
+        // register the schema changes into state
         // every change should be visible to the source function
         StateUtils.registerHistory(instanceName, records);
     }
@@ -99,7 +99,9 @@ public class FlinkDatabaseHistory extends AbstractDatabaseHistory {
         return "Flink Database History";
     }
 
-    /** Determine the {@link FlinkDatabaseHistory} is compatible with the specified state. */
+    /**
+     * Determine whether the {@link FlinkDatabaseHistory} is compatible with the specified state.
+     */
     public static boolean isCompatible(Collection<HistoryRecord> records) {
         for (HistoryRecord record : records) {
             // check the source/position/ddl is not null
@@ -107,6 +109,8 @@ public class FlinkDatabaseHistory extends AbstractDatabaseHistory {
                     || isNullValue(record.document(), HistoryRecord.Fields.SOURCE)
                     || isNullValue(record.document(), HistoryRecord.Fields.DDL_STATEMENTS)) {
                 return false;
+            } else {
+                break;
             }
         }
         return true;

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/FlinkDatabaseSchemaHistory.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/FlinkDatabaseSchemaHistory.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.debezium.internal;
+
+import com.alibaba.ververica.cdc.debezium.DebeziumSourceFunction;
+import com.alibaba.ververica.cdc.debezium.DebeziumSourceFunction.StateUtils;
+import io.debezium.config.Configuration;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import io.debezium.relational.ddl.DdlParser;
+import io.debezium.relational.history.DatabaseHistory;
+import io.debezium.relational.history.DatabaseHistoryException;
+import io.debezium.relational.history.DatabaseHistoryListener;
+import io.debezium.relational.history.HistoryRecord;
+import io.debezium.relational.history.HistoryRecordComparator;
+import io.debezium.relational.history.JsonTableChangeSerializer;
+import io.debezium.relational.history.TableChanges;
+import io.debezium.schema.DatabaseSchema;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static io.debezium.relational.history.TableChanges.TableChange;
+
+/**
+ * The {@link FlinkDatabaseSchemaHistory} only stores the snapshot of the current schema of the
+ * monitored tables. When recovering from the checkpoint, it should apply all the table to the
+ * {@link DatabaseSchema}, which doesn't need to replay the history anymore.
+ *
+ * <p>Considering the data structure maintained in the {@link FlinkDatabaseSchemaHistory} is much
+ * different from the {@link FlinkDatabaseHistory}, it's not compatible with the {@link
+ * FlinkDatabaseHistory}. Because it only maintains the snapshot of the tables, it's more efficient
+ * to use the memory.
+ */
+public class FlinkDatabaseSchemaHistory implements DatabaseHistory {
+
+    public static final String DATABASE_HISTORY_INSTANCE_NAME = "database.history.instance.name";
+
+    private final JsonTableChangeSerializer tableChangesSerializer =
+            new JsonTableChangeSerializer();
+
+    private ConcurrentMap<TableId, HistoryRecord> tables;
+    private String instanceName;
+    private DatabaseHistoryListener listener;
+    private boolean storeOnlyMonitoredTablesDdl;
+    private boolean skipUnparseableDDL;
+    private boolean useCatalogBeforeSchema;
+
+    @Override
+    public void configure(
+            Configuration config,
+            HistoryRecordComparator comparator,
+            DatabaseHistoryListener listener,
+            boolean useCatalogBeforeSchema) {
+        this.instanceName = config.getString(DATABASE_HISTORY_INSTANCE_NAME);
+        this.listener = listener;
+        this.storeOnlyMonitoredTablesDdl = config.getBoolean(STORE_ONLY_MONITORED_TABLES_DDL);
+        this.skipUnparseableDDL = config.getBoolean(SKIP_UNPARSEABLE_DDL_STATEMENTS);
+        this.useCatalogBeforeSchema = useCatalogBeforeSchema;
+
+        // recover
+        this.tables = new ConcurrentHashMap<>();
+        for (HistoryRecord record : StateUtils.retrieveHistory(instanceName)) {
+            // validate here
+            TableChange tableChange =
+                    JsonTableChangeSerializer.fromDocument(
+                            record.document(), useCatalogBeforeSchema);
+            tables.put(tableChange.getId(), record);
+        }
+        // register
+        StateUtils.registerHistory(instanceName, tables.values());
+    }
+
+    @Override
+    public void start() {
+        listener.started();
+    }
+
+    @Override
+    public void record(
+            Map<String, ?> source, Map<String, ?> position, String databaseName, String ddl)
+            throws DatabaseHistoryException {
+        throw new UnsupportedOperationException(
+                "The FlinkDatabaseSchemaHistory needs debezium provides the schema.");
+    }
+
+    @Override
+    public void record(
+            Map<String, ?> source,
+            Map<String, ?> position,
+            String databaseName,
+            String schemaName,
+            String ddl,
+            TableChanges changes)
+            throws DatabaseHistoryException {
+        final HistoryRecord record =
+                new HistoryRecord(source, position, databaseName, schemaName, ddl, changes);
+        for (TableChanges.TableChange change : changes) {
+            switch (change.getType()) {
+                case CREATE:
+                case ALTER:
+                    tables.put(
+                            change.getId(),
+                            new HistoryRecord(tableChangesSerializer.toDocument(change)));
+                    break;
+                case DROP:
+                    tables.remove(change.getId());
+                    break;
+                default:
+                    // impossible
+                    throw new RuntimeException(
+                            String.format("Unknown change type: %s.", change.getType()));
+            }
+        }
+        listener.onChangeApplied(record);
+    }
+
+    @Override
+    public void recover(
+            Map<String, ?> source, Map<String, ?> position, Tables schema, DdlParser ddlParser) {
+        listener.recoveryStarted();
+        for (HistoryRecord record : tables.values()) {
+            TableChange tableChange =
+                    JsonTableChangeSerializer.fromDocument(
+                            record.document(), useCatalogBeforeSchema);
+            schema.overwriteTable(tableChange.getTable());
+        }
+        listener.recoveryStopped();
+    }
+
+    @Override
+    public void stop() {
+        if (instanceName != null) {
+            DebeziumSourceFunction.StateUtils.removeHistory(instanceName);
+        }
+        listener.stopped();
+    }
+
+    @Override
+    public boolean exists() {
+        return tables != null && !tables.isEmpty();
+    }
+
+    @Override
+    public boolean storageExists() {
+        return true;
+    }
+
+    @Override
+    public void initializeStorage() {
+        // do nothing
+    }
+
+    @Override
+    public boolean storeOnlyMonitoredTables() {
+        return storeOnlyMonitoredTablesDdl;
+    }
+
+    @Override
+    public boolean skipUnparseableDdlStatements() {
+        return skipUnparseableDDL;
+    }
+
+    /** Determine the {@link FlinkDatabaseSchemaHistory} is compatible with the specified state. */
+    public static boolean isCompatible(Collection<HistoryRecord> records) {
+        for (HistoryRecord record : records) {
+            // Try to deserialize the record
+            try {
+                TableChange tableChange =
+                        JsonTableChangeSerializer.fromDocument(record.document(), false);
+                // No table change in the state
+                if (tableChange.getId() == null) {
+                    return false;
+                }
+            } catch (Exception e) {
+                // Failed to deserialize the table from the state.
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/SchemaRecord.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/SchemaRecord.java
@@ -20,7 +20,6 @@ package com.alibaba.ververica.cdc.debezium.internal;
 
 import io.debezium.document.Document;
 import io.debezium.relational.history.HistoryRecord;
-import io.debezium.relational.history.JsonTableChangeSerializer;
 import io.debezium.relational.history.TableChanges.TableChange;
 
 import javax.annotation.Nullable;
@@ -34,9 +33,6 @@ import javax.annotation.Nullable;
  * FlinkDatabaseSchemaHistory} which keeps the latest latest table change for each table.
  */
 public class SchemaRecord {
-
-    private static final JsonTableChangeSerializer TABLE_CHANGE_SERIALIZER =
-            new JsonTableChangeSerializer();
 
     @Nullable private final HistoryRecord historyRecord;
 

--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/SchemaRecord.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/internal/SchemaRecord.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.ververica.cdc.debezium.internal;
+
+import io.debezium.document.Document;
+import io.debezium.relational.history.HistoryRecord;
+import io.debezium.relational.history.JsonTableChangeSerializer;
+import io.debezium.relational.history.TableChanges.TableChange;
+
+import javax.annotation.Nullable;
+
+/**
+ * The Record represents a schema change event, it contains either one {@link HistoryRecord} or
+ * {@link TableChange}.
+ *
+ * <p>The {@link HistoryRecord} will be used by {@link FlinkDatabaseHistory} which keeps full
+ * history of table change events for all tables, the {@link TableChange} will be used by {@link
+ * FlinkDatabaseSchemaHistory} which keeps the latest latest table change for each table.
+ */
+public class SchemaRecord {
+
+    private static final JsonTableChangeSerializer TABLE_CHANGE_SERIALIZER =
+            new JsonTableChangeSerializer();
+
+    @Nullable private final HistoryRecord historyRecord;
+
+    @Nullable private final Document tableChangeDoc;
+
+    public SchemaRecord(HistoryRecord historyRecord) {
+        this.historyRecord = historyRecord;
+        this.tableChangeDoc = null;
+    }
+
+    public SchemaRecord(Document document) {
+        if (isHistoryRecordDocument(document)) {
+            this.historyRecord = new HistoryRecord(document);
+            this.tableChangeDoc = null;
+        } else {
+            this.tableChangeDoc = document;
+            this.historyRecord = null;
+        }
+    }
+
+    @Nullable
+    public HistoryRecord getHistoryRecord() {
+        return historyRecord;
+    }
+
+    @Nullable
+    public Document getTableChangeDoc() {
+        return tableChangeDoc;
+    }
+
+    public boolean isHistoryRecord() {
+        return historyRecord != null;
+    }
+
+    public boolean isTableChangeRecord() {
+        return tableChangeDoc != null;
+    }
+
+    public Document toDocument() {
+        if (historyRecord != null) {
+            return historyRecord.document();
+        } else {
+            return tableChangeDoc;
+        }
+    }
+
+    private boolean isHistoryRecordDocument(Document document) {
+        return new HistoryRecord(document).isValid();
+    }
+}

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/MySQLSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/MySQLSource.java
@@ -28,6 +28,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static com.alibaba.ververica.cdc.debezium.DebeziumSourceFunction.LEGACY_IMPLEMENTATION_KEY;
+import static com.alibaba.ververica.cdc.debezium.DebeziumSourceFunction.LEGACY_IMPLEMENTATION_VALUE;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A builder to build a SourceFunction which can read snapshot and continue to consume binlog. */
@@ -215,6 +217,15 @@ public class MySQLSource {
 
             if (dbzProperties != null) {
                 dbzProperties.forEach(props::put);
+                // Add default configurations for compatibility when set the legacy mysql connector
+                // implementation
+                if (LEGACY_IMPLEMENTATION_VALUE.equals(
+                        dbzProperties.get(LEGACY_IMPLEMENTATION_KEY))) {
+                    props.put("transforms", "snapshotasinsert");
+                    props.put(
+                            "transforms.snapshotasinsert.type",
+                            "io.debezium.connector.mysql.transforms.ReadToInsertEvent");
+                }
             }
 
             return new DebeziumSourceFunction<>(deserializer, props, specificOffset);

--- a/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/MySQLSourceTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/MySQLSourceTest.java
@@ -817,7 +817,7 @@ public class MySQLSourceTest extends MySQLTestBase {
             } catch (Exception e) {
                 assertTrue(e instanceof IllegalStateException);
                 assertEquals(
-                        "Use the legacy implementation of the database history but FlnkDatabaseHistory can't load the state.",
+                        "The configured option 'debezium.internal.implementation' is 'legacy', but the state of source is incompatible with this implementation, you should remove the the option.",
                         e.getMessage());
             }
         } else {
@@ -1251,7 +1251,10 @@ public class MySQLSourceTest extends MySQLTestBase {
     }
 
     private static class MockedTable implements Table {
+
         private static final Table INSTANCE = new MockedTable();
+
+        private MockedTable() {}
 
         @Override
         public TableId id() {

--- a/flink-connector-mysql-cdc/src/test/resources/ddl/inventory.sql
+++ b/flink-connector-mysql-cdc/src/test/resources/ddl/inventory.sql
@@ -20,13 +20,13 @@
 -- Create and populate our products using a single insert with many rows
 CREATE TABLE products (
   id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,
-  name VARCHAR(255) NOT NULL,
+  name VARCHAR(255) NOT NULL DEFAULT 'flink',
   description VARCHAR(512),
   weight FLOAT
 );
 ALTER TABLE products AUTO_INCREMENT = 101;
 
-INSERT INTO products 
+INSERT INTO products
 VALUES (default,"scooter","Small 2-wheel scooter",3.14),
        (default,"car battery","12V car battery",8.1),
        (default,"12-pack drill bits","12-pack of drill bits with sizes ranging from #40 to #3",0.8),
@@ -80,7 +80,7 @@ CREATE TABLE orders (
   FOREIGN KEY ordered_product (product_id) REFERENCES products(id)
 ) AUTO_INCREMENT = 10001;
 
-INSERT INTO orders 
+INSERT INTO orders
 VALUES (default, '2016-01-16', 1001, 1, 102),
        (default, '2016-01-17', 1002, 2, 105),
        (default, '2016-02-18', 1004, 3, 109),

--- a/flink-connector-postgres-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/postgres/table/PostgreSQLConnectorITCase.java
+++ b/flink-connector-postgres-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/postgres/table/PostgreSQLConnectorITCase.java
@@ -98,7 +98,7 @@ public class PostgreSQLConnectorITCase extends PostgresTestBase {
                         + ") WITH ("
                         + " 'connector' = 'values',"
                         + " 'sink-insert-only' = 'false',"
-                        + " 'sink-expected-messages-num' = '20'"
+                        + " 'sink-expected-messages-num' = '21'"
                         + ")";
         tEnv.executeSql(sourceDDL);
         tEnv.executeSql(sinkDDL);
@@ -124,9 +124,11 @@ public class PostgreSQLConnectorITCase extends PostgresTestBase {
                     "UPDATE inventory.products SET description='new water resistent white wind breaker', weight='0.5' WHERE id=110;");
             statement.execute("UPDATE inventory.products SET weight='5.17' WHERE id=111;");
             statement.execute("DELETE FROM inventory.products WHERE id=111;");
+            statement.execute(
+                    "INSERT INTO inventory.products(id, description, weight) VALUES (default, 'Go go go', 0.1);");
         }
 
-        waitForSinkSize("sink", 20);
+        waitForSinkSize("sink", 21);
 
         // The final database table looks like this:
         //
@@ -155,6 +157,8 @@ public class PostgreSQLConnectorITCase extends PostgresTestBase {
         // 22.2 |
         // | 110 | jacket             | new water resistent white wind breaker                  |
         // 0.5 |
+        // | 111 | flink              | Go go go                                                |
+        // 0.1 |
         // +-----+--------------------+---------------------------------------------------------+--------+
 
         String[] expected =
@@ -165,7 +169,8 @@ public class PostgreSQLConnectorITCase extends PostgresTestBase {
                     "hammer,2.625",
                     "rocks,5.100",
                     "jacket,0.600",
-                    "spare tire,22.200"
+                    "spare tire,22.200",
+                    "flink,0.100"
                 };
 
         List<String> actual = TestValuesTableFactory.getResults("sink");

--- a/flink-connector-postgres-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/postgres/table/PostgreSQLConnectorITCase.java
+++ b/flink-connector-postgres-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/postgres/table/PostgreSQLConnectorITCase.java
@@ -98,7 +98,7 @@ public class PostgreSQLConnectorITCase extends PostgresTestBase {
                         + ") WITH ("
                         + " 'connector' = 'values',"
                         + " 'sink-insert-only' = 'false',"
-                        + " 'sink-expected-messages-num' = '21'"
+                        + " 'sink-expected-messages-num' = '20'"
                         + ")";
         tEnv.executeSql(sourceDDL);
         tEnv.executeSql(sinkDDL);
@@ -124,42 +124,31 @@ public class PostgreSQLConnectorITCase extends PostgresTestBase {
                     "UPDATE inventory.products SET description='new water resistent white wind breaker', weight='0.5' WHERE id=110;");
             statement.execute("UPDATE inventory.products SET weight='5.17' WHERE id=111;");
             statement.execute("DELETE FROM inventory.products WHERE id=111;");
-            statement.execute(
-                    "INSERT INTO inventory.products(id, description, weight) VALUES (default, 'Go go go', 0.1);");
         }
 
-        waitForSinkSize("sink", 21);
+        waitForSinkSize("sink", 20);
 
-        // The final database table looks like this:
-        //
-        // > SELECT * FROM inventory.products;
-        // +-----+--------------------+---------------------------------------------------------+--------+
-        // | id  | name               | description                                             |
-        // weight |
-        // +-----+--------------------+---------------------------------------------------------+--------+
-        // | 101 | scooter            | Small 2-wheel scooter                                   |
-        // 3.14 |
-        // | 102 | car battery        | 12V car battery                                         |
-        // 8.1 |
-        // | 103 | 12-pack drill bits | 12-pack of drill bits with sizes ranging from #40 to #3 |
-        // 0.8 |
-        // | 104 | hammer             | 12oz carpenter's hammer                                 |
-        // 0.75 |
-        // | 105 | hammer             | 14oz carpenter's hammer                                 |
-        // 0.875 |
-        // | 106 | hammer             | 18oz carpenter hammer                                   |
-        //   1 |
-        // | 107 | rocks              | box of assorted rocks                                   |
-        // 5.1 |
-        // | 108 | jacket             | water resistent black wind breaker                      |
-        // 0.1 |
-        // | 109 | spare tire         | 24 inch spare tire                                      |
-        // 22.2 |
-        // | 110 | jacket             | new water resistent white wind breaker                  |
-        // 0.5 |
-        // | 111 | flink              | Go go go                                                |
-        // 0.1 |
-        // +-----+--------------------+---------------------------------------------------------+--------+
+        /*
+         * <pre>
+         * The final database table looks like this:
+         *
+         * > SELECT * FROM products;
+         * +-----+--------------------+---------------------------------------------------------+--------+
+         * | id  | name               | description                                             | weight |
+         * +-----+--------------------+---------------------------------------------------------+--------+
+         * | 101 | scooter            | Small 2-wheel scooter                                   |   3.14 |
+         * | 102 | car battery        | 12V car battery                                         |    8.1 |
+         * | 103 | 12-pack drill bits | 12-pack of drill bits with sizes ranging from #40 to #3 |    0.8 |
+         * | 104 | hammer             | 12oz carpenter's hammer                                 |   0.75 |
+         * | 105 | hammer             | 14oz carpenter's hammer                                 |  0.875 |
+         * | 106 | hammer             | 18oz carpenter hammer                                   |      1 |
+         * | 107 | rocks              | box of assorted rocks                                   |    5.1 |
+         * | 108 | jacket             | water resistent black wind breaker                      |    0.1 |
+         * | 109 | spare tire         | 24 inch spare tire                                      |   22.2 |
+         * | 110 | jacket             | new water resistent white wind breaker                  |    0.5 |
+         * +-----+--------------------+---------------------------------------------------------+--------+
+         * </pre>
+         */
 
         String[] expected =
                 new String[] {
@@ -169,8 +158,7 @@ public class PostgreSQLConnectorITCase extends PostgresTestBase {
                     "hammer,2.625",
                     "rocks,5.100",
                     "jacket,0.600",
-                    "spare tire,22.200",
-                    "flink,0.100"
+                    "spare tire,22.200"
                 };
 
         List<String> actual = TestValuesTableFactory.getResults("sink");

--- a/flink-connector-postgres-cdc/src/test/resources/ddl/inventory.sql
+++ b/flink-connector-postgres-cdc/src/test/resources/ddl/inventory.sql
@@ -21,7 +21,7 @@ SET search_path TO inventory;
 -- Create and populate our products using a single insert with many rows
 CREATE TABLE products (
   id SERIAL NOT NULL PRIMARY KEY,
-  name VARCHAR(255) NOT NULL DEFAULT 'flink',
+  name VARCHAR(255) NOT NULL,
   description VARCHAR(512),
   weight FLOAT
 );

--- a/flink-connector-postgres-cdc/src/test/resources/ddl/inventory.sql
+++ b/flink-connector-postgres-cdc/src/test/resources/ddl/inventory.sql
@@ -21,7 +21,7 @@ SET search_path TO inventory;
 -- Create and populate our products using a single insert with many rows
 CREATE TABLE products (
   id SERIAL NOT NULL PRIMARY KEY,
-  name VARCHAR(255) NOT NULL,
+  name VARCHAR(255) NOT NULL DEFAULT 'flink',
   description VARCHAR(512),
   weight FLOAT
 );


### PR DESCRIPTION
*This PR aims to solve the out of memory poblem caused by the frequent schema changes. In this PR, we propose to use `FlinkDatabaseSchemaHistory`, which only stores the current snapshot of the table schema. If the pipeline fails and recovers from the state, it doesn't need to replay all the ddl history any more but only applies the maintained tables.*

*When starting from a state, the source funciton will automatically determine which history should use according to the state structure.  Users don't need to pay attention to the internal implementation.*

**Break Changes**
Because the new database history has a different state structure comparing to before. Therefore, it's not avaliable to start the pipeline with a state with different structure.

  
