### PR TITLE
[docs] Fix oracle DATE type mapping

### DIFF
--- a/docs/content/connectors/oracle-cdc.md
+++ b/docs/content/connectors/oracle-cdc.md
@@ -353,11 +353,10 @@ Data Type Mapping
       <td>BOOLEAN</td>
     </tr>
     <tr>
-      <td>DATE</td>
-      <td>DATE</td>
-    </tr>
-    <tr>
-      <td>TIMESTAMP [(p)]</td>
+      <td>
+        DATE<br>
+        TIMESTAMP [(p)]
+      </td>
       <td>TIMESTAMP [(p)] [WITHOUT TIMEZONE]</td>
     </tr>
     <tr>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36807946/140478328-b95d1ec3-2d1b-4ea6-b174-563aebeec632.png)
Oracle's DATE type is actually a datetime type, which should be mapped to flink's TIMESTAMP type.