### PR TITLE
[changelog-json] The extension supports the encode.decimal-as-plain-number parameter #issue-527

### DIFF
--- a/flink-format-changelog-json/src/main/java/com/ververica/cdc/formats/json/ChangelogJsonFormatFactory.java
+++ b/flink-format-changelog-json/src/main/java/com/ververica/cdc/formats/json/ChangelogJsonFormatFactory.java
@@ -93,8 +93,6 @@ public class ChangelogJsonFormatFactory
     public EncodingFormat<SerializationSchema<RowData>> createEncodingFormat(
             DynamicTableFactory.Context context, ReadableConfig formatOptions) {
         FactoryUtil.validateFactoryOptions(this, formatOptions);
-        TimestampFormat timestampFormat = JsonOptions.getTimestampFormat(formatOptions);
-        boolean encodeDecimalAsPlainNumber = formatOptions.get(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
 
         return new EncodingFormat<SerializationSchema<RowData>>() {
 
@@ -112,8 +110,7 @@ public class ChangelogJsonFormatFactory
             public SerializationSchema<RowData> createRuntimeEncoder(
                     DynamicTableSink.Context context, DataType consumedDataType) {
                 final RowType rowType = (RowType) consumedDataType.getLogicalType();
-                return new ChangelogJsonSerializationSchema(
-                        rowType, timestampFormat, encodeDecimalAsPlainNumber);
+                return new ChangelogJsonSerializationSchema(rowType, formatOptions);
             }
         };
     }

--- a/flink-format-changelog-json/src/main/java/com/ververica/cdc/formats/json/ChangelogJsonFormatFactory.java
+++ b/flink-format-changelog-json/src/main/java/com/ververica/cdc/formats/json/ChangelogJsonFormatFactory.java
@@ -56,6 +56,8 @@ public class ChangelogJsonFormatFactory
 
     public static final ConfigOption<String> TIMESTAMP_FORMAT = JsonOptions.TIMESTAMP_FORMAT;
 
+    public static final ConfigOption<Boolean> ENCODE_DECIMAL_AS_PLAIN_NUMBER = JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
+
     @Override
     public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
             DynamicTableFactory.Context context, ReadableConfig formatOptions) {
@@ -91,6 +93,7 @@ public class ChangelogJsonFormatFactory
             DynamicTableFactory.Context context, ReadableConfig formatOptions) {
         FactoryUtil.validateFactoryOptions(this, formatOptions);
         TimestampFormat timestampFormat = JsonOptions.getTimestampFormat(formatOptions);
+        boolean encodeDecimalAsPlainNumber = formatOptions.get(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
 
         return new EncodingFormat<SerializationSchema<RowData>>() {
 
@@ -108,7 +111,7 @@ public class ChangelogJsonFormatFactory
             public SerializationSchema<RowData> createRuntimeEncoder(
                     DynamicTableSink.Context context, DataType consumedDataType) {
                 final RowType rowType = (RowType) consumedDataType.getLogicalType();
-                return new ChangelogJsonSerializationSchema(rowType, timestampFormat);
+                return new ChangelogJsonSerializationSchema(rowType, timestampFormat, encodeDecimalAsPlainNumber);
             }
         };
     }
@@ -128,6 +131,7 @@ public class ChangelogJsonFormatFactory
         Set<ConfigOption<?>> options = new HashSet<>();
         options.add(IGNORE_PARSE_ERRORS);
         options.add(TIMESTAMP_FORMAT);
+        options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
         return options;
     }
 }

--- a/flink-format-changelog-json/src/main/java/com/ververica/cdc/formats/json/ChangelogJsonFormatFactory.java
+++ b/flink-format-changelog-json/src/main/java/com/ververica/cdc/formats/json/ChangelogJsonFormatFactory.java
@@ -56,7 +56,8 @@ public class ChangelogJsonFormatFactory
 
     public static final ConfigOption<String> TIMESTAMP_FORMAT = JsonOptions.TIMESTAMP_FORMAT;
 
-    public static final ConfigOption<Boolean> ENCODE_DECIMAL_AS_PLAIN_NUMBER = JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
+    public static final ConfigOption<Boolean> ENCODE_DECIMAL_AS_PLAIN_NUMBER =
+            JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
 
     @Override
     public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
@@ -111,7 +112,8 @@ public class ChangelogJsonFormatFactory
             public SerializationSchema<RowData> createRuntimeEncoder(
                     DynamicTableSink.Context context, DataType consumedDataType) {
                 final RowType rowType = (RowType) consumedDataType.getLogicalType();
-                return new ChangelogJsonSerializationSchema(rowType, timestampFormat, encodeDecimalAsPlainNumber);
+                return new ChangelogJsonSerializationSchema(
+                        rowType, timestampFormat, encodeDecimalAsPlainNumber);
             }
         };
     }

--- a/flink-format-changelog-json/src/main/java/com/ververica/cdc/formats/json/ChangelogJsonSerializationSchema.java
+++ b/flink-format-changelog-json/src/main/java/com/ververica/cdc/formats/json/ChangelogJsonSerializationSchema.java
@@ -53,14 +53,14 @@ public class ChangelogJsonSerializationSchema implements SerializationSchema<Row
 
     private transient GenericRowData reuse;
 
-    public ChangelogJsonSerializationSchema(RowType rowType, TimestampFormat timestampFormat) {
+    public ChangelogJsonSerializationSchema(RowType rowType, TimestampFormat timestampFormat, boolean encodeDecimalAsPlainNumber) {
         this.jsonSerializer =
                 new JsonRowDataSerializationSchema(
                         createJsonRowType(fromLogicalToDataType(rowType)),
                         timestampFormat,
                         JsonOptions.MapNullKeyMode.FAIL,
                         JsonOptions.MAP_NULL_KEY_LITERAL.defaultValue(),
-                        JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.defaultValue());
+                        encodeDecimalAsPlainNumber);
         this.timestampFormat = timestampFormat;
     }
 

--- a/flink-format-changelog-json/src/main/java/com/ververica/cdc/formats/json/ChangelogJsonSerializationSchema.java
+++ b/flink-format-changelog-json/src/main/java/com/ververica/cdc/formats/json/ChangelogJsonSerializationSchema.java
@@ -53,7 +53,8 @@ public class ChangelogJsonSerializationSchema implements SerializationSchema<Row
 
     private transient GenericRowData reuse;
 
-    public ChangelogJsonSerializationSchema(RowType rowType, TimestampFormat timestampFormat, boolean encodeDecimalAsPlainNumber) {
+    public ChangelogJsonSerializationSchema(
+            RowType rowType, TimestampFormat timestampFormat, boolean encodeDecimalAsPlainNumber) {
         this.jsonSerializer =
                 new JsonRowDataSerializationSchema(
                         createJsonRowType(fromLogicalToDataType(rowType)),

--- a/flink-format-changelog-json/src/main/java/com/ververica/cdc/formats/json/ChangelogJsonSerializationSchema.java
+++ b/flink-format-changelog-json/src/main/java/com/ververica/cdc/formats/json/ChangelogJsonSerializationSchema.java
@@ -19,6 +19,7 @@
 package com.ververica.cdc.formats.json;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.formats.common.TimestampFormat;
 import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.formats.json.JsonRowDataSerializationSchema;
@@ -32,6 +33,7 @@ import org.apache.flink.types.RowKind;
 
 import java.util.Objects;
 
+import static com.ververica.cdc.formats.json.ChangelogJsonFormatFactory.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
 
 /**
@@ -53,15 +55,16 @@ public class ChangelogJsonSerializationSchema implements SerializationSchema<Row
 
     private transient GenericRowData reuse;
 
-    public ChangelogJsonSerializationSchema(
-            RowType rowType, TimestampFormat timestampFormat, boolean encodeDecimalAsPlainNumber) {
+    public ChangelogJsonSerializationSchema(RowType rowType, ReadableConfig formatOptions) {
+        TimestampFormat timestampFormat = JsonOptions.getTimestampFormat(formatOptions);
+
         this.jsonSerializer =
                 new JsonRowDataSerializationSchema(
                         createJsonRowType(fromLogicalToDataType(rowType)),
                         timestampFormat,
                         JsonOptions.MapNullKeyMode.FAIL,
                         JsonOptions.MAP_NULL_KEY_LITERAL.defaultValue(),
-                        encodeDecimalAsPlainNumber);
+                        formatOptions.get(ENCODE_DECIMAL_AS_PLAIN_NUMBER));
         this.timestampFormat = timestampFormat;
     }
 

--- a/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonFormatFactoryTest.java
+++ b/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonFormatFactoryTest.java
@@ -76,11 +76,13 @@ public class ChangelogJsonFormatFactoryTest extends TestLogger {
         final ChangelogJsonDeserializationSchema expectedDeser =
                 new ChangelogJsonDeserializationSchema(
                         ROW_TYPE, InternalTypeInfo.of(ROW_TYPE), true, TimestampFormat.ISO_8601);
+
+        Configuration formatOptions = new Configuration();
+        formatOptions.setString(JsonOptions.TIMESTAMP_FORMAT.key(), JsonOptions.ISO_8601);
+        formatOptions.setBoolean(JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.key(), false);
+
         final ChangelogJsonSerializationSchema expectedSer =
-                new ChangelogJsonSerializationSchema(
-                        ROW_TYPE,
-                        TimestampFormat.ISO_8601,
-                        JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.defaultValue());
+                new ChangelogJsonSerializationSchema(ROW_TYPE, formatOptions);
 
         final Map<String, String> options = getAllOptions();
 

--- a/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonFormatFactoryTest.java
+++ b/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonFormatFactoryTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.Column;
@@ -76,7 +77,7 @@ public class ChangelogJsonFormatFactoryTest extends TestLogger {
                 new ChangelogJsonDeserializationSchema(
                         ROW_TYPE, InternalTypeInfo.of(ROW_TYPE), true, TimestampFormat.ISO_8601);
         final ChangelogJsonSerializationSchema expectedSer =
-                new ChangelogJsonSerializationSchema(ROW_TYPE, TimestampFormat.ISO_8601);
+                new ChangelogJsonSerializationSchema(ROW_TYPE, TimestampFormat.ISO_8601, JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.defaultValue());
 
         final Map<String, String> options = getAllOptions();
 

--- a/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonFormatFactoryTest.java
+++ b/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonFormatFactoryTest.java
@@ -77,7 +77,10 @@ public class ChangelogJsonFormatFactoryTest extends TestLogger {
                 new ChangelogJsonDeserializationSchema(
                         ROW_TYPE, InternalTypeInfo.of(ROW_TYPE), true, TimestampFormat.ISO_8601);
         final ChangelogJsonSerializationSchema expectedSer =
-                new ChangelogJsonSerializationSchema(ROW_TYPE, TimestampFormat.ISO_8601, JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.defaultValue());
+                new ChangelogJsonSerializationSchema(
+                        ROW_TYPE,
+                        TimestampFormat.ISO_8601,
+                        JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.defaultValue());
 
         final Map<String, String> options = getAllOptions();
 

--- a/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonSerDeDecimalTest.java
+++ b/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonSerDeDecimalTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.formats.json;
+
+import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Collector;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.api.DataTypes.DECIMAL;
+import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.apache.flink.table.api.DataTypes.FLOAT;
+import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link ChangelogJsonSerializationSchema} and {@link
+ * ChangelogJsonDeserializationSchema}.
+ */
+public class ChangelogJsonSerDeDecimalTest {
+
+    private static final RowType SCHEMA =
+            (RowType)
+                    ROW(
+                                    FIELD("id", INT().notNull()),
+                                    FIELD("name", STRING()),
+                                    FIELD("money", DECIMAL(20, 2)))
+                            .getLogicalType();
+
+    @Test
+    public void testDecimalSerializationDeserialization() throws Exception {
+        List<String> lines = readLines("changelog-json-data2.txt");
+        ChangelogJsonDeserializationSchema deserializationSchema =
+                new ChangelogJsonDeserializationSchema(
+                        SCHEMA, InternalTypeInfo.of(SCHEMA), false, TimestampFormat.SQL);
+
+        deserializationSchema.open(null);
+        SimpleCollector collector = new SimpleCollector();
+        for (String line : lines) {
+            deserializationSchema.deserialize(line.getBytes(StandardCharsets.UTF_8), collector);
+        }
+
+        List<String> expected = Arrays.asList(
+                "+I(112,liaooo,10.00)",
+                "-U(112,liaooo,10.00)",
+                "+U(112,liaooo,1000000.00)",
+                "-U(112,liaooo,1000000.00)",
+                "+U(112,liaooo,9999999.50)");
+        List<String> actual = collector.list.stream().map(Object::toString).collect(Collectors.toList());
+        assertEquals(expected, actual);
+
+        // decimal字段会启用科学记数法
+        ChangelogJsonSerializationSchema serializationSchema =
+                new ChangelogJsonSerializationSchema(SCHEMA, TimestampFormat.SQL, false);
+        serializationSchema.open(null);
+        List<String> result = new ArrayList<>();
+        for (RowData rowData : collector.list) {
+            result.add(new String(serializationSchema.serialize(rowData), StandardCharsets.UTF_8));
+        }
+        List<String> expectedResult =
+                Arrays.asList(
+                        "{\"data\":{\"id\":112,\"name\":\"liaooo\",\"money\":1E+1},\"op\":\"+I\"}",
+                        "{\"data\":{\"id\":112,\"name\":\"liaooo\",\"money\":1E+1},\"op\":\"-U\"}",
+                        "{\"data\":{\"id\":112,\"name\":\"liaooo\",\"money\":1E+6},\"op\":\"+U\"}",
+                        "{\"data\":{\"id\":112,\"name\":\"liaooo\",\"money\":1E+6},\"op\":\"-U\"}",
+                        "{\"data\":{\"id\":112,\"name\":\"liaooo\",\"money\":9999999.5},\"op\":\"+U\"}");
+        assertEquals(expectedResult, result);
+
+        // 使decimal字段以plain形式展示
+        ChangelogJsonSerializationSchema serializationSchema2 =
+                new ChangelogJsonSerializationSchema(SCHEMA, TimestampFormat.SQL, true);
+        serializationSchema2.open(null);
+        List<String> result2 = new ArrayList<>();
+        for (RowData rowData : collector.list) {
+            result2.add(new String(serializationSchema2.serialize(rowData), StandardCharsets.UTF_8));
+        }
+        List<String> expectedResult2 =
+                Arrays.asList(
+                        "{\"data\":{\"id\":112,\"name\":\"liaooo\",\"money\":10},\"op\":\"+I\"}",
+                        "{\"data\":{\"id\":112,\"name\":\"liaooo\",\"money\":10},\"op\":\"-U\"}",
+                        "{\"data\":{\"id\":112,\"name\":\"liaooo\",\"money\":1000000},\"op\":\"+U\"}",
+                        "{\"data\":{\"id\":112,\"name\":\"liaooo\",\"money\":1000000},\"op\":\"-U\"}",
+                        "{\"data\":{\"id\":112,\"name\":\"liaooo\",\"money\":9999999.5},\"op\":\"+U\"}");
+        assertEquals(expectedResult2, result2);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Utilities
+    // --------------------------------------------------------------------------------------------
+
+    private static List<String> readLines(String resource) throws IOException {
+        final URL url = ChangelogJsonSerDeDecimalTest.class.getClassLoader().getResource(resource);
+        assert url != null;
+        Path path = new File(url.getFile()).toPath();
+        return Files.readAllLines(path);
+    }
+
+    private static class SimpleCollector implements Collector<RowData> {
+
+        private List<RowData> list = new ArrayList<>();
+
+        @Override
+        public void collect(RowData record) {
+            list.add(record);
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
+    }
+}

--- a/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonSerDeDecimalTest.java
+++ b/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonSerDeDecimalTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Collector;
+
 import org.junit.Test;
 
 import java.io.File;
@@ -38,7 +39,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.table.api.DataTypes.DECIMAL;
 import static org.apache.flink.table.api.DataTypes.FIELD;
-import static org.apache.flink.table.api.DataTypes.FLOAT;
 import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.STRING;
@@ -71,13 +71,15 @@ public class ChangelogJsonSerDeDecimalTest {
             deserializationSchema.deserialize(line.getBytes(StandardCharsets.UTF_8), collector);
         }
 
-        List<String> expected = Arrays.asList(
-                "+I(112,liaooo,10.00)",
-                "-U(112,liaooo,10.00)",
-                "+U(112,liaooo,1000000.00)",
-                "-U(112,liaooo,1000000.00)",
-                "+U(112,liaooo,9999999.50)");
-        List<String> actual = collector.list.stream().map(Object::toString).collect(Collectors.toList());
+        List<String> expected =
+                Arrays.asList(
+                        "+I(112,liaooo,10.00)",
+                        "-U(112,liaooo,10.00)",
+                        "+U(112,liaooo,1000000.00)",
+                        "-U(112,liaooo,1000000.00)",
+                        "+U(112,liaooo,9999999.50)");
+        List<String> actual =
+                collector.list.stream().map(Object::toString).collect(Collectors.toList());
         assertEquals(expected, actual);
 
         // decimal字段会启用科学记数法
@@ -103,7 +105,8 @@ public class ChangelogJsonSerDeDecimalTest {
         serializationSchema2.open(null);
         List<String> result2 = new ArrayList<>();
         for (RowData rowData : collector.list) {
-            result2.add(new String(serializationSchema2.serialize(rowData), StandardCharsets.UTF_8));
+            result2.add(
+                    new String(serializationSchema2.serialize(rowData), StandardCharsets.UTF_8));
         }
         List<String> expectedResult2 =
                 Arrays.asList(

--- a/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonSerDeDecimalTest.java
+++ b/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonSerDeDecimalTest.java
@@ -18,7 +18,9 @@
 
 package com.ververica.cdc.formats.json;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
@@ -82,9 +84,13 @@ public class ChangelogJsonSerDeDecimalTest {
                 collector.list.stream().map(Object::toString).collect(Collectors.toList());
         assertEquals(expected, actual);
 
+        Configuration formatOptions = new Configuration();
+        formatOptions.setString(JsonOptions.TIMESTAMP_FORMAT.key(), JsonOptions.SQL);
+        formatOptions.setBoolean(JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.key(), false);
+
         // decimal字段会启用科学记数法
         ChangelogJsonSerializationSchema serializationSchema =
-                new ChangelogJsonSerializationSchema(SCHEMA, TimestampFormat.SQL, false);
+                new ChangelogJsonSerializationSchema(SCHEMA, formatOptions);
         serializationSchema.open(null);
         List<String> result = new ArrayList<>();
         for (RowData rowData : collector.list) {
@@ -100,8 +106,9 @@ public class ChangelogJsonSerDeDecimalTest {
         assertEquals(expectedResult, result);
 
         // 使decimal字段以plain形式展示
+        formatOptions.setBoolean(JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.key(), true);
         ChangelogJsonSerializationSchema serializationSchema2 =
-                new ChangelogJsonSerializationSchema(SCHEMA, TimestampFormat.SQL, true);
+                new ChangelogJsonSerializationSchema(SCHEMA, formatOptions);
         serializationSchema2.open(null);
         List<String> result2 = new ArrayList<>();
         for (RowData rowData : collector.list) {

--- a/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonSerDeTest.java
+++ b/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonSerDeTest.java
@@ -19,6 +19,7 @@
 package com.ververica.cdc.formats.json;
 
 import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
@@ -126,7 +127,7 @@ public class ChangelogJsonSerDeTest {
         assertEquals(expected, actual);
 
         ChangelogJsonSerializationSchema serializationSchema =
-                new ChangelogJsonSerializationSchema(SCHEMA, TimestampFormat.SQL);
+                new ChangelogJsonSerializationSchema(SCHEMA, TimestampFormat.SQL, JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.defaultValue());
         serializationSchema.open(null);
         List<String> result = new ArrayList<>();
         for (RowData rowData : collector.list) {

--- a/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonSerDeTest.java
+++ b/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonSerDeTest.java
@@ -127,7 +127,10 @@ public class ChangelogJsonSerDeTest {
         assertEquals(expected, actual);
 
         ChangelogJsonSerializationSchema serializationSchema =
-                new ChangelogJsonSerializationSchema(SCHEMA, TimestampFormat.SQL, JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.defaultValue());
+                new ChangelogJsonSerializationSchema(
+                        SCHEMA,
+                        TimestampFormat.SQL,
+                        JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.defaultValue());
         serializationSchema.open(null);
         List<String> result = new ArrayList<>();
         for (RowData rowData : collector.list) {

--- a/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonSerDeTest.java
+++ b/flink-format-changelog-json/src/test/java/com/ververica/cdc/formats/json/ChangelogJsonSerDeTest.java
@@ -18,6 +18,7 @@
 
 package com.ververica.cdc.formats.json;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.formats.common.TimestampFormat;
 import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.table.data.RowData;
@@ -126,11 +127,12 @@ public class ChangelogJsonSerDeTest {
                 collector.list.stream().map(Object::toString).collect(Collectors.toList());
         assertEquals(expected, actual);
 
+        Configuration formatOptions = new Configuration();
+        formatOptions.setString(JsonOptions.TIMESTAMP_FORMAT.key(), JsonOptions.SQL);
+        formatOptions.setBoolean(JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.key(), false);
+
         ChangelogJsonSerializationSchema serializationSchema =
-                new ChangelogJsonSerializationSchema(
-                        SCHEMA,
-                        TimestampFormat.SQL,
-                        JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER.defaultValue());
+                new ChangelogJsonSerializationSchema(SCHEMA, formatOptions);
         serializationSchema.open(null);
         List<String> result = new ArrayList<>();
         for (RowData rowData : collector.list) {

--- a/flink-format-changelog-json/src/test/resources/changelog-json-data2.txt
+++ b/flink-format-changelog-json/src/test/resources/changelog-json-data2.txt
@@ -1,4 +1,4 @@
-{"data":{"id":112,"name":"liaooo","money":10.00},"op":"+I"}
+{"data":{"id":112,"name":"liaooo","money":1E+1},"op":"+I"}
 {"data":{"id":112,"name":"liaooo","money":10.00},"op":"-U"}
 {"data":{"id":112,"name":"liaooo","money":1000000.00},"op":"+U"}
 {"data":{"id":112,"name":"liaooo","money":1000000.00},"op":"-U"}

--- a/flink-format-changelog-json/src/test/resources/changelog-json-data2.txt
+++ b/flink-format-changelog-json/src/test/resources/changelog-json-data2.txt
@@ -1,0 +1,5 @@
+{"data":{"id":112,"name":"liaooo","money":10.00},"op":"+I"}
+{"data":{"id":112,"name":"liaooo","money":10.00},"op":"-U"}
+{"data":{"id":112,"name":"liaooo","money":1000000.00},"op":"+U"}
+{"data":{"id":112,"name":"liaooo","money":1000000.00},"op":"-U"}
+{"data":{"id":112,"name":"liaooo","money":9999999.50},"op":"+U"}


### PR DESCRIPTION
将changelog-json内部依赖的flink-json，创建JsonRowDataSerializationSchema实例时使用了encode.decimal-as-plain-number默认值。本次修改使该选项放开到changelog-json的选项可配置，以解决在使用了Decimal类型字段场景中会序列化为科学计数法的问题。