### PR TITLE
[tests] Upgrade testcontainers dependency to 1.16.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@ under the License.
         <flink.version>1.13.1</flink.version>
         <debezium.version>1.5.4.Final</debezium.version>
         <geometry.version>2.2.0</geometry.version>
-        <testcontainers.version>1.15.1</testcontainers.version>
+        <testcontainers.version>1.16.2</testcontainers.version>
         <java.version>1.8</java.version>
         <scala.binary.version>2.11</scala.binary.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
* Upgrade the testcontainers dependency from 1.15.1 to 1.16.2. This newer version should be quicker and also includes support for Oracle XE