### PR TITLE
[mysql]: fix the normalizedSplitRecords logic

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/RecordUtils.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/RecordUtils.java
@@ -153,9 +153,6 @@ public class RecordUtils {
                     Envelope.Operation operation =
                             Envelope.Operation.forCode(
                                     value.getString(Envelope.FieldName.OPERATION));
-                    if (snapshotRecords.containsKey(key)) {
-                        snapshotRecords.remove(key);
-                    }
                     switch (operation) {
                         case UPDATE:
                             Envelope envelope = Envelope.fromSchema(binlog.valueSchema());
@@ -174,13 +171,13 @@ public class RecordUtils {
                                             binlog.key(),
                                             binlog.valueSchema(),
                                             envelope.read(updateAfter, source, ts));
-                            normalizedBinlogRecords.add(record);
+                            snapshotRecords.put(key, record);
                             break;
                         case DELETE:
-                            // The deleting from snapshotRecords has been promoted to outer scope.
+                            snapshotRecords.remove(key);
                             break;
                         case CREATE:
-                            normalizedBinlogRecords.add(binlog);
+                            snapshotRecords.put(key, binlog);
                             break;
                         case READ:
                             throw new IllegalStateException(

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/RecordUtils.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/RecordUtils.java
@@ -153,6 +153,9 @@ public class RecordUtils {
                     Envelope.Operation operation =
                             Envelope.Operation.forCode(
                                     value.getString(Envelope.FieldName.OPERATION));
+                    if (snapshotRecords.containsKey(key)) {
+                        snapshotRecords.remove(key);
+                    }
                     switch (operation) {
                         case UPDATE:
                             Envelope envelope = Envelope.fromSchema(binlog.valueSchema());
@@ -174,14 +177,7 @@ public class RecordUtils {
                             normalizedBinlogRecords.add(record);
                             break;
                         case DELETE:
-                            if (snapshotRecords.containsKey(key)) {
-                                snapshotRecords.remove(key);
-                            } else {
-                                throw new IllegalStateException(
-                                        String.format(
-                                                "The delete record %s doesn't exists in table split %s.",
-                                                binlog, split));
-                            }
+                            // The deleting from snapshotRecords has been promoted to outer scope.
                             break;
                         case CREATE:
                             normalizedBinlogRecords.add(binlog);


### PR DESCRIPTION
When nomarlize the snapshotRecords and binlogRecords, we should
remove from snapshotRecords by binlogRecords.keys().

Short version reason: it's the rule from DBLog paper

Long version reason. TLDR;

Let't see the followling illustration:

```
    snapshot readview(sr)
            |
            v
------lw---------hw-----    <- binlog stream
```

For RR isolation level, the readview is a point corresponding to
the binlog stream, let's name it sr.

1. For an update binlog(ub):

If lw <= ub <= sr, the normalizedBinlogRecord first add the
new value(i.e the updateAfter), and then add the snapshotRecords,
so there will be two record for this key, both contain the new value,
there is no problem since the downstream use the upsert logic.

But if sr < ub <= hw, the snapshotRecords contains the old
value, and the normalizedBinlogRecord first add the new value,
and then add the old value from the snapshotRecords, now there
is problem, since the upsert logic will apply the old value
to the downstream, data inconsistency ;(

2. For an delete binlog(db)

If lw <= db <= sr, the snapshotRecords does not contain the
corresponding key, and if sr < db <= hw, the snapshotRecords
contains the key, so the logic `if contain then delete` is
just ok, no need to throw Exception if snapshotRecords does
not contains the key.

3. For an create binlog(cb)

If lw <= db <= sr, there will be two create binlog in the
normalizedBinlogRecords with the same value, no problem
since downstream apply the upsert logic.

So, a simple solution to update and delete problem is to
delete the corresponding key from snapshotRecords.
For create, delete from snapshotRecords will eliminate
the duplication.

For RC isolation level, delete from snapshotRecords first
will also work, I will leave the analysis for those who
will see this patch and interested.

[v2]

After some discussion with @wuchong , the upsert logic should be the
following logic:

0. add `lowWatermarkEvent` into `normalizedBinlogRecords`
1. iterate all the records in `binlogRecords`
    1.0. for DELETE records, we get the key and `Map.remove` it from `snapshotRecords`
    1.1. for all other kind records, we get the key and `Map.put` it into `snapshotRecords` (we still need to decorate the UPDATE event into READ event).
2. add `snapshotRecords.values()` into `normalizedBinlogRecords`
3. add `highWatermarkEvent` into `normalizedBinlogRecords`
4. return `normalizedBinlogRecords`



Signed-off-by: 元组 <zhaojunwang.zjw@alibaba-inc.com>