### PR TITLE
[mysql] Support numeric type optimization for split boundary calculation

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/source/MySQLSourceOptions.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/source/MySQLSourceOptions.java
@@ -151,7 +151,7 @@ public class MySQLSourceOptions {
                     .booleanType()
                     .defaultValue(true)
                     .withDescription(
-                            "Optimization to calculate the boundary of table snapshot split base on integral value rather than querying the DB,"
+                            "Optimization to calculate the boundary of table snapshot split base on numeric value rather than querying the DB,"
                                     + " by default this option is enabled.");
 
     // utils

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/source/MySQLSourceOptions.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/source/MySQLSourceOptions.java
@@ -146,6 +146,14 @@ public class MySQLSourceOptions {
                     .withDescription(
                             "Optional timestamp used in case of \"timestamp\" startup mode");
 
+    public static final ConfigOption<Boolean> SCAN_OPTIMIZE_INTEGRAL_KEY =
+            ConfigOptions.key("scan.optimize.integral-key")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Optimization to calculate the boundary of table snapshot split base on integral value rather than querying the DB,"
+                                    + " by default this option is enabled.");
+
     // utils
     public static String validateAndGetServerId(ReadableConfig configuration) {
         final String serverIdValue = configuration.get(MySQLSourceOptions.SERVER_ID);

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/source/utils/RecordUtils.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/source/utils/RecordUtils.java
@@ -334,9 +334,7 @@ public class RecordUtils {
         }
     }
 
-    /**
-     * Return the split key type can use integral optimization or not.
-     */
+    /** Return the split key type can use numeric optimization or not. */
     public static boolean isOptimizedKeyType(LogicalTypeRoot typeRoot) {
         return typeRoot == LogicalTypeRoot.BIGINT
                 || typeRoot == LogicalTypeRoot.INTEGER

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/source/utils/RecordUtils.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/source/utils/RecordUtils.java
@@ -19,6 +19,7 @@
 package com.alibaba.ververica.cdc.connectors.mysql.source.utils;
 
 import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 
 import com.alibaba.ververica.cdc.connectors.mysql.debezium.dispatcher.SignalEventDispatcher.WatermarkKind;
@@ -331,6 +332,15 @@ public class RecordUtils {
                     && (Arrays.stream(upperBoundRes).anyMatch(value -> value < 0)
                             && Arrays.stream(upperBoundRes).allMatch(value -> value <= 0));
         }
+    }
+
+    /**
+     * Return the split key type can use integral optimization or not.
+     */
+    public static boolean isOptimizedKeyType(LogicalTypeRoot typeRoot) {
+        return typeRoot == LogicalTypeRoot.BIGINT
+                || typeRoot == LogicalTypeRoot.INTEGER
+                || typeRoot == LogicalTypeRoot.DECIMAL;
     }
 
     private static int compareObjects(Object o1, Object o2) {

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSource.java
@@ -51,6 +51,7 @@ import java.util.Properties;
 
 import static com.alibaba.ververica.cdc.connectors.mysql.debezium.EmbeddedFlinkDatabaseHistory.DATABASE_HISTORY_INSTANCE_NAME;
 import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.DATABASE_SERVER_NAME;
+import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.SCAN_OPTIMIZE_INTEGRAL_KEY;
 import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.SCAN_SPLIT_COLUMN;
 import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.SERVER_ID;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -71,6 +72,7 @@ public class MySQLTableSource implements ScanTableSource {
     private final String tableName;
     private final ZoneId serverTimeZone;
     private final Properties dbzProperties;
+    private final boolean enableIntegralOptimization;
     private final boolean enableParallelRead;
     private final int splitSize;
     private final int fetchSize;
@@ -88,6 +90,7 @@ public class MySQLTableSource implements ScanTableSource {
             ZoneId serverTimeZone,
             Properties dbzProperties,
             @Nullable String serverId,
+            boolean enableIntegralOptimization,
             boolean enableParallelRead,
             int splitSize,
             int fetchSize,
@@ -103,6 +106,7 @@ public class MySQLTableSource implements ScanTableSource {
         this.serverId = serverId;
         this.serverTimeZone = serverTimeZone;
         this.dbzProperties = dbzProperties;
+        this.enableIntegralOptimization = enableIntegralOptimization;
         this.enableParallelRead = enableParallelRead;
         this.splitSize = splitSize;
         this.fetchSize = fetchSize;
@@ -201,6 +205,9 @@ public class MySQLTableSource implements ScanTableSource {
         // set mode
         properties.put("snapshot.mode", "initial");
 
+        properties.put(
+                SCAN_OPTIMIZE_INTEGRAL_KEY.key(), String.valueOf(enableIntegralOptimization));
+
         // set split key
         if (pkRowType.getFieldCount() > 1) {
             properties.put(SCAN_SPLIT_COLUMN.key(), splitColumn);
@@ -222,6 +229,7 @@ public class MySQLTableSource implements ScanTableSource {
                 serverTimeZone,
                 dbzProperties,
                 serverId,
+                enableIntegralOptimization,
                 enableParallelRead,
                 splitSize,
                 fetchSize,
@@ -239,6 +247,7 @@ public class MySQLTableSource implements ScanTableSource {
         }
         MySQLTableSource that = (MySQLTableSource) o;
         return port == that.port
+                && enableIntegralOptimization == that.enableIntegralOptimization
                 && enableParallelRead == that.enableParallelRead
                 && splitSize == that.splitSize
                 && fetchSize == that.fetchSize
@@ -268,6 +277,7 @@ public class MySQLTableSource implements ScanTableSource {
                 tableName,
                 serverTimeZone,
                 dbzProperties,
+                enableIntegralOptimization,
                 enableParallelRead,
                 splitSize,
                 fetchSize,

--- a/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSourceFactory.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSourceFactory.java
@@ -39,6 +39,7 @@ import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptio
 import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.PASSWORD;
 import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.PORT;
 import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.SCAN_FETCH_SIZE;
+import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.SCAN_OPTIMIZE_INTEGRAL_KEY;
 import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.SCAN_SPLIT_COLUMN;
 import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.SCAN_SPLIT_SIZE;
 import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.SCAN_STARTUP_MODE;
@@ -78,6 +79,7 @@ public class MySQLTableSourceFactory implements DynamicTableSourceFactory {
         TableSchema physicalSchema =
                 TableSchemaUtils.getPhysicalSchema(context.getCatalogTable().getSchema());
         String serverId = validateAndGetServerId(config);
+        boolean enableIntegralOptimization = config.get(SCAN_OPTIMIZE_INTEGRAL_KEY);
         boolean enableParallelRead = config.get(SNAPSHOT_PARALLEL_SCAN);
         String splitColumn = null;
         StartupOptions startupOptions = getStartupOptions(config);
@@ -98,6 +100,7 @@ public class MySQLTableSourceFactory implements DynamicTableSourceFactory {
                 serverTimeZone,
                 getDebeziumProperties(context.getCatalogTable().getOptions()),
                 serverId,
+                enableIntegralOptimization,
                 enableParallelRead,
                 splitSize,
                 fetchSize,
@@ -135,6 +138,7 @@ public class MySQLTableSourceFactory implements DynamicTableSourceFactory {
         options.add(SCAN_SPLIT_SIZE);
         options.add(SCAN_FETCH_SIZE);
         options.add(SCAN_SPLIT_COLUMN);
+        options.add(SCAN_OPTIMIZE_INTEGRAL_KEY);
         return options;
     }
 

--- a/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/source/MySQLParallelSourceITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/source/MySQLParallelSourceITCase.java
@@ -288,9 +288,9 @@ public class MySQLParallelSourceITCase extends MySQLTestBase {
         properties.put("database.user", customDatabase.getUsername());
         properties.put("database.password", customDatabase.getPassword());
         properties.put("database.history.skip.unparseable.ddl", "true");
-        properties.put("server-id.range", "1001,1004");
-        properties.put("scan.split.size", "4");
-        properties.put("scan.fetch.size", "2");
+        properties.put("server-id", "1001,1004");
+        properties.put("scan.split.size", "1024");
+        properties.put("scan.fetch.size", "512");
         properties.put("database.serverTimezone", ZoneId.of("UTC").toString());
         properties.put("snapshot.mode", "initial");
         properties.put("database.history", EmbeddedFlinkDatabaseHistory.class.getCanonicalName());

--- a/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/source/assigner/MySQLSnapshotSplitAssignerTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/source/assigner/MySQLSnapshotSplitAssignerTest.java
@@ -107,10 +107,10 @@ public class MySQLSnapshotSplitAssignerTest extends MySQLTestBase {
     public void testEnableIntegralKeyOptimization() {
         String[] expected =
                 new String[] {
-                    "customers SNAPSHOT [null] [101]",
+                    "customers SNAPSHOT null [101]",
                     "customers SNAPSHOT [101] [1101]",
                     "customers SNAPSHOT [1101] [2000]",
-                    "customers SNAPSHOT [2000] [null]"
+                    "customers SNAPSHOT [2000] null"
                 };
         final RowType pkType =
                 (RowType) DataTypes.ROW(DataTypes.FIELD("id", DataTypes.INT())).getLogicalType();
@@ -123,14 +123,14 @@ public class MySQLSnapshotSplitAssignerTest extends MySQLTestBase {
     public void testEnableIntegralKeyOptimizationWithMultipleTable() {
         String[] expected =
                 new String[] {
-                    "customers SNAPSHOT [null] [101]",
+                    "customers SNAPSHOT null [101]",
                     "customers SNAPSHOT [101] [1101]",
                     "customers SNAPSHOT [1101] [2000]",
-                    "customers SNAPSHOT [2000] [null]",
-                    "customers_1 SNAPSHOT [null] [101]",
+                    "customers SNAPSHOT [2000] null",
+                    "customers_1 SNAPSHOT null [101]",
                     "customers_1 SNAPSHOT [101] [1101]",
                     "customers_1 SNAPSHOT [1101] [2000]",
-                    "customers_1 SNAPSHOT [2000] [null]"
+                    "customers_1 SNAPSHOT [2000] null"
                 };
         final RowType pkType =
                 (RowType) DataTypes.ROW(DataTypes.FIELD("id", DataTypes.INT())).getLogicalType();
@@ -144,10 +144,10 @@ public class MySQLSnapshotSplitAssignerTest extends MySQLTestBase {
     public void testEnableBigIntKeyOptimization() {
         String[] expected =
                 new String[] {
-                    "shopping_cart_big SNAPSHOT [null] [9223372036854773807]",
+                    "shopping_cart_big SNAPSHOT null [9223372036854773807]",
                     "shopping_cart_big SNAPSHOT [9223372036854773807] [9223372036854774807]",
                     "shopping_cart_big SNAPSHOT [9223372036854774807] [9223372036854775807]",
-                    "shopping_cart_big SNAPSHOT [9223372036854775807] [null]"
+                    "shopping_cart_big SNAPSHOT [9223372036854775807] null"
                 };
         // MySQL BIGINT UNSIGNED <=> Flink DECIMAL(20, 0)
         final RowType pkType =
@@ -163,11 +163,11 @@ public class MySQLSnapshotSplitAssignerTest extends MySQLTestBase {
     public void testEnableDecimalKeyOptimization() {
         String[] expected =
                 new String[] {
-                    "shopping_cart_dec SNAPSHOT [null] [123456.1230]",
+                    "shopping_cart_dec SNAPSHOT null [123456.1230]",
                     "shopping_cart_dec SNAPSHOT [123456.1230] [124456.1230]",
                     "shopping_cart_dec SNAPSHOT [124456.1230] [125456.1230]",
                     "shopping_cart_dec SNAPSHOT [125456.1230] [125489.6789]",
-                    "shopping_cart_dec SNAPSHOT [125489.6789] [null]"
+                    "shopping_cart_dec SNAPSHOT [125489.6789] null"
                 };
         final RowType pkType =
                 (RowType)

--- a/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/source/assigner/MySQLSnapshotSplitAssignerTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/source/assigner/MySQLSnapshotSplitAssignerTest.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.alibaba.ververica.cdc.connectors.mysql.debezium.EmbeddedFlinkDatabaseHistory.DATABASE_HISTORY_INSTANCE_NAME;
+import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.SCAN_OPTIMIZE_INTEGRAL_KEY;
 import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;
@@ -70,7 +71,7 @@ public class MySQLSnapshotSplitAssignerTest extends MySQLTestBase {
                 };
         final RowType pkType =
                 (RowType) DataTypes.ROW(DataTypes.FIELD("id", DataTypes.BIGINT())).getLogicalType();
-        List<String> splits = testAssignSnapshotSplits(4, pkType, new String[] {"customers"});
+        List<String> splits = getTestAssignSnapshotSplits(4, pkType, new String[] {"customers"});
         assertArrayEquals(expected, splits.toArray());
     }
 
@@ -98,14 +99,98 @@ public class MySQLSnapshotSplitAssignerTest extends MySQLTestBase {
         final RowType pkType =
                 (RowType) DataTypes.ROW(DataTypes.FIELD("id", DataTypes.BIGINT())).getLogicalType();
         List<String> splits =
-                testAssignSnapshotSplits(4, pkType, new String[] {"customers", "customers_1"});
+                getTestAssignSnapshotSplits(4, pkType, new String[] {"customers", "customers_1"});
         assertArrayEquals(expected, splits.toArray());
     }
 
-    private List<String> testAssignSnapshotSplits(
+    @Test
+    public void testEnableIntegralKeyOptimization() {
+        String[] expected =
+                new String[] {
+                    "customers SNAPSHOT [null] [101]",
+                    "customers SNAPSHOT [101] [1101]",
+                    "customers SNAPSHOT [1101] [2000]",
+                    "customers SNAPSHOT [2000] [null]"
+                };
+        final RowType pkType =
+                (RowType) DataTypes.ROW(DataTypes.FIELD("id", DataTypes.INT())).getLogicalType();
+        List<String> splits =
+                getTestAssignSnapshotSplits(1000, pkType, new String[] {"customers"}, true);
+        assertArrayEquals(expected, splits.toArray());
+    }
+
+    @Test
+    public void testEnableIntegralKeyOptimizationWithMultipleTable() {
+        String[] expected =
+                new String[] {
+                    "customers SNAPSHOT [null] [101]",
+                    "customers SNAPSHOT [101] [1101]",
+                    "customers SNAPSHOT [1101] [2000]",
+                    "customers SNAPSHOT [2000] [null]",
+                    "customers_1 SNAPSHOT [null] [101]",
+                    "customers_1 SNAPSHOT [101] [1101]",
+                    "customers_1 SNAPSHOT [1101] [2000]",
+                    "customers_1 SNAPSHOT [2000] [null]"
+                };
+        final RowType pkType =
+                (RowType) DataTypes.ROW(DataTypes.FIELD("id", DataTypes.INT())).getLogicalType();
+        List<String> splits =
+                getTestAssignSnapshotSplits(
+                        1000, pkType, new String[] {"customers", "customers_1"}, true);
+        assertArrayEquals(expected, splits.toArray());
+    }
+
+    @Test
+    public void testEnableBigIntKeyOptimization() {
+        String[] expected =
+                new String[] {
+                    "shopping_cart_big SNAPSHOT [null] [9223372036854773807]",
+                    "shopping_cart_big SNAPSHOT [9223372036854773807] [9223372036854774807]",
+                    "shopping_cart_big SNAPSHOT [9223372036854774807] [9223372036854775807]",
+                    "shopping_cart_big SNAPSHOT [9223372036854775807] [null]"
+                };
+        // MySQL BIGINT UNSIGNED <=> Flink DECIMAL(20, 0)
+        final RowType pkType =
+                (RowType)
+                        DataTypes.ROW(DataTypes.FIELD("product_no", DataTypes.DECIMAL(20, 0)))
+                                .getLogicalType();
+        List<String> splits =
+                getTestAssignSnapshotSplits(1000, pkType, new String[] {"shopping_cart_big"}, true);
+        assertArrayEquals(expected, splits.toArray());
+    }
+
+    @Test
+    public void testEnableDecimalKeyOptimization() {
+        String[] expected =
+                new String[] {
+                    "shopping_cart_dec SNAPSHOT [null] [123456.1230]",
+                    "shopping_cart_dec SNAPSHOT [123456.1230] [124456.1230]",
+                    "shopping_cart_dec SNAPSHOT [124456.1230] [125456.1230]",
+                    "shopping_cart_dec SNAPSHOT [125456.1230] [125489.6789]",
+                    "shopping_cart_dec SNAPSHOT [125489.6789] [null]"
+                };
+        final RowType pkType =
+                (RowType)
+                        DataTypes.ROW(DataTypes.FIELD("product_no", DataTypes.DECIMAL(10, 4)))
+                                .getLogicalType();
+        List<String> splits =
+                getTestAssignSnapshotSplits(1000, pkType, new String[] {"shopping_cart_dec"}, true);
+        assertArrayEquals(expected, splits.toArray());
+    }
+
+    private List<String> getTestAssignSnapshotSplits(
             int splitSize, RowType pkType, String[] captureTables) {
+        return getTestAssignSnapshotSplits(splitSize, pkType, captureTables, false);
+    }
+
+    private List<String> getTestAssignSnapshotSplits(
+            int splitSize,
+            RowType pkType,
+            String[] captureTables,
+            boolean enableIntegralOptimization) {
         Configuration configuration = getConfig();
         configuration.setString("scan.split.size", String.valueOf(splitSize));
+        configuration.setBoolean(SCAN_OPTIMIZE_INTEGRAL_KEY.key(), enableIntegralOptimization);
         List<String> captureTableIds =
                 Arrays.stream(captureTables)
                         .map(tableName -> customDatabase.getDatabaseName() + "." + tableName)
@@ -155,7 +240,8 @@ public class MySQLSnapshotSplitAssignerTest extends MySQLTestBase {
                 (RowType)
                         DataTypes.ROW(DataTypes.FIELD("card_no", DataTypes.BIGINT()))
                                 .getLogicalType();
-        List<String> splits = testAssignSnapshotSplits(4, pkType, new String[] {"customer_card"});
+        List<String> splits =
+                getTestAssignSnapshotSplits(4, pkType, new String[] {"customer_card"});
         assertArrayEquals(expected, splits.toArray());
     }
 
@@ -171,7 +257,7 @@ public class MySQLSnapshotSplitAssignerTest extends MySQLTestBase {
                         DataTypes.ROW(DataTypes.FIELD("card_no", DataTypes.BIGINT()))
                                 .getLogicalType();
         List<String> splits =
-                testAssignSnapshotSplits(4, pkType, new String[] {"customer_card_single_line"});
+                getTestAssignSnapshotSplits(4, pkType, new String[] {"customer_card_single_line"});
         assertArrayEquals(expected, splits.toArray());
     }
 
@@ -190,7 +276,8 @@ public class MySQLSnapshotSplitAssignerTest extends MySQLTestBase {
                 (RowType)
                         DataTypes.ROW(DataTypes.FIELD("product_no", DataTypes.BIGINT()))
                                 .getLogicalType();
-        List<String> splits = testAssignSnapshotSplits(4, pkType, new String[] {"shopping_cart"});
+        List<String> splits =
+                getTestAssignSnapshotSplits(4, pkType, new String[] {"shopping_cart"});
         assertArrayEquals(expected, splits.toArray());
     }
 
@@ -206,9 +293,10 @@ public class MySQLSnapshotSplitAssignerTest extends MySQLTestBase {
                 };
         final RowType pkType =
                 (RowType)
-                        DataTypes.ROW(DataTypes.FIELD("user_id", DataTypes.BIGINT()))
+                        DataTypes.ROW(DataTypes.FIELD("user_id", DataTypes.STRING()))
                                 .getLogicalType();
-        List<String> splits = testAssignSnapshotSplits(4, pkType, new String[] {"shopping_cart"});
+        List<String> splits =
+                getTestAssignSnapshotSplits(4, pkType, new String[] {"shopping_cart"});
         assertArrayEquals(expected, splits.toArray());
     }
 
@@ -240,7 +328,7 @@ public class MySQLSnapshotSplitAssignerTest extends MySQLTestBase {
                 };
         final RowType pkType =
                 (RowType) DataTypes.ROW(DataTypes.FIELD("id", DataTypes.BIGINT())).getLogicalType();
-        List<String> splits = testAssignSnapshotSplits(2, pkType, new String[] {"customers"});
+        List<String> splits = getTestAssignSnapshotSplits(2, pkType, new String[] {"customers"});
         assertArrayEquals(expected, splits.toArray());
     }
 
@@ -250,7 +338,8 @@ public class MySQLSnapshotSplitAssignerTest extends MySQLTestBase {
                 new String[] {"customers SNAPSHOT null [2000]", "customers SNAPSHOT [2000] null"};
         final RowType pkType =
                 (RowType) DataTypes.ROW(DataTypes.FIELD("id", DataTypes.BIGINT())).getLogicalType();
-        List<String> splits = testAssignSnapshotSplits(21, pkType, new String[] {"customers"});
+        List<String> splits = getTestAssignSnapshotSplits(2000, pkType, new String[] {"customers"});
+        System.out.println(splits);
         assertArrayEquals(expected, splits.toArray());
     }
 
@@ -261,7 +350,7 @@ public class MySQLSnapshotSplitAssignerTest extends MySQLTestBase {
                     (RowType)
                             DataTypes.ROW(DataTypes.FIELD("id", DataTypes.BIGINT()))
                                     .getLogicalType();
-            testAssignSnapshotSplits(1, pkType, new String[] {"customers"});
+            getTestAssignSnapshotSplits(1, pkType, new String[] {"customers"});
             fail("should fail.");
         } catch (IllegalStateException e) {
             assertThat(

--- a/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSourceFactoryTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSourceFactoryTest.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.SCAN_FETCH_SIZE;
+import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.SCAN_OPTIMIZE_INTEGRAL_KEY;
 import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.SCAN_SPLIT_SIZE;
 import static com.alibaba.ververica.cdc.connectors.mysql.source.MySQLSourceOptions.SNAPSHOT_PARALLEL_SCAN;
 import static org.apache.flink.table.api.TableSchema.fromResolvedSchema;
@@ -89,6 +90,7 @@ public class MySQLTableSourceFactoryTest {
                         ZoneId.of("UTC"),
                         PROPERTIES,
                         null,
+                        SCAN_OPTIMIZE_INTEGRAL_KEY.defaultValue(),
                         SNAPSHOT_PARALLEL_SCAN.defaultValue(),
                         SCAN_SPLIT_SIZE.defaultValue(),
                         SCAN_FETCH_SIZE.defaultValue(),
@@ -120,6 +122,40 @@ public class MySQLTableSourceFactoryTest {
                         ZoneId.of("UTC"),
                         PROPERTIES,
                         "123,126",
+                        SCAN_OPTIMIZE_INTEGRAL_KEY.defaultValue(),
+                        true,
+                        8000,
+                        100,
+                        "aaa",
+                        StartupOptions.initial());
+        assertEquals(expectedSource, actualSource);
+    }
+
+    @Test
+    public void testDisableIntegralOptimization() {
+        Map<String, String> properties = getAllOptions();
+        properties.put("snapshot.parallel-scan", "true");
+        properties.put("server-id", "123,126");
+        properties.put("scan.split.column", "aaa");
+        properties.put("scan.split.size", "8000");
+        properties.put("scan.fetch.size", "100");
+        properties.put("scan.optimize.integral-key", "false");
+
+        // validation for source
+        DynamicTableSource actualSource = createTableSource(properties);
+        MySQLTableSource expectedSource =
+                new MySQLTableSource(
+                        TableSchemaUtils.getPhysicalSchema(fromResolvedSchema(SCHEMA)),
+                        3306,
+                        MY_LOCALHOST,
+                        MY_DATABASE,
+                        MY_TABLE,
+                        MY_USERNAME,
+                        MY_PASSWORD,
+                        ZoneId.of("UTC"),
+                        PROPERTIES,
+                        "123,126",
+                        false,
                         true,
                         8000,
                         100,
@@ -151,6 +187,7 @@ public class MySQLTableSourceFactoryTest {
                         ZoneId.of("Asia/Shanghai"),
                         dbzProperties,
                         "4321",
+                        SCAN_OPTIMIZE_INTEGRAL_KEY.defaultValue(),
                         SNAPSHOT_PARALLEL_SCAN.defaultValue(),
                         SCAN_SPLIT_SIZE.defaultValue(),
                         SCAN_FETCH_SIZE.defaultValue(),
@@ -184,6 +221,7 @@ public class MySQLTableSourceFactoryTest {
                         ZoneId.of("UTC"),
                         PROPERTIES,
                         "4321",
+                        SCAN_OPTIMIZE_INTEGRAL_KEY.defaultValue(),
                         SNAPSHOT_PARALLEL_SCAN.defaultValue(),
                         SCAN_SPLIT_SIZE.defaultValue(),
                         SCAN_FETCH_SIZE.defaultValue(),
@@ -211,6 +249,7 @@ public class MySQLTableSourceFactoryTest {
                         ZoneId.of("UTC"),
                         PROPERTIES,
                         null,
+                        SCAN_OPTIMIZE_INTEGRAL_KEY.defaultValue(),
                         SNAPSHOT_PARALLEL_SCAN.defaultValue(),
                         SCAN_SPLIT_SIZE.defaultValue(),
                         SCAN_FETCH_SIZE.defaultValue(),
@@ -238,6 +277,7 @@ public class MySQLTableSourceFactoryTest {
                         ZoneId.of("UTC"),
                         PROPERTIES,
                         null,
+                        SCAN_OPTIMIZE_INTEGRAL_KEY.defaultValue(),
                         SNAPSHOT_PARALLEL_SCAN.defaultValue(),
                         SCAN_SPLIT_SIZE.defaultValue(),
                         SCAN_FETCH_SIZE.defaultValue(),
@@ -265,6 +305,7 @@ public class MySQLTableSourceFactoryTest {
                         ZoneId.of("UTC"),
                         PROPERTIES,
                         null,
+                        SCAN_OPTIMIZE_INTEGRAL_KEY.defaultValue(),
                         SNAPSHOT_PARALLEL_SCAN.defaultValue(),
                         SCAN_SPLIT_SIZE.defaultValue(),
                         SCAN_FETCH_SIZE.defaultValue(),

--- a/flink-connector-mysql-cdc/src/test/resources/ddl/custom.sql
+++ b/flink-connector-mysql-cdc/src/test/resources/ddl/custom.sql
@@ -144,3 +144,31 @@ VALUES (101, 'KIND_001', 'user_1', 'my shopping cart'),
        (401, 'KIND_007', 'user_5', 'leo list'),
        (404, 'KIND_008', 'user_5', 'leo list'),
        (600, 'KIND_009', 'user_6', 'my shopping cart');
+
+-- table has bigint unsigned primary key
+CREATE TABLE shopping_cart_big (
+  product_no BIGINT UNSIGNED NOT NULL,
+  product_kind VARCHAR(255),
+  user_id VARCHAR(255) NOT NULL,
+  description VARCHAR(255) NOT NULL,
+  PRIMARY KEY(product_no)
+);
+
+insert into shopping_cart_big
+VALUES (9223372036854773807, 'KIND_001', 'user_1', 'my shopping cart'),
+       (9223372036854774807, 'KIND_002', 'user_1', 'my shopping cart'),
+       (9223372036854775807, 'KIND_003', 'user_1', 'my shopping cart');
+
+-- table has decimal primary key
+CREATE TABLE shopping_cart_dec (
+  product_no DECIMAL(10, 4) NOT NULL,
+  product_kind VARCHAR(255),
+  user_id VARCHAR(255) NOT NULL,
+  description VARCHAR(255) NOT NULL,
+  PRIMARY KEY(product_no)
+);
+
+insert into shopping_cart_dec
+VALUES (123456.123, 'KIND_001', 'user_1', 'my shopping cart'),
+       (124456.456, 'KIND_002', 'user_1', 'my shopping cart'),
+       (125489.6789, 'KIND_003', 'user_1', 'my shopping cart');


### PR DESCRIPTION
In the case that the split key is integral type(INT and BIGINT, DECIMAL), we can optimize the snapshot splits analyzing by integral range rather than querying the DB for every splits.

Introduce option `scan.optimize.integral-key` to enable the feature or not, by default the option value is `true` which means the enable this optimization. 