### PR TITLE
[mongodb] Support metadata columns for mongodb-cdc connector (#476)

### DIFF
--- a/docs/content/connectors/mongodb-cdc.md
+++ b/docs/content/connectors/mongodb-cdc.md
@@ -248,6 +248,41 @@ Connector Options
 Note: `heartbeat.interval.ms` is highly recommended to set a proper value larger than 0 **if the collection changes slowly**.
 The heartbeat event can pushing the `resumeToken` forward to avoid `resumeToken` being expired when we recover the Flink job from a checkpoint or savepoint.
 
+Available Metadata
+----------------
+
+The following format metadata can be exposed as read-only (VIRTUAL) columns in a table definition.
+
+<div class="highlight">
+<table class="colwidths-auto docutils">
+  <thead>
+     <tr>
+       <th class="text-left" style="width: 15%">Key</th>
+       <th class="text-left" style="width: 30%">DataType</th>
+       <th class="text-left" style="width: 55%">Description</th>
+     </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>database_name</td>
+      <td>STRING NOT NULL</td>
+      <td>Name of the database that contain the row.</td>
+    </tr>
+    <tr>
+      <td>collection_name</td>
+      <td>STRING NOT NULL</td>
+      <td>Name of the collection that contain the row.</td>
+    </tr>
+    <tr>
+      <td>op_ts</td>
+      <td>TIMESTAMP_LTZ(3) NOT NULL</td>
+      <td>It indicates the time that the change was made in the database. <br>If the record is read from snapshot of the table instead of the change stream, the value is always 0.</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+
 Features
 --------
 

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/internal/MongoDBConnectorSourceTask.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/internal/MongoDBConnectorSourceTask.java
@@ -46,8 +46,6 @@ public class MongoDBConnectorSourceTask extends SourceTask {
 
     private static final String TRUE = "true";
 
-    private static final String CLUSTER_TIME_FIELD = "clusterTime";
-
     private final MongoSourceTask target;
 
     private final Field isCopyingField;
@@ -162,8 +160,8 @@ public class MongoDBConnectorSourceTask extends SourceTask {
         // It indicates the time that the change was made in the database. If the record is read
         // from snapshot of the table instead of the change stream, the value is always 0.
         long timestamp = 0L;
-        if (value.schema().field(CLUSTER_TIME_FIELD) != null) {
-            String clusterTime = value.getString(CLUSTER_TIME_FIELD);
+        if (value.schema().field(MongoDBEnvelope.CLUSTER_TIME_FIELD) != null) {
+            String clusterTime = value.getString(MongoDBEnvelope.CLUSTER_TIME_FIELD);
             if (clusterTime != null) {
                 timestamp = new JsonReader(clusterTime).readTimestamp().getTime() * 1000L;
             }

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/internal/MongoDBConnectorSourceTask.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/internal/MongoDBConnectorSourceTask.java
@@ -159,7 +159,9 @@ public class MongoDBConnectorSourceTask extends SourceTask {
     private void markRecordTimestamp(SourceRecord record) {
         final Struct value = (Struct) record.value();
         final Struct source = new Struct(value.schema().field(Envelope.FieldName.SOURCE).schema());
-        long timestamp = System.currentTimeMillis();
+        // It indicates the time that the change was made in the database. If the record is read
+        // from snapshot of the table instead of the change stream, the value is always 0.
+        long timestamp = 0L;
         if (value.schema().field(CLUSTER_TIME_FIELD) != null) {
             String clusterTime = value.getString(CLUSTER_TIME_FIELD);
             if (clusterTime != null) {

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/internal/MongoDBEnvelope.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/internal/MongoDBEnvelope.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mongodb.internal;
+
+/**
+ * An immutable descriptor for the structure of {@link
+ * com.mongodb.client.model.changestream.ChangeStreamDocument} envelopes.
+ */
+public class MongoDBEnvelope {
+
+    public static final String CLUSTER_TIME_FIELD = "clusterTime";
+
+    public static final String FULL_DOCUMENT_FIELD = "fullDocument";
+
+    public static final String DOCUMENT_KEY_FIELD = "documentKey";
+
+    public static final String OPERATION_TYPE_FIELD = "operationType";
+
+    public static final String NAMESPACE_FIELD = "ns";
+
+    public static final String NAMESPACE_DATABASE_FIELD = "db";
+
+    public static final String NAMESPACE_COLLECTION_FIELD = "coll";
+}

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBConnectorDeserializationSchema.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBConnectorDeserializationSchema.java
@@ -36,6 +36,8 @@ import org.apache.flink.util.Collector;
 import com.mongodb.client.model.changestream.OperationType;
 import com.mongodb.internal.HexUtils;
 import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import com.ververica.cdc.debezium.table.AppendMetadataCollector;
+import com.ververica.cdc.debezium.table.MetadataConverter;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -90,14 +92,27 @@ public class MongoDBConnectorDeserializationSchema
 
     /**
      * Runtime converter that converts {@link
-     * com.mongodb.client.model.changestream.ChangeStreamDocument}s into objects of Flink SQL
-     * internal data structures.
+     * com.mongodb.client.model.changestream.ChangeStreamDocument}s into {@link RowData} consisted
+     * of physical column values.
      */
-    private final DeserializationRuntimeConverter runtimeConverter;
+    protected final DeserializationRuntimeConverter physicalConverter;
+
+    /** Whether the deserializer needs to handle metadata columns. */
+    protected final boolean hasMetadata;
+
+    /**
+     * A wrapped output collector which is used to append metadata columns after physical columns.
+     */
+    private final AppendMetadataCollector appendMetadataCollector;
 
     public MongoDBConnectorDeserializationSchema(
-            RowType rowType, TypeInformation<RowData> resultTypeInfo, ZoneId localTimeZone) {
-        this.runtimeConverter = createConverter(rowType);
+            RowType physicalDataType,
+            MetadataConverter[] metadataConverters,
+            TypeInformation<RowData> resultTypeInfo,
+            ZoneId localTimeZone) {
+        this.hasMetadata = checkNotNull(metadataConverters).length > 0;
+        this.appendMetadataCollector = new AppendMetadataCollector(metadataConverters);
+        this.physicalConverter = createConverter(physicalDataType);
         this.resultTypeInfo = resultTypeInfo;
         this.localTimeZone = localTimeZone;
     }
@@ -116,12 +131,12 @@ public class MongoDBConnectorDeserializationSchema
             case INSERT:
                 GenericRowData insert = extractRowData(fullDocument);
                 insert.setRowKind(RowKind.INSERT);
-                out.collect(insert);
+                emit(record, insert, out);
                 break;
             case DELETE:
                 GenericRowData delete = extractRowData(documentKey);
                 delete.setRowKind(RowKind.DELETE);
-                out.collect(delete);
+                emit(record, delete, out);
                 break;
             case UPDATE:
                 // It’s null if another operation deletes the document
@@ -131,12 +146,12 @@ public class MongoDBConnectorDeserializationSchema
                 }
                 GenericRowData updateAfter = extractRowData(fullDocument);
                 updateAfter.setRowKind(RowKind.UPDATE_AFTER);
-                out.collect(updateAfter);
+                emit(record, updateAfter, out);
                 break;
             case REPLACE:
                 GenericRowData replaceAfter = extractRowData(fullDocument);
                 replaceAfter.setRowKind(RowKind.UPDATE_AFTER);
-                out.collect(replaceAfter);
+                emit(record, replaceAfter, out);
                 break;
             case INVALIDATE:
             case DROP:
@@ -150,7 +165,7 @@ public class MongoDBConnectorDeserializationSchema
 
     private GenericRowData extractRowData(BsonDocument document) throws Exception {
         checkNotNull(document);
-        return (GenericRowData) runtimeConverter.convert(document);
+        return (GenericRowData) physicalConverter.convert(document);
     }
 
     private BsonDocument extractBsonDocument(Struct value, Schema valueSchema, String fieldName) {
@@ -171,6 +186,17 @@ public class MongoDBConnectorDeserializationSchema
     private OperationType operationTypeFor(SourceRecord record) {
         Struct value = (Struct) record.value();
         return OperationType.fromString(value.getString(OPERATION_TYPE_FIELD));
+    }
+
+    private void emit(SourceRecord inRecord, RowData physicalRow, Collector<RowData> collector) {
+        if (!hasMetadata) {
+            collector.collect(physicalRow);
+            return;
+        }
+
+        appendMetadataCollector.inputRecord = inRecord;
+        appendMetadataCollector.outputCollector = collector;
+        appendMetadataCollector.collect(physicalRow);
     }
 
     // -------------------------------------------------------------------------------------

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBReadableMetadata.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBReadableMetadata.java
@@ -32,7 +32,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 /** Defines the supported metadata columns for {@link MongoDBTableSource}. */
 public enum MongoDBReadableMetadata {
 
-    /** Name of the collection that contain the row. . */
+    /** Name of the collection that contain the row. */
     COLLECTION(
             "collection_name",
             DataTypes.STRING().notNull(),

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBReadableMetadata.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBReadableMetadata.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mongodb.table;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.DataType;
+
+import com.ververica.cdc.debezium.table.MetadataConverter;
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.data.Envelope;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+/** Defines the supported metadata columns for {@link MongoDBTableSource}. */
+public enum MongoDBReadableMetadata {
+
+    /** Name of the collection that contain the row. . */
+    COLLECTION(
+            "collection_name",
+            DataTypes.STRING().notNull(),
+            new MetadataConverter() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public Object read(SourceRecord record) {
+                    Struct value = (Struct) record.value();
+                    Struct to = value.getStruct("ns");
+                    return StringData.fromString(to.getString("coll"));
+                }
+            }),
+
+    /** Name of the database that contain the row. */
+    DATABASE(
+            "database_name",
+            DataTypes.STRING().notNull(),
+            new MetadataConverter() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public Object read(SourceRecord record) {
+                    Struct value = (Struct) record.value();
+                    Struct to = value.getStruct("ns");
+                    return StringData.fromString(to.getString("db"));
+                }
+            }),
+
+    /**
+     * It indicates the time that the change was made in the database. If the record is read from
+     * snapshot of the table instead of the change stream, the value is always 0.
+     */
+    TIMESTAMP(
+            "op_ts",
+            DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
+            new MetadataConverter() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public Object read(SourceRecord record) {
+                    Struct value = (Struct) record.value();
+                    Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+                    return TimestampData.fromEpochMillis(
+                            (Long) source.get(AbstractSourceInfo.TIMESTAMP_KEY));
+                }
+            });
+
+    private final String key;
+
+    private final DataType dataType;
+
+    private final MetadataConverter converter;
+
+    MongoDBReadableMetadata(String key, DataType dataType, MetadataConverter converter) {
+        this.key = key;
+        this.dataType = dataType;
+        this.converter = converter;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public DataType getDataType() {
+        return dataType;
+    }
+
+    public MetadataConverter getConverter() {
+        return converter;
+    }
+}

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBReadableMetadata.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBReadableMetadata.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
 
+import com.ververica.cdc.connectors.mongodb.internal.MongoDBEnvelope;
 import com.ververica.cdc.debezium.table.MetadataConverter;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.data.Envelope;
@@ -42,8 +43,9 @@ public enum MongoDBReadableMetadata {
                 @Override
                 public Object read(SourceRecord record) {
                     Struct value = (Struct) record.value();
-                    Struct to = value.getStruct("ns");
-                    return StringData.fromString(to.getString("coll"));
+                    Struct to = value.getStruct(MongoDBEnvelope.NAMESPACE_FIELD);
+                    return StringData.fromString(
+                            to.getString(MongoDBEnvelope.NAMESPACE_COLLECTION_FIELD));
                 }
             }),
 
@@ -57,8 +59,9 @@ public enum MongoDBReadableMetadata {
                 @Override
                 public Object read(SourceRecord record) {
                     Struct value = (Struct) record.value();
-                    Struct to = value.getStruct("ns");
-                    return StringData.fromString(to.getString("db"));
+                    Struct to = value.getStruct(MongoDBEnvelope.NAMESPACE_FIELD);
+                    return StringData.fromString(
+                            to.getString(MongoDBEnvelope.NAMESPACE_DATABASE_FIELD));
                 }
             }),
 
@@ -66,7 +69,7 @@ public enum MongoDBReadableMetadata {
      * It indicates the time that the change was made in the database. If the record is read from
      * snapshot of the table instead of the change stream, the value is always 0.
      */
-    TIMESTAMP(
+    OP_TS(
             "op_ts",
             DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
             new MetadataConverter() {

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
@@ -117,7 +117,6 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
         this.pollAwaitTimeMillis = pollAwaitTimeMillis;
         this.heartbeatIntervalMillis = heartbeatIntervalMillis;
         this.localTimeZone = localTimeZone;
-        // Mutable attributes
         this.producedDataType = physicalSchema.toPhysicalRowDataType();
         this.metadataKeys = Collections.emptyList();
     }


### PR DESCRIPTION
We introduced following MongoDB metadata columns in this PR:

#476

Key | DataType | Description
-- | -- | --
database_name | STRING NOT NULL | Name of the database that contain the row.
collection_name | STRING NOT NULL | Name of the collection that contain the row.
op_ts | TIMESTAMP_LTZ(3) NOT NULL | It indicates the time that the change was made in the database. If the record is read from snapshot of the table instead of the change stream, the value is always 0.

