### PR TITLE
Optimize reader for mysql-cdc

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/DebeziumReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/DebeziumReader.java
@@ -28,14 +28,10 @@ public interface DebeziumReader<T, Split> {
     /** Return the current split of the reader is finished or not. */
     boolean isFinished();
 
-    /**
-     * Add to split to read, this should call only the when reader is idle.
-     *
-     * @param splitToRead
-     */
-    void submitSplit(Split splitToRead);
+    /** Start the reader. */
+    void start();
 
-    /** Close the reader and releases all resources. */
+    /** Close the reader. */
     void close();
 
     /**

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/MySqlBinlogSplitReadTask.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/MySqlBinlogSplitReadTask.java
@@ -50,7 +50,6 @@ public class MySqlBinlogSplitReadTask extends MySqlStreamingChangeEventSource {
     private static final Logger logger = LoggerFactory.getLogger(MySqlBinlogSplitReadTask.class);
     private final MySqlBinlogSplit binlogSplit;
     private final MySqlOffsetContext offsetContext;
-    private final EventDispatcherImpl<TableId> eventDispatcher;
     private final SignalEventDispatcher signalEventDispatcher;
     private final ErrorHandler errorHandler;
     private ChangeEventSourceContext context;
@@ -59,28 +58,26 @@ public class MySqlBinlogSplitReadTask extends MySqlStreamingChangeEventSource {
             MySqlConnectorConfig connectorConfig,
             MySqlOffsetContext offsetContext,
             MySqlConnection connection,
-            EventDispatcherImpl<TableId> dispatcher,
+            EventDispatcherImpl<TableId> eventDispatcher,
+            SignalEventDispatcher signalEventDispatcher,
             ErrorHandler errorHandler,
             Clock clock,
             MySqlTaskContext taskContext,
             MySqlStreamingChangeEventSourceMetrics metrics,
-            String topic,
             MySqlBinlogSplit binlogSplit) {
         super(
                 connectorConfig,
                 offsetContext,
                 connection,
-                dispatcher,
+                eventDispatcher,
                 errorHandler,
                 clock,
                 taskContext,
                 metrics);
         this.binlogSplit = binlogSplit;
-        this.eventDispatcher = dispatcher;
+        this.signalEventDispatcher = signalEventDispatcher;
         this.offsetContext = offsetContext;
         this.errorHandler = errorHandler;
-        this.signalEventDispatcher =
-                new SignalEventDispatcher(offsetContext, topic, eventDispatcher.getQueue());
     }
 
     @Override

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
@@ -207,14 +207,14 @@ public class SnapshotSplitReaderTest extends MySqlTestBase {
 
         StatefulTaskContext statefulTaskContext =
                 new StatefulTaskContext(configuration, binaryLogClient, mySqlConnection);
-        SnapshotSplitReader snapshotSplitReader = new SnapshotSplitReader(statefulTaskContext, 0);
+        SnapshotSplitReader snapshotSplitReader;
 
         List<SourceRecord> result = new ArrayList<>();
         for (int i = 0; i < scanSplitsNum; i++) {
             MySqlSplit sqlSplit = mySqlSplits.get(i);
-            if (snapshotSplitReader.isFinished()) {
-                snapshotSplitReader.submitSplit(sqlSplit);
-            }
+            snapshotSplitReader =
+                    new SnapshotSplitReader(statefulTaskContext, 0, sqlSplit.asSnapshotSplit());
+            snapshotSplitReader.start();
             Iterator<SourceRecord> res;
             while ((res = snapshotSplitReader.pollSplitRecords()) != null) {
                 while (res.hasNext()) {

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlParallelSourceTestBase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlParallelSourceTestBase.java
@@ -139,7 +139,7 @@ public abstract class MySqlParallelSourceTestBase extends TestLogger {
                         customDatabase.getPassword(),
                         customDatabase.getDatabaseName(),
                         getTableName(captureCustomerTables),
-                        getServerId());
+                        "5401");
         // first step: check the snapshot data
         String[] snapshotForSingleTable =
                 new String[] {


### PR DESCRIPTION
1:  Bind reader to split, create reader when read a new split and close reader when finish reading split.
2: Skip reading binlog when low watermark = hige watermark  in snapshot phase.