### PR TITLE
[hotfix][mongodb] Correct the connection uri building of MongoDB

### DIFF
--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/MongoDBTestBase.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/MongoDBTestBase.java
@@ -52,7 +52,7 @@ public class MongoDBTestBase extends AbstractTestBase {
     private static final Pattern COMMENT_PATTERN = Pattern.compile("^(.*)//.*$");
 
     protected static final String FLINK_USER = "flinkuser";
-    protected static final String FLINK_USER_PASSWORD = "flinkpw";
+    protected static final String FLINK_USER_PASSWORD = "a1?~!@#$%^&*(){}[]<>.,+_-=/|:;";
 
     protected static final String MONGO_SUPER_USER = "superuser";
     protected static final String MONGO_SUPER_PASSWORD = "superpw";

--- a/flink-connector-mongodb-cdc/src/test/resources/ddl/setup.js
+++ b/flink-connector-mongodb-cdc/src/test/resources/ddl/setup.js
@@ -36,7 +36,7 @@ if (db.system.users.find({user:'flinkuser'}).count() == 0) {
   db.createUser(
    {
      user: 'flinkuser',
-     pwd: 'flinkpw',
+     pwd: 'a1?~!@#$%^&*(){}[]<>.,+_-=/|:;',
      roles: [
         { role: 'read', db: 'admin' },
         { role: 'readAnyDatabase', db: 'admin' }


### PR DESCRIPTION
Fix the username or password contains `: / ? # [ ] @` authentication failed problem.
Cause URI encoded `authority` twice.