### PR TITLE
Add support for copy.existing.namespace.regex and pipeline config to mongo-cdc

### DIFF
--- a/docs/content/connectors/mongodb-cdc.md
+++ b/docs/content/connectors/mongodb-cdc.md
@@ -152,14 +152,14 @@ Connector Options
       <td>required</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Name of the database to watch for changes.</td>
+      <td>Name of the database to watch for changes. If set to empty string, then all databases will be captured (databases can be filtered using the copy.existing.namespace.regex setting).</td>
     </tr>
     <tr>
       <td>collection</td>
       <td>required</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Name of the collection in the database to watch for changes.</td>
+      <td>Name of the collection in the database to watch for changes. If set to empty string, then all collections will be caputred (collections can be filtered using the copy.existing.namespace.regex setting)</td>
     </tr>
     <tr>
       <td>connection.options</td>
@@ -205,6 +205,13 @@ Connector Options
            eg. <code>[{"$match": {"closed": "false"}}]</code> ensures that 
            only documents in which the closed field is set to false are copied.
       </td>
+    </tr>
+    <tr>
+      <td>copy.existing.namespace.regex</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">16000</td>
+      <td>String</td>
+      <td>Regular expression that matches the namespaces from which to copy data. A namespace describes the database name and collection separated by a period, e.g. databaseName.collectionName.</td>
     </tr>
     <tr>
       <td>copy.existing.max.threads</td>

--- a/docs/content/connectors/mongodb-cdc.md
+++ b/docs/content/connectors/mongodb-cdc.md
@@ -152,14 +152,14 @@ Connector Options
       <td>required</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Name of the database to watch for changes. If set to empty string, then all databases will be captured (databases can be filtered using the copy.existing.namespace.regex setting).</td>
+      <td>Name of the database to watch for changes. If set to empty string, then all databases will be captured (databases can be filtered using the pipeline setting).</td>
     </tr>
     <tr>
       <td>collection</td>
       <td>required</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Name of the collection in the database to watch for changes. If set to empty string, then all collections will be caputred (collections can be filtered using the copy.existing.namespace.regex setting)</td>
+      <td>Name of the collection in the database to watch for changes. If set to empty string, then all collections will be captured (collections can be filtered using the pipeline setting)</td>
     </tr>
     <tr>
       <td>connection.options</td>
@@ -189,6 +189,13 @@ Connector Options
       <td>Whether details of failed operations should be written to the log file.</td>
     </tr>
     <tr>
+      <td>pipeline</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>An array of JSON objects describing the pipeline operations to run. Example: [{"$match": {"operationType": "insert"}}, {"$addFields": {"Kafka": "Rules!"}}]</td>
+    </tr>
+    <tr>
       <td>copy.existing</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">true</td>
@@ -209,7 +216,7 @@ Connector Options
     <tr>
       <td>copy.existing.namespace.regex</td>
       <td>optional</td>
-      <td style="word-wrap: break-word;">16000</td>
+      <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
       <td>Regular expression that matches the namespaces from which to copy data. A namespace describes the database name and collection separated by a period, e.g. databaseName.collectionName.</td>
     </tr>

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/MongoDBSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/MongoDBSource.java
@@ -133,6 +133,7 @@ public class MongoDBSource {
         private Integer copyExistingMaxThreads;
         private Integer copyExistingQueueSize;
         private String copyExistingPipeline;
+        private String copyExistingNamespaceRegex;
         private Boolean errorsLogEnable;
         private String errorsTolerance;
         private Integer heartbeatIntervalMillis;
@@ -320,6 +321,18 @@ public class MongoDBSource {
             return this;
         }
 
+        /**
+         * copy.existing.namespace.regex
+         *
+         * <p>Regular expression that matches the namespaces from which to copy data. A namespace
+         * describes the database name and collection separated by a period, e.g.
+         * databaseName.collectionName.
+         */
+        public Builder<T> copyExistingNamespaceRegex(String copyExistingNamespaceRegex) {
+            this.copyExistingNamespaceRegex = copyExistingNamespaceRegex;
+            return this;
+        }
+
         /** Build connection uri. */
         private URI buildConnectionUri() {
             String authority = checkNotNull(hosts);
@@ -416,6 +429,12 @@ public class MongoDBSource {
             if (copyExistingPipeline != null) {
                 props.setProperty(
                         MongoSourceConfig.COPY_EXISTING_PIPELINE_CONFIG, copyExistingPipeline);
+            }
+
+            if (copyExistingNamespaceRegex != null) {
+                props.setProperty(
+                        MongoSourceConfig.COPY_EXISTING_NAMESPACE_REGEX_CONFIG,
+                        copyExistingNamespaceRegex);
             }
 
             if (heartbeatIntervalMillis != null) {

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
@@ -55,6 +55,7 @@ public class MongoDBTableSource implements ScanTableSource {
     private final String collection;
     private final Boolean errorsLogEnable;
     private final String errorsTolerance;
+    private final String pipeline;
     private final Boolean copyExisting;
     private final String copyExistingPipeline;
     private final Integer copyExistingMaxThreads;
@@ -75,6 +76,7 @@ public class MongoDBTableSource implements ScanTableSource {
             @Nullable String connectionOptions,
             @Nullable String errorsTolerance,
             @Nullable Boolean errorsLogEnable,
+            @Nullable String pipeline,
             @Nullable Boolean copyExisting,
             @Nullable String copyExistingPipeline,
             @Nullable Integer copyExistingMaxThreads,
@@ -93,6 +95,7 @@ public class MongoDBTableSource implements ScanTableSource {
         this.connectionOptions = connectionOptions;
         this.errorsTolerance = errorsTolerance;
         this.errorsLogEnable = errorsLogEnable;
+        this.pipeline = pipeline;
         this.copyExisting = copyExisting;
         this.copyExistingPipeline = copyExistingPipeline;
         this.copyExistingMaxThreads = copyExistingMaxThreads;
@@ -134,6 +137,7 @@ public class MongoDBTableSource implements ScanTableSource {
         Optional.ofNullable(connectionOptions).ifPresent(builder::connectionOptions);
         Optional.ofNullable(errorsLogEnable).ifPresent(builder::errorsLogEnable);
         Optional.ofNullable(errorsTolerance).ifPresent(builder::errorsTolerance);
+        Optional.ofNullable(pipeline).ifPresent(builder::pipeline);
         Optional.ofNullable(copyExisting).ifPresent(builder::copyExisting);
         Optional.ofNullable(copyExistingPipeline).ifPresent(builder::copyExistingPipeline);
         Optional.ofNullable(copyExistingMaxThreads).ifPresent(builder::copyExistingMaxThreads);
@@ -161,6 +165,7 @@ public class MongoDBTableSource implements ScanTableSource {
                 connectionOptions,
                 errorsTolerance,
                 errorsLogEnable,
+                pipeline,
                 copyExisting,
                 copyExistingPipeline,
                 copyExistingMaxThreads,

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
@@ -63,6 +63,7 @@ public class MongoDBTableSource implements ScanTableSource {
     private final Integer pollAwaitTimeMillis;
     private final Integer heartbeatIntervalMillis;
     private final ZoneId localTimeZone;
+    private final String copyExistingNamespaceRegex;
 
     public MongoDBTableSource(
             TableSchema physicalSchema,
@@ -78,6 +79,7 @@ public class MongoDBTableSource implements ScanTableSource {
             @Nullable String copyExistingPipeline,
             @Nullable Integer copyExistingMaxThreads,
             @Nullable Integer copyExistingQueueSize,
+            @Nullable String copyExistingNamespaceRegex,
             @Nullable Integer pollMaxBatchSize,
             @Nullable Integer pollAwaitTimeMillis,
             @Nullable Integer heartbeatIntervalMillis,
@@ -95,6 +97,7 @@ public class MongoDBTableSource implements ScanTableSource {
         this.copyExistingPipeline = copyExistingPipeline;
         this.copyExistingMaxThreads = copyExistingMaxThreads;
         this.copyExistingQueueSize = copyExistingQueueSize;
+        this.copyExistingNamespaceRegex = copyExistingNamespaceRegex;
         this.pollMaxBatchSize = pollMaxBatchSize;
         this.pollAwaitTimeMillis = pollAwaitTimeMillis;
         this.heartbeatIntervalMillis = heartbeatIntervalMillis;
@@ -135,6 +138,8 @@ public class MongoDBTableSource implements ScanTableSource {
         Optional.ofNullable(copyExistingPipeline).ifPresent(builder::copyExistingPipeline);
         Optional.ofNullable(copyExistingMaxThreads).ifPresent(builder::copyExistingMaxThreads);
         Optional.ofNullable(copyExistingQueueSize).ifPresent(builder::copyExistingQueueSize);
+        Optional.ofNullable(copyExistingNamespaceRegex)
+                .ifPresent(builder::copyExistingNamespaceRegex);
         Optional.ofNullable(pollMaxBatchSize).ifPresent(builder::pollMaxBatchSize);
         Optional.ofNullable(pollAwaitTimeMillis).ifPresent(builder::pollAwaitTimeMillis);
         Optional.ofNullable(heartbeatIntervalMillis).ifPresent(builder::heartbeatIntervalMillis);
@@ -160,6 +165,7 @@ public class MongoDBTableSource implements ScanTableSource {
                 copyExistingPipeline,
                 copyExistingMaxThreads,
                 copyExistingQueueSize,
+                copyExistingNamespaceRegex,
                 pollMaxBatchSize,
                 pollAwaitTimeMillis,
                 heartbeatIntervalMillis,

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
@@ -143,6 +143,15 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
                     .withDescription(
                             "The max size of the queue to use when copying data. Defaults to 16000.");
 
+    private static final ConfigOption<String> COPY_EXISTING_NAMESPACE_REGEX =
+            ConfigOptions.key("copy.existing.namespace.regex")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Regular expression that matches the namespaces from which to copy data. "
+                                    + "A namespace describes the database name and collection separated by a period, "
+                                    + "e.g. databaseName.collectionName.");
+
     private static final ConfigOption<Integer> POLL_MAX_BATCH_SIZE =
             ConfigOptions.key("poll.max.batch.size")
                     .intType()
@@ -201,6 +210,8 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
         String copyExistingPipeline = config.getOptional(COPY_EXISTING_PIPELINE).orElse(null);
         Integer copyExistingMaxThreads = config.getOptional(COPY_EXISTING_MAX_THREADS).orElse(null);
         Integer copyExistingQueueSize = config.getOptional(COPY_EXISTING_QUEUE_SIZE).orElse(null);
+        String copyExistingNamespaceRegex =
+                config.getOptional(COPY_EXISTING_NAMESPACE_REGEX).orElse(null);
 
         String zoneId = context.getConfiguration().get(TableConfigOptions.LOCAL_TIME_ZONE);
         ZoneId localTimeZone =
@@ -227,6 +238,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
                 copyExistingPipeline,
                 copyExistingMaxThreads,
                 copyExistingQueueSize,
+                copyExistingNamespaceRegex,
                 pollMaxBatchSize,
                 pollAwaitTimeMillis,
                 heartbeatIntervalMillis,
@@ -265,6 +277,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
         options.add(COPY_EXISTING_PIPELINE);
         options.add(COPY_EXISTING_MAX_THREADS);
         options.add(COPY_EXISTING_QUEUE_SIZE);
+        options.add(COPY_EXISTING_NAMESPACE_REGEX);
         options.add(POLL_MAX_BATCH_SIZE);
         options.add(POLL_AWAIT_TIME_MILLIS);
         options.add(HEARTBEAT_INTERVAL_MILLIS);

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
@@ -110,6 +110,13 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
                                     + "When set to true, both errors that are tolerated (determined by the errors.tolerance setting) "
                                     + "and not tolerated are written. When set to false, errors that are tolerated are omitted.");
 
+    private static final ConfigOption<String> PIPELINE =
+            ConfigOptions.key("pipeline")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "An array of objects describing the pipeline operations to run.");
+
     private static final ConfigOption<Boolean> COPY_EXISTING =
             ConfigOptions.key("copy.existing")
                     .booleanType()
@@ -206,6 +213,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
         Integer heartbeatIntervalMillis =
                 config.getOptional(HEARTBEAT_INTERVAL_MILLIS).orElse(null);
 
+        String pipeline = config.getOptional(PIPELINE).orElse(null);
         Boolean copyExisting = config.get(COPY_EXISTING);
         String copyExistingPipeline = config.getOptional(COPY_EXISTING_PIPELINE).orElse(null);
         Integer copyExistingMaxThreads = config.getOptional(COPY_EXISTING_MAX_THREADS).orElse(null);
@@ -234,6 +242,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
                 connectionOptions,
                 errorsTolerance,
                 errorsLogEnable,
+                pipeline,
                 copyExisting,
                 copyExistingPipeline,
                 copyExistingMaxThreads,
@@ -273,6 +282,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
         options.add(CONNECTION_OPTIONS);
         options.add(ERRORS_TOLERANCE);
         options.add(ERRORS_LOG_ENABLE);
+        options.add(PIPELINE);
         options.add(COPY_EXISTING);
         options.add(COPY_EXISTING_PIPELINE);
         options.add(COPY_EXISTING_MAX_THREADS);

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
@@ -87,6 +87,7 @@ public class MongoDBTableFactoryTest {
                         null,
                         ERROR_TOLERANCE,
                         ERROR_LOGS_ENABLE,
+                        null,
                         COPY_EXISTING,
                         null,
                         null,
@@ -105,6 +106,9 @@ public class MongoDBTableFactoryTest {
         options.put("connection.options", "replicaSet=test&connectTimeoutMS=300000");
         options.put("errors.tolerance", "all");
         options.put("errors.log.enable", "false");
+        options.put(
+                "pipeline",
+                "[{\"$match\": {\"ns.coll\": {\"$regex\": /^(collection1|collection2)$/}}}]");
         options.put("copy.existing", "false");
         options.put("copy.existing.pipeline", "[ { \"$match\": { \"closed\": \"false\" } } ]");
         options.put("copy.existing.max.threads", "1");
@@ -126,6 +130,7 @@ public class MongoDBTableFactoryTest {
                         "replicaSet=test&connectTimeoutMS=300000",
                         ERROR_TOLERANCE_ALL,
                         false,
+                        "[{\"$match\": {\"ns.coll\": {\"$regex\": /^(collection1|collection2)$/}}}]",
                         false,
                         "[ { \"$match\": { \"closed\": \"false\" } } ]",
                         1,

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
@@ -91,6 +91,7 @@ public class MongoDBTableFactoryTest {
                         null,
                         null,
                         null,
+                        null,
                         POLL_MAX_BATCH_SIZE_DEFAULT,
                         POLL_AWAIT_TIME_MILLIS_DEFAULT,
                         null,
@@ -108,6 +109,7 @@ public class MongoDBTableFactoryTest {
         options.put("copy.existing.pipeline", "[ { \"$match\": { \"closed\": \"false\" } } ]");
         options.put("copy.existing.max.threads", "1");
         options.put("copy.existing.queue.size", "101");
+        options.put("copy.existing.namespace.regex", ".*");
         options.put("poll.max.batch.size", "102");
         options.put("poll.await.time.ms", "103");
         options.put("heartbeat.interval.ms", "104");
@@ -128,6 +130,7 @@ public class MongoDBTableFactoryTest {
                         "[ { \"$match\": { \"closed\": \"false\" } } ]",
                         1,
                         101,
+                        ".*",
                         102,
                         103,
                         104,


### PR DESCRIPTION
Problem: I need to capture data from multiple tenant databases in the same mongodb cluster

The connector already allowed you to capture data from multiple databases/collections, but this was not very useful without the ability to filter. The copy.existing.namespace.regex setting already exists in the kafka source connector and does exactly this. So this PR just exposes the existing setting to the flink connector.
