### PR TITLE
[hotfix][docs] fix wrong kibana url in oracle-docs

### DIFF
--- a/docs/content/quickstart/oracle-tutorial.md
+++ b/docs/content/quickstart/oracle-tutorial.md
@@ -124,7 +124,7 @@ Flink SQL> INSERT INTO enriched_orders
 
 **4. Check result in Elasticsearch**
 
-Check the data has been written to Elasticsearch successfully, you can visit [Kibana](http://localhost:8081/#/overview) to see the data.
+Check the data has been written to Elasticsearch successfully, you can visit [Kibana](http://localhost:5601/) to see the data.
 
 **5. Make changes in Oracle and watch result in Elasticsearch**
 

--- a/docs/content/快速上手/oracle-tutorial-zh.md
+++ b/docs/content/快速上手/oracle-tutorial-zh.md
@@ -122,7 +122,7 @@ Flink SQL> INSERT INTO enriched_orders
 
 **4. 检查 ElasticSearch 中的结果**
 
-检查最终的结果是否写入ElasticSearch中, 可以在[Kibana](http://localhost:8081/#/overview)看到ElasticSearch中的数据
+检查最终的结果是否写入ElasticSearch中, 可以在[Kibana](http://localhost:5601/)看到ElasticSearch中的数据
 
 **5. 在 Oracle 制造一些变更，观察 ElasticSearch 中的结果**
 


### PR DESCRIPTION
in the oracle quick start docs, kibana's  url use the  wrong url, correct it with the right url