### PR TITLE
add `slot.name` to optional arguments

### DIFF
--- a/flink-connector-postgres-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/postgres/table/PostgreSQLTableFactory.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/postgres/table/PostgreSQLTableFactory.java
@@ -156,6 +156,7 @@ public class PostgreSQLTableFactory implements DynamicTableSourceFactory {
         Set<ConfigOption<?>> options = new HashSet<>();
         options.add(PORT);
         options.add(DECODING_PLUGIN_NAME);
+        options.add(SLOT_NAME);
         return options;
     }
 }


### PR DESCRIPTION
currently it is not possible to specify `slot.name` in `CREATE TABLE () WITH(..., 'slot.name' = ...)`. Trying to do so results in an error: 
```
Caused by: org.apache.flink.table.api.ValidationException: Unsupported options found for 'postgres-cdc'.
[error] Unsupported options:
[error] slot.name
[error] Supported options:
```
this quick change fixes the problem