### PR TITLE
[docs] Correct Usage for DataStream API

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,19 +66,23 @@ Include following Maven dependency (available through Maven Central):
 ```java
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import com.ververica.cdc.debezium.StringDebeziumDeserializationSchema;
+import com.ververica.cdc.debezium.JsonDebeziumDeserializationSchema;
 import com.ververica.cdc.connectors.mysql.MySqlSource;
 
 public class MySqlBinlogSourceExample {
   public static void main(String[] args) throws Exception {
-    SourceFunction<String> sourceFunction = MySqlSource.<String>builder()
-      .hostname("localhost")
-      .port(3306)
-      .databaseList("inventory") // monitor all tables under inventory database
-      .username("flinkuser")
-      .password("flinkpw")
-      .deserializer(new StringDebeziumDeserializationSchema()) // converts SourceRecord to String
-      .build();
+    Properties debeziumProperties = new Properties();
+    debeziumProperties.put("snapshot.locking.mode", "none");// do not use lock
+    SourceFunction<String> sourceFunction = MySQLSource.<String>builder()
+            .hostname("yourHostname")
+            .port(yourPort)
+            .databaseList("yourDatabaseName") // set captured database
+            .tableList("yourDatabaseName.yourTableName") // set captured table
+            .username("yourUsername")
+            .password("yourPassword")
+            .deserializer(new JsonDebeziumDeserializationSchema()) // converts SourceRecord to JSON String
+            .debeziumProperties(debeziumProperties)
+            .build();
 
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 

--- a/docs/content/about.md
+++ b/docs/content/about.md
@@ -88,14 +88,18 @@ import com.ververica.cdc.connectors.mysql.MySqlSource;
 
 public class MySqlBinlogSourceExample {
   public static void main(String[] args) throws Exception {
-    SourceFunction<String> sourceFunction = MySqlSource.<String>builder()
-      .hostname("localhost")
-      .port(3306)
-      .databaseList("inventory") // monitor all tables under inventory database
-      .username("flinkuser")
-      .password("flinkpw")
-      .deserializer(new JsonDebeziumDeserializationSchema()) // converts SourceRecord to JSON String
-      .build();
+    Properties debeziumProperties = new Properties();
+    debeziumProperties.put("snapshot.locking.mode", "none");// do not use lock
+    SourceFunction<String> sourceFunction = MySQLSource.<String>builder()
+        .hostname("yourHostname")
+        .port(yourPort)
+        .databaseList("yourDatabaseName") // set captured database
+        .tableList("yourDatabaseName.yourTableName") // set captured table
+        .username("yourUsername")
+        .password("yourPassword")
+        .deserializer(new JsonDebeziumDeserializationSchema()) // converts SourceRecord to JSON String
+        .debeziumProperties(debeziumProperties)
+        .build();
 
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 

--- a/docs/content/connectors/mysql-cdc.md
+++ b/docs/content/connectors/mysql-cdc.md
@@ -370,14 +370,18 @@ import com.ververica.cdc.connectors.mysql.MySqlSource;
 
 public class MySqlBinlogSourceExample {
   public static void main(String[] args) throws Exception {
-    SourceFunction<String> sourceFunction = MySqlSource.<String>builder()
-      .hostname("localhost")
-      .port(3306)
-      .databaseList("inventory") // monitor all tables under inventory database
-      .username("flinkuser")
-      .password("flinkpw")
-      .deserializer(new JsonDebeziumDeserializationSchema()) // converts SourceRecord to JSON String
-      .build();
+    Properties debeziumProperties = new Properties();
+    debeziumProperties.put("snapshot.locking.mode", "none");// do not use lock
+    SourceFunction<String> sourceFunction = MySQLSource.<String>builder()
+        .hostname("yourHostname")
+        .port(yourPort)
+        .databaseList("yourDatabaseName") // set captured database
+        .tableList("yourDatabaseName.yourTableName") // set captured table
+        .username("yourUsername")
+        .password("yourPassword")
+        .deserializer(new JsonDebeziumDeserializationSchema()) // converts SourceRecord to JSON String
+        .debeziumProperties(debeziumProperties)
+        .build();
 
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 

--- a/docs/content/connectors/postgres-cdc.md
+++ b/docs/content/connectors/postgres-cdc.md
@@ -179,7 +179,7 @@ public class PostgreSQLSourceExample {
       .hostname("localhost")
       .port(5432)
       .database("postgres") // monitor postgres database 
-      .schemaList("inventory")  // monitor captured schema
+      .schemaList("inventory")  // monitor inventory schema
       .tableList("inventory.products") // monitor products table
       .username("flinkuser")
       .password("flinkpw")

--- a/docs/content/connectors/postgres-cdc.md
+++ b/docs/content/connectors/postgres-cdc.md
@@ -178,8 +178,9 @@ public class PostgreSQLSourceExample {
     SourceFunction<String> sourceFunction = PostgreSQLSource.<String>builder()
       .hostname("localhost")
       .port(5432)
-      .database("postgres")
-      .schemaList("inventory") // monitor all tables under inventory schema
+      .database("postgres") // monitor postgres database 
+      .schemaList("inventory")  // monitor captured schema
+      .tableList("inventory.products") // monitor products table
       .username("flinkuser")
       .password("flinkpw")
       .deserializer(new JsonDebeziumDeserializationSchema()) // converts SourceRecord to JSON String

--- a/docs/content/connectors/postgres-cdc.md
+++ b/docs/content/connectors/postgres-cdc.md
@@ -178,7 +178,7 @@ public class PostgreSQLSourceExample {
     SourceFunction<String> sourceFunction = PostgreSQLSource.<String>builder()
       .hostname("localhost")
       .port(5432)
-      .database("postgres") // monitor postgres database 
+      .database("postgres") // monitor postgres database
       .schemaList("inventory")  // monitor inventory schema
       .tableList("inventory.products") // monitor products table
       .username("flinkuser")


### PR DESCRIPTION
issue #414 

# When users use the DataStream API, they often encounter the following problems:

- Incorrect use of no lock mode.
e.g. `debeziumProperties.put("debezium.snapshot.locking.mode", "none")`
- The captured table could not be set up correctly..
e.g. `tableList("tableName")`
- Unable to get json output.
e.g. `deserializer(new StringDebeziumDeserializationSchema())`

# The Correct Usage for DataStream API following：

```java
Properties debeziumProperties = new Properties();
      debeziumProperties.put("snapshot.locking.mode", "none");// do not use lock
      SourceFunction<String> sourceFunction = MySQLSource.<String>builder()
      .hostname("yourHostname")
      .port(yourPort)
      .databaseList("yourDatabaseName") // set captured database
      .tableList("yourDatabaseName.yourTableName") // set captured table
      .username("yourUsername")
      .password("yourPassword")
      .deserializer(new JsonDebeziumDeserializationSchema()) // converts SourceRecord to JSON String
      .debeziumProperties(debeziumProperties)
      .build();
```