### PR TITLE
release-2.0:com.ververica.cdc.debezium.Validator add Serializable

### DIFF
--- a/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/Validator.java
+++ b/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/Validator.java
@@ -18,8 +18,10 @@
 
 package com.ververica.cdc.debezium;
 
+import java.io.Serializable;
+
 /** Validator to validate the connected database satisfies the cdc connector's requirements. */
-public interface Validator {
+public interface Validator extends Serializable {
 
     void validate();
 

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/MySqlValidator.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/MySqlValidator.java
@@ -28,7 +28,6 @@ import com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils;
 import com.ververica.cdc.debezium.Validator;
 import io.debezium.connector.mysql.MySqlConnection;
 
-import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Properties;
@@ -37,7 +36,7 @@ import java.util.Properties;
  * The validator for MySql: it only cares about the version of the database is larger than or equal
  * to 5.7. It also requires the binlog format in the database is ROW and row image is FULL.
  */
-public class MySqlValidator implements Validator, Serializable {
+public class MySqlValidator implements Validator {
 
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
提交解决问题：
 com.ververica.cdc.debezium.Validator$$Lambda$25/1712669532@12f41634 is not serializable.

https://github.com/ververica/flink-cdc-connectors/issues/311