### PR TITLE
[ISSUE-371] Fix enum type cause DataException

### DIFF
--- a/flink-connector-debezium/src/main/java/io/debezium/relational/history/JsonTableChangeSerializer.java
+++ b/flink-connector-debezium/src/main/java/io/debezium/relational/history/JsonTableChangeSerializer.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.relational.history;
+
+import io.debezium.document.Array;
+import io.debezium.document.Array.Entry;
+import io.debezium.document.Document;
+import io.debezium.document.Value;
+import io.debezium.relational.Column;
+import io.debezium.relational.ColumnEditor;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableEditor;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.TableChanges.TableChange;
+import io.debezium.relational.history.TableChanges.TableChangeType;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Copied from Debezium project. Make it can serialize and deserialize Column's defaultValue and
+ * enumValues.
+ */
+public class JsonTableChangeSerializer implements TableChanges.TableChangesSerializer<Array> {
+
+    @Override
+    public Array serialize(TableChanges tableChanges) {
+        List<Value> values =
+                StreamSupport.stream(tableChanges.spliterator(), false)
+                        .map(this::toDocument)
+                        .map(Value::create)
+                        .collect(Collectors.toList());
+
+        return Array.create(values);
+    }
+
+    public Document toDocument(TableChange tableChange) {
+        Document document = Document.create();
+
+        document.setString("type", tableChange.getType().name());
+        document.setString("id", tableChange.getId().toDoubleQuotedString());
+        document.setDocument("table", toDocument(tableChange.getTable()));
+        return document;
+    }
+
+    private Document toDocument(Table table) {
+        Document document = Document.create();
+
+        document.set("defaultCharsetName", table.defaultCharsetName());
+        document.set("primaryKeyColumnNames", Array.create(table.primaryKeyColumnNames()));
+
+        List<Document> columns =
+                table.columns().stream().map(this::toDocument).collect(Collectors.toList());
+
+        document.setArray("columns", Array.create(columns));
+
+        return document;
+    }
+
+    private Document toDocument(Column column) {
+        Document document = Document.create();
+
+        document.setString("name", column.name());
+        document.setNumber("jdbcType", column.jdbcType());
+
+        if (column.nativeType() != Column.UNSET_INT_VALUE) {
+            document.setNumber("nativeType", column.nativeType());
+        }
+
+        document.setString("typeName", column.typeName());
+        document.setString("typeExpression", column.typeExpression());
+        document.setString("charsetName", column.charsetName());
+
+        if (column.length() != Column.UNSET_INT_VALUE) {
+            document.setNumber("length", column.length());
+        }
+
+        column.scale().ifPresent(s -> document.setNumber("scale", s));
+
+        document.setNumber("position", column.position());
+        document.setBoolean("optional", column.isOptional());
+        document.setBoolean("autoIncremented", column.isAutoIncremented());
+        document.setBoolean("generated", column.isGenerated());
+
+        document.setBoolean("hasDefaultValue", column.hasDefaultValue());
+        document.set("defaultValue", column.defaultValue());
+        Optional.ofNullable(column.enumValues())
+                .map(List::toArray)
+                .ifPresent(enums -> document.setArray("enumValues", enums));
+
+        return document;
+    }
+
+    @Override
+    public TableChanges deserialize(Array array, boolean useCatalogBeforeSchema) {
+        TableChanges tableChanges = new TableChanges();
+
+        for (Entry entry : array) {
+            TableChange change =
+                    fromDocument(entry.getValue().asDocument(), useCatalogBeforeSchema);
+
+            if (change.getType() == TableChangeType.CREATE) {
+                tableChanges.create(change.getTable());
+            } else if (change.getType() == TableChangeType.ALTER) {
+                tableChanges.alter(change.getTable());
+            } else if (change.getType() == TableChangeType.DROP) {
+                tableChanges.drop(change.getTable());
+            }
+        }
+
+        return tableChanges;
+    }
+
+    private static Table fromDocument(TableId id, Document document) {
+        TableEditor editor =
+                Table.editor()
+                        .tableId(id)
+                        .setDefaultCharsetName(document.getString("defaultCharsetName"));
+
+        document.getArray("columns")
+                .streamValues()
+                .map(Value::asDocument)
+                .map(
+                        v -> {
+                            ColumnEditor columnEditor =
+                                    Column.editor()
+                                            .name(v.getString("name"))
+                                            .jdbcType(v.getInteger("jdbcType"));
+
+                            Integer nativeType = v.getInteger("nativeType");
+                            if (nativeType != null) {
+                                columnEditor.nativeType(nativeType);
+                            }
+
+                            columnEditor
+                                    .type(v.getString("typeName"), v.getString("typeExpression"))
+                                    .charsetName(v.getString("charsetName"));
+
+                            Integer length = v.getInteger("length");
+                            if (length != null) {
+                                columnEditor.length(length);
+                            }
+
+                            Integer scale = v.getInteger("scale");
+                            if (scale != null) {
+                                columnEditor.scale(scale);
+                            }
+
+                            Boolean hasDefaultValue = v.getBoolean("hasDefaultValue");
+                            if (hasDefaultValue != null && hasDefaultValue) {
+                                Object defaultValue = v.get("defaultValue").asObject();
+                                columnEditor.defaultValue(defaultValue);
+                            }
+
+                            Array enumValues = v.getArray("enumValues");
+                            if (enumValues != null && !enumValues.isEmpty()) {
+                                columnEditor.enumValues(
+                                        enumValues
+                                                .streamValues()
+                                                .map(Value::asString)
+                                                .collect(Collectors.toList()));
+                            }
+
+                            columnEditor
+                                    .position(v.getInteger("position"))
+                                    .optional(v.getBoolean("optional"))
+                                    .autoIncremented(v.getBoolean("autoIncremented"))
+                                    .generated(v.getBoolean("generated"));
+
+                            return columnEditor.create();
+                        })
+                .forEach(editor::addColumn);
+
+        editor.setPrimaryKeyNames(
+                document.getArray("primaryKeyColumnNames")
+                        .streamValues()
+                        .map(Value::asString)
+                        .collect(Collectors.toList()));
+
+        return editor.create();
+    }
+
+    public static TableChange fromDocument(Document document, boolean useCatalogBeforeSchema) {
+        TableChangeType type = TableChangeType.valueOf(document.getString("type"));
+        TableId id = TableId.parse(document.getString("id"), useCatalogBeforeSchema);
+        Table table = null;
+
+        if (type == TableChangeType.CREATE || type == TableChangeType.ALTER) {
+            table = fromDocument(id, document.getDocument("table"));
+        } else {
+            table = Table.editor().tableId(id).create();
+        }
+        return new TableChange(type, table);
+    }
+}

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/MySqlSourceITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/MySqlSourceITCase.java
@@ -130,7 +130,7 @@ public class MySqlSourceITCase extends MySqlTestBase {
         try (Connection connection = fullTypesDatabase.getJdbcConnection();
                 Statement statement = connection.createStatement()) {
             statement.execute(
-                    "UPDATE full_types SET timestamp_c = '2020-07-17 18:33:22' WHERE id=1;");
+                    "UPDATE full_types SET timestamp_c = '2020-07-17 18:33:22', enum_c = '1' WHERE id=1;");
         }
 
         // check the binlog result

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlConnectorITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlConnectorITCase.java
@@ -322,6 +322,7 @@ public class MySqlConnectorITCase extends MySqlTestBase {
                                 + "    datetime6_c TIMESTAMP(6),\n"
                                 + "    timestamp_c TIMESTAMP(0),\n"
                                 + "    file_uuid BYTES,\n"
+                                + "    enum_c STRING,\n"
                                 + "    primary key (`id`) not enforced"
                                 + ") WITH ("
                                 + " 'connector' = 'mysql-cdc',"
@@ -372,7 +373,9 @@ public class MySqlConnectorITCase extends MySqlTestBase {
                                 + "datetime3_c,\n"
                                 + "datetime6_c,\n"
                                 + "timestamp_c,\n"
-                                + "TO_BASE64(DECODE(file_uuid, 'UTF-8')) FROM full_types");
+                                + "TO_BASE64(DECODE(file_uuid, 'UTF-8')),\n"
+                                + "enum_c\n"
+                                + "FROM full_types");
 
         CloseableIterator<Row> iterator = result.collect();
         waitForSnapshotStarted(iterator);
@@ -381,14 +384,14 @@ public class MySqlConnectorITCase extends MySqlTestBase {
                 Statement statement = connection.createStatement()) {
 
             statement.execute(
-                    "UPDATE full_types SET timestamp_c = '2020-07-17 18:33:22' WHERE id=1;");
+                    "UPDATE full_types SET timestamp_c = '2020-07-17 18:33:22', enum_c = '1' WHERE id=1;");
         }
 
         String[] expected =
                 new String[] {
-                    "+I[1, 127, 255, 32767, 65535, 2147483647, 4294967295, 2147483647, 9223372036854775807, Hello World, abc, 123.102, 404.4443, 123.4567, 346, true, 2020-07-17, 18:00:22, 2020-07-17T18:00:22.123, 2020-07-17T18:00:22.123456, 2020-07-17T18:00:22, ZRrvv70IOQ9I77+977+977+9Nu+/vT57dAA=]",
-                    "-U[1, 127, 255, 32767, 65535, 2147483647, 4294967295, 2147483647, 9223372036854775807, Hello World, abc, 123.102, 404.4443, 123.4567, 346, true, 2020-07-17, 18:00:22, 2020-07-17T18:00:22.123, 2020-07-17T18:00:22.123456, 2020-07-17T18:00:22, ZRrvv70IOQ9I77+977+977+9Nu+/vT57dAA=]",
-                    "+U[1, 127, 255, 32767, 65535, 2147483647, 4294967295, 2147483647, 9223372036854775807, Hello World, abc, 123.102, 404.4443, 123.4567, 346, true, 2020-07-17, 18:00:22, 2020-07-17T18:00:22.123, 2020-07-17T18:00:22.123456, 2020-07-17T18:33:22, ZRrvv70IOQ9I77+977+977+9Nu+/vT57dAA=]"
+                    "+I[1, 127, 255, 32767, 65535, 2147483647, 4294967295, 2147483647, 9223372036854775807, Hello World, abc, 123.102, 404.4443, 123.4567, 346, true, 2020-07-17, 18:00:22, 2020-07-17T18:00:22.123, 2020-07-17T18:00:22.123456, 2020-07-17T18:00:22, ZRrvv70IOQ9I77+977+977+9Nu+/vT57dAA=, 0]",
+                    "-U[1, 127, 255, 32767, 65535, 2147483647, 4294967295, 2147483647, 9223372036854775807, Hello World, abc, 123.102, 404.4443, 123.4567, 346, true, 2020-07-17, 18:00:22, 2020-07-17T18:00:22.123, 2020-07-17T18:00:22.123456, 2020-07-17T18:00:22, ZRrvv70IOQ9I77+977+977+9Nu+/vT57dAA=, 0]",
+                    "+U[1, 127, 255, 32767, 65535, 2147483647, 4294967295, 2147483647, 9223372036854775807, Hello World, abc, 123.102, 404.4443, 123.4567, 346, true, 2020-07-17, 18:00:22, 2020-07-17T18:00:22.123, 2020-07-17T18:00:22.123456, 2020-07-17T18:33:22, ZRrvv70IOQ9I77+977+977+9Nu+/vT57dAA=, 1]"
                 };
 
         assertThat(fetchRows(result.collect(), 3), containsInAnyOrder(expected));

--- a/flink-connector-mysql-cdc/src/test/resources/ddl/column_type_test.sql
+++ b/flink-connector-mysql-cdc/src/test/resources/ddl/column_type_test.sql
@@ -40,6 +40,7 @@ CREATE TABLE full_types (
     datetime6_c DATETIME(6),
     timestamp_c TIMESTAMP,
     file_uuid BINARY(16),
+    enum_c enum('0', '1') NOT NULL DEFAULT '0',
     PRIMARY KEY (id)
 ) DEFAULT CHARSET=utf8;
 
@@ -47,5 +48,5 @@ INSERT INTO full_types VALUES (
     DEFAULT, 127, 255, 32767, 65535, 2147483647, 4294967295, 2147483647, 9223372036854775807,
     'Hello World', 'abc', 123.102, 404.4443, 123.4567, 345.6, true,
     '2020-07-17', '18:00:22', '2020-07-17 18:00:22.123', '2020-07-17 18:00:22.123456', '2020-07-17 18:00:22',
-    unhex(replace('651aed08-390f-4893-b2f1-36923e7b7400','-',''))
+    unhex(replace('651aed08-390f-4893-b2f1-36923e7b7400','-','')), '0'
 );

--- a/flink-connector-mysql-cdc/src/test/resources/file/debezium-data-schema-exclude.json
+++ b/flink-connector-mysql-cdc/src/test/resources/file/debezium-data-schema-exclude.json
@@ -23,7 +23,8 @@
             "datetime3_c": 1595008822123,
             "datetime6_c": 1595008822123456,
             "timestamp_c": "2020-07-17T18:00:22Z",
-            "file_uuid": "ZRrtCDkPSJOy8TaSPnt0AA=="
+            "file_uuid": "ZRrtCDkPSJOy8TaSPnt0AA==",
+            "enum_c": "0"
         },
         "op": "r",
         "transaction": null
@@ -51,7 +52,8 @@
             "datetime3_c": 1595008822123,
             "datetime6_c": 1595008822123456,
             "timestamp_c": "2020-07-17T18:00:22Z",
-            "file_uuid": "ZRrtCDkPSJOy8TaSPnt0AA=="
+            "file_uuid": "ZRrtCDkPSJOy8TaSPnt0AA==",
+            "enum_c": "0"
         },
         "after": {
             "id": 1,
@@ -75,7 +77,8 @@
             "datetime3_c": 1595008822123,
             "datetime6_c": 1595008822123456,
             "timestamp_c": "2020-07-17T18:33:22Z",
-            "file_uuid": "ZRrtCDkPSJOy8TaSPnt0AA=="
+            "file_uuid": "ZRrtCDkPSJOy8TaSPnt0AA==",
+            "enum_c": "1"
         },
         "op": "u",
         "transaction": null

--- a/flink-connector-mysql-cdc/src/test/resources/file/debezium-data-schema-include.json
+++ b/flink-connector-mysql-cdc/src/test/resources/file/debezium-data-schema-include.json
@@ -434,7 +434,8 @@
                 "datetime3_c": 1595008822123,
                 "datetime6_c": 1595008822123456,
                 "timestamp_c": "2020-07-17T18:00:22Z",
-                "file_uuid": "ZRrtCDkPSJOy8TaSPnt0AA=="
+                "file_uuid": "ZRrtCDkPSJOy8TaSPnt0AA==",
+                "enum_c": "0"
             },
             "source": {
                 "version": "1.5.2.Final",
@@ -597,6 +598,13 @@
                             "type": "bytes",
                             "optional": true,
                             "field": "file_uuid"
+                        },
+                        {
+                            "type": "string",
+                            "optional": false,
+                            "version": 1,
+                            "default": "0",
+                            "field": "enum_c"
                         }
                     ],
                     "optional": true,
@@ -738,6 +746,13 @@
                             "type": "bytes",
                             "optional": true,
                             "field": "file_uuid"
+                        },
+                        {
+                            "type": "string",
+                            "optional": true,
+                            "version": 1,
+                            "default": "0",
+                            "field": "enum_c"
                         }
                     ],
                     "optional": true,
@@ -892,7 +907,8 @@
                 "datetime3_c": 1595008822123,
                 "datetime6_c": 1595008822123456,
                 "timestamp_c": "2020-07-17T18:00:22Z",
-                "file_uuid": "ZRrtCDkPSJOy8TaSPnt0AA=="
+                "file_uuid": "ZRrtCDkPSJOy8TaSPnt0AA==",
+                "enum_c": "0"
             },
             "after": {
                 "id": 1,
@@ -916,7 +932,8 @@
                 "datetime3_c": 1595008822123,
                 "datetime6_c": 1595008822123456,
                 "timestamp_c": "2020-07-17T18:33:22Z",
-                "file_uuid": "ZRrtCDkPSJOy8TaSPnt0AA=="
+                "file_uuid": "ZRrtCDkPSJOy8TaSPnt0AA==",
+                "enum_c": "1"
             },
             "source": {
                 "version": "1.5.2.Final",


### PR DESCRIPTION
This problem happens when serialize and deserialize `MySqlSplit`.
Cause debezium `JsonTableChangeSerializer` ignored `defaultValue` and `enumValues` when serializing `Table.Column`.

Rewritten `JsonTableChangeSerializer` as a compromise and it works fine.

Relate to #371