### PR TITLE
[docs] fix MySQLSource typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ public class MySqlBinlogSourceExample {
   public static void main(String[] args) throws Exception {
     Properties debeziumProperties = new Properties();
     debeziumProperties.put("snapshot.locking.mode", "none");// do not use lock
-    SourceFunction<String> sourceFunction = MySQLSource.<String>builder()
+    SourceFunction<String> sourceFunction = MySqlSource.<String>builder()
             .hostname("yourHostname")
             .port(yourPort)
             .databaseList("yourDatabaseName") // set captured database

--- a/docs/content/about.md
+++ b/docs/content/about.md
@@ -90,7 +90,7 @@ public class MySqlBinlogSourceExample {
   public static void main(String[] args) throws Exception {
     Properties debeziumProperties = new Properties();
     debeziumProperties.put("snapshot.locking.mode", "none");// do not use lock
-    SourceFunction<String> sourceFunction = MySQLSource.<String>builder()
+    SourceFunction<String> sourceFunction = MySqlSource.<String>builder()
         .hostname("yourHostname")
         .port(yourPort)
         .databaseList("yourDatabaseName") // set captured database

--- a/docs/content/connectors/mysql-cdc.md
+++ b/docs/content/connectors/mysql-cdc.md
@@ -393,7 +393,7 @@ public class MySqlBinlogSourceExample {
   public static void main(String[] args) throws Exception {
     Properties debeziumProperties = new Properties();
     debeziumProperties.put("snapshot.locking.mode", "none");// do not use lock
-    SourceFunction<String> sourceFunction = MySQLSource.<String>builder()
+    SourceFunction<String> sourceFunction = MySqlSource.<String>builder()
         .hostname("yourHostname")
         .port(yourPort)
         .databaseList("yourDatabaseName") // set captured database


### PR DESCRIPTION
When cdc version more than 2.0, MySQLSource should replace to MySqlSource. This is a bug left over from the last PR. (https://github.com/ververica/flink-cdc-connectors/pull/440)