### PR TITLE
[docs] Changed field names to uppercase in Flink create table SQL.

### DIFF
--- a/docs/content/connectors/oracle-cdc.md
+++ b/docs/content/connectors/oracle-cdc.md
@@ -120,10 +120,10 @@ The Oracle CDC table can be defined as following:
 ```sql 
 -- register an Oracle table 'products' in Flink SQL
 Flink SQL> CREATE TABLE products (
-     id INT NOT NULL,
-     name STRING,
-     description STRING,
-     weight DECIMAL(10, 3),
+     ID INT NOT NULL,
+     NAME STRING,
+     DESCRIPTION STRING,
+     WEIGHT DECIMAL(10, 3),
      PRIMARY KEY(id) NOT ENFORCED
      ) WITH (
      'connector' = 'oracle-cdc',
@@ -288,10 +288,10 @@ CREATE TABLE products (
     schema_name STRING METADATA FROM 'schema_name' VIRTUAL, 
     table_name STRING METADATA  FROM 'table_name' VIRTUAL,
     operation_ts TIMESTAMP_LTZ(3) METADATA FROM 'op_ts' VIRTUAL,
-    id INT NOT NULL,
-    name STRING,
-    description STRING,
-    weight DECIMAL(10, 3),
+    ID INT NOT NULL,
+    NAME STRING,
+    DESCRIPTION STRING,
+    WEIGHT DECIMAL(10, 3),
     PRIMARY KEY(id) NOT ENFORCED
 ) WITH (
     'connector' = 'oracle-cdc',
@@ -304,6 +304,8 @@ CREATE TABLE products (
     'table-name' = 'products'
 );
 ```
+
+** Note ** : The Oracle dialect is case-sensitive, it converts field name to uppercase if the field name is not quoted, Flink SQL doesn't convert the field name. Thus for physical columns from oracle database, we should use its converted field name in Oracle when define an `oracle-cdc` table in Flink SQL. 
 
 Features
 --------


### PR DESCRIPTION
In Oracle database if we created a table without quoting the field names, it would automatically convert the field names to uppercase. As a result, we can get the right data only if we create table in Flink with field names excatly matching cases with those defined in Oracle. Field name defined without quotes will be convert to uppercase by oracle and fieled names in SQL executed in Oracle will also be converted to uppercase. However, Flink SQL will not do it, which means usually we have to create table with uppercased field names, otherwise we would get null values.

To minify the misleading effect of the document, I suggest we change the field names in oracle-cdc.md to uppercase. By the way we can keep it consistent with those SQLs in oracle-tutorial-zh.md.