### PR TITLE
[tests] Upgrade testcontainers dependency to 1.16.2

### DIFF
--- a/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/OracleSourceTest.java
+++ b/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/OracleSourceTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.util.Collector;
 import org.apache.flink.util.Preconditions;
 
 import com.jayway.jsonpath.JsonPath;
+import com.ververica.cdc.connectors.oracle.utils.OracleCdcContainer;
 import com.ververica.cdc.connectors.oracle.utils.OracleTestUtils;
 import com.ververica.cdc.connectors.utils.TestSourceContext;
 import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
@@ -46,7 +47,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.lifecycle.Startables;
 
@@ -78,7 +78,7 @@ public class OracleSourceTest extends AbstractTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(OracleSourceTest.class);
 
-    private OracleContainer oracleContainer =
+    private OracleCdcContainer oracleContainer =
             OracleTestUtils.ORACLE_CONTAINER.withLogConsumer(new Slf4jLogConsumer(LOG));
 
     @Before
@@ -579,7 +579,8 @@ public class OracleSourceTest extends AbstractTestBase {
         return basicSourceBuilder(oracleContainer).build();
     }
 
-    private OracleSource.Builder<SourceRecord> basicSourceBuilder(OracleContainer oracleContainer) {
+    private OracleSource.Builder<SourceRecord> basicSourceBuilder(
+            OracleCdcContainer oracleContainer) {
 
         return OracleSource.<SourceRecord>builder()
                 .hostname(oracleContainer.getHost())

--- a/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/table/OracleConnectorITCase.java
+++ b/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/table/OracleConnectorITCase.java
@@ -25,13 +25,13 @@ import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.test.util.AbstractTestBase;
 
+import com.ververica.cdc.connectors.oracle.utils.OracleCdcContainer;
 import com.ververica.cdc.connectors.oracle.utils.OracleTestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.lifecycle.Startables;
 
@@ -54,7 +54,7 @@ public class OracleConnectorITCase extends AbstractTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(OracleConnectorITCase.class);
 
-    private OracleContainer oracleContainer =
+    private OracleCdcContainer oracleContainer =
             OracleTestUtils.ORACLE_CONTAINER.withLogConsumer(new Slf4jLogConsumer(LOG));
 
     private final StreamExecutionEnvironment env =

--- a/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/utils/OracleCdcContainer.java
+++ b/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/utils/OracleCdcContainer.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.oracle.utils;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+/**
+ * Docker container for Oracle. The difference between this class and {@link
+ * org.testcontainers.containers.OracleContainer} is that TC OracleContainer has problems when using
+ * base docker image "wnameless/oracle-xe-11g-r2" (can't find log output "DATABASE IS READY TO
+ * USE!").
+ */
+public class OracleCdcContainer extends JdbcDatabaseContainer<OracleCdcContainer> {
+
+    public static final String NAME = "oracle";
+
+    private static final ImageFromDockerfile ORACLE_IMAGE =
+            new ImageFromDockerfile("oracle-xe-11g-tmp")
+                    .withFileFromClasspath(".", "docker")
+                    .withFileFromClasspath(
+                            "assets/activate-archivelog.sh", "docker/assets/activate-archivelog.sh")
+                    .withFileFromClasspath(
+                            "assets/activate-archivelog.sql",
+                            "docker/assets/activate-archivelog.sql");
+
+    private static final int ORACLE_PORT = 1521;
+    private static final int APEX_HTTP_PORT = 8080;
+
+    private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 240;
+    private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 120;
+
+    private String username = "system";
+    private String password = "oracle";
+
+    public OracleCdcContainer() {
+        super(ORACLE_IMAGE);
+        preconfigure();
+    }
+
+    private void preconfigure() {
+        withStartupTimeoutSeconds(DEFAULT_STARTUP_TIMEOUT_SECONDS);
+        withConnectTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS);
+        addExposedPorts(ORACLE_PORT, APEX_HTTP_PORT);
+    }
+
+    @Override
+    protected Integer getLivenessCheckPort() {
+        return getMappedPort(ORACLE_PORT);
+    }
+
+    @Override
+    public String getDriverClassName() {
+        return "oracle.jdbc.OracleDriver";
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return "jdbc:oracle:thin:"
+                + getUsername()
+                + "/"
+                + getPassword()
+                + "@"
+                + getHost()
+                + ":"
+                + getOraclePort()
+                + ":"
+                + getSid();
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public OracleCdcContainer withUsername(String username) {
+        this.username = username;
+        return self();
+    }
+
+    @Override
+    public OracleCdcContainer withPassword(String password) {
+        this.password = password;
+        return self();
+    }
+
+    @Override
+    public OracleCdcContainer withUrlParam(String paramName, String paramValue) {
+        throw new UnsupportedOperationException("The OracleDb does not support this");
+    }
+
+    @SuppressWarnings("SameReturnValue")
+    public String getSid() {
+        return "xe";
+    }
+
+    public Integer getOraclePort() {
+        return getMappedPort(ORACLE_PORT);
+    }
+
+    @SuppressWarnings("unused")
+    public Integer getWebPort() {
+        return getMappedPort(APEX_HTTP_PORT);
+    }
+
+    @Override
+    public String getTestQueryString() {
+        return "SELECT 1 FROM DUAL";
+    }
+}

--- a/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/utils/OracleTestUtils.java
+++ b/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/utils/OracleTestUtils.java
@@ -18,34 +18,19 @@
 
 package com.ververica.cdc.connectors.oracle.utils;
 
-import org.testcontainers.containers.OracleContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.images.builder.ImageFromDockerfile;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
 /** Utility class for oracle tests. */
 public class OracleTestUtils {
-    public static final OracleContainer ORACLE_CONTAINER =
-            new OracleContainer(
-                            new ImageFromDockerfile("oracle-xe-11g-tmp")
-                                    .withFileFromClasspath(".", "docker")
-                                    .withFileFromClasspath(
-                                            "assets/activate-archivelog.sh",
-                                            "docker/assets/activate-archivelog.sh")
-                                    .withFileFromClasspath(
-                                            "assets/activate-archivelog.sql",
-                                            "docker/assets/activate-archivelog.sql"))
-                    // override waitStrategy to adapt for wnameless/oracle-xe-11g-r2
-                    .waitingFor(Wait.defaultWaitStrategy());
+    public static final OracleCdcContainer ORACLE_CONTAINER = new OracleCdcContainer();
 
     public static final String ORACLE_USER = "dbzuser";
 
     public static final String ORACLE_PWD = "dbz";
 
-    public static Connection getJdbcConnection(OracleContainer oracleContainer)
+    public static Connection getJdbcConnection(OracleCdcContainer oracleContainer)
             throws SQLException {
         return DriverManager.getConnection(oracleContainer.getJdbcUrl(), ORACLE_USER, ORACLE_PWD);
     }

--- a/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/utils/OracleTestUtils.java
+++ b/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/utils/OracleTestUtils.java
@@ -19,14 +19,12 @@
 package com.ververica.cdc.connectors.oracle.utils;
 
 import org.testcontainers.containers.OracleContainer;
-import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 
 /** Utility class for oracle tests. */
 public class OracleTestUtils {
@@ -41,13 +39,7 @@ public class OracleTestUtils {
                                             "assets/activate-archivelog.sql",
                                             "docker/assets/activate-archivelog.sql"))
                     // override waitStrategy to adapt for wnameless/oracle-xe-11g-r2
-                    // see the output of wnameless/oracle-xe-11g-r2:
-                    // https://github.com/wnameless/docker-oracle-xe-11g/blob/master/assets/startup.sh#L43
-                    .waitingFor(
-                            new LogMessageWaitStrategy()
-                                    .withRegEx(".*DATABASE IS READY TO USE!.*")
-                                    .withTimes(1)
-                                    .withStartupTimeout(Duration.of(240L, ChronoUnit.SECONDS)));
+                    .waitingFor(Wait.defaultWaitStrategy());
 
     public static final String ORACLE_USER = "dbzuser";
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@ under the License.
         <flink.version>1.13.1</flink.version>
         <debezium.version>1.5.4.Final</debezium.version>
         <geometry.version>2.2.0</geometry.version>
-        <testcontainers.version>1.15.1</testcontainers.version>
+        <testcontainers.version>1.16.2</testcontainers.version>
         <java.version>1.8</java.version>
         <scala.binary.version>2.11</scala.binary.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
Upgrade the testcontainers dependency from 1.15.1 to 1.16.2. This newer version should be quicker.