### PR TITLE
[common] Bump debeizum version to 1.5.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@ under the License.
 
     <properties>
         <flink.version>1.13.1</flink.version>
-        <debezium.version>1.5.2.Final</debezium.version>
+        <debezium.version>1.5.4.Final</debezium.version>
         <geometry.version>2.2.0</geometry.version>
         <testcontainers.version>1.15.1</testcontainers.version>
         <java.version>1.8</java.version>


### PR DESCRIPTION
There are some critical bug fix in the new debezium version, e.g. [DBZ-3068](https://issues.redhat.com/browse/DBZ-3068). 