### PR TITLE
[common] Remove useless parameter 'converter.schemas.enable'

### DIFF
--- a/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
+++ b/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
@@ -370,9 +370,6 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
             // restored from state
             properties.setProperty(FlinkOffsetBackingStore.OFFSET_STATE_VALUE, restoredOffsetState);
         }
-        // DO NOT include schema payload in change event
-        properties.setProperty("key.converter.schemas.enable", "false");
-        properties.setProperty("value.converter.schemas.enable", "false");
         // DO NOT include schema change, e.g. DDL
         properties.setProperty("include.schema.changes", "false");
         // disable the offset flush totally


### PR DESCRIPTION
cherry-pick to 2.0 branch