### PR TITLE
[ISSUE-326] Fix database history missing.

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlParallelSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlParallelSource.java
@@ -50,6 +50,7 @@ import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
 import org.apache.kafka.connect.source.SourceRecord;
 
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Supplier;
 
 import static com.ververica.cdc.connectors.mysql.debezium.EmbeddedFlinkDatabaseHistory.DATABASE_HISTORY_INSTANCE_NAME;
@@ -78,12 +79,16 @@ public class MySqlParallelSource<T>
     private final DebeziumDeserializationSchema<T> deserializationSchema;
     private final Configuration config;
     private final String startupMode;
+    private final String historyInstanceName;
 
     public MySqlParallelSource(
             DebeziumDeserializationSchema<T> deserializationSchema, Configuration config) {
         this.deserializationSchema = deserializationSchema;
         this.config = config;
         this.startupMode = config.get(SCAN_STARTUP_MODE);
+        this.historyInstanceName =
+                config.toMap()
+                        .getOrDefault(DATABASE_HISTORY_INSTANCE_NAME, UUID.randomUUID().toString());
     }
 
     @Override
@@ -117,9 +122,7 @@ public class MySqlParallelSource<T>
         // set the DatabaseHistory name for each reader, will used by debezium reader
         readerConfiguration.setString(
                 DATABASE_HISTORY_INSTANCE_NAME,
-                config.toMap().get(DATABASE_HISTORY_INSTANCE_NAME)
-                        + "_"
-                        + readerContext.getIndexOfSubtask());
+                historyInstanceName + "_" + readerContext.getIndexOfSubtask());
         return readerConfiguration;
     }
 


### PR DESCRIPTION
Fixed the problem of #326 .

If `database.history.instance.name` property not set, the key of `EmbeddedFlinkDatabaseHistory.TABLE_SCHEMAS` will be "null_" + SourceReaderContext.getIndexOfSubtask. 
The exception may happen in the scenario of multi-table join because `EmbeddedFlinkDatabaseHistory.TABLE_SCHEMAS`  will be incorrectly overwritten or removed when executed concurrently.

Add logger at  MySqlParallelSource.getReaderConfig
```
ReaderConfig index of task: 0
ReaderConfig index of task: 0
ReaderConfig table: {database.user=mysqluser, database.server.name=mysql_binlog_source, scan.startup.mode=initial, database.port=55169, table.whitelist=history_missing_7rl2ke.sfy_live_act_employ, scan.snapshot.fetch.size=1024, database.serverTimezone=UTC, database.hostname=localhost, database.password=mysqlpw, database.history.skip.unparseable.ddl=true, scan.incremental.snapshot.chunk.size=8096, database.whitelist=history_missing_7rl2ke, database.history.instance.name=null_0, database.history=com.ververica.cdc.connectors.mysql.debezium.EmbeddedFlinkDatabaseHistory, connect.timeout.ms=30000}
ReaderConfig table: {database.user=mysqluser, database.server.name=mysql_binlog_source, scan.startup.mode=initial, database.port=55169, table.whitelist=history_missing_7rl2ke.sfy_live_share_relation, scan.snapshot.fetch.size=1024, database.serverTimezone=UTC, database.hostname=localhost, database.password=mysqlpw, database.history.skip.unparseable.ddl=true, scan.incremental.snapshot.chunk.size=8096, database.whitelist=history_missing_7rl2ke, database.history.instance.name=null_0, database.history=com.ververica.cdc.connectors.mysql.debezium.EmbeddedFlinkDatabaseHistory, connect.timeout.ms=30000}
```