### PR TITLE
[docs-356] Add FAQ that the tableList is using full path rather than table name in datastream API

### DIFF
--- a/docs/content/connectors/mysql-cdc.md
+++ b/docs/content/connectors/mysql-cdc.md
@@ -776,3 +776,6 @@ This is because the MySQL user account uses `sha256_password` authentication whi
 ALTER USER 'username'@'localhost' IDENTIFIED WITH mysql_native_password BY 'password';
 FLUSH PRIVILEGES;
 ```
+#### Q5: How to config tableList when we build mysql-cdc source in datastream API?
+
+The tableList is using full path rather than table name in datastream API. For mysql-cdc, the tableList is like 'my_db.my_table'.

--- a/docs/content/connectors/mysql-cdc.md
+++ b/docs/content/connectors/mysql-cdc.md
@@ -776,10 +776,10 @@ This is because the MySQL user account uses `sha256_password` authentication whi
 ALTER USER 'username'@'localhost' IDENTIFIED WITH mysql_native_password BY 'password';
 FLUSH PRIVILEGES;
 ```
-#### Q5: How to config tableList when we build mysql-cdc source in datastream API?
+#### Q5: How to config `tableList` option when build MySQL CDC source in DataStream API?
 
-The tableList is using full path rather than table name in datastream API. For mysql-cdc, the tableList is like 'my_db.my_table'.
+The `tableList` option requires table name with database name rather than table name in DataStream API. For MySQL CDC source, the `tableList` option value should  like 'my_db.my_table'.
 
-#### Q6: How to config mysql server timezone in DataStream API?
+#### Q6: How to config MySQL server timezone in DataStream API?
 
-User who use DataStream API should deal the timezone in their custom deserializer like RowDataDebeziumDeserializeSchema.
+The timezone of MySQL server influences the data value of TIMESTAMP column in its binlog file, thus we need to consider the MySQL server timezone when deal record that contains TIMESTAMP column. You can refer `com.ververica.cdc.debezium.table.RowDataDebeziumDeserializeSchema` as an example  when you define your custom deserializer to deal binlog data correctly.

--- a/docs/content/connectors/mysql-cdc.md
+++ b/docs/content/connectors/mysql-cdc.md
@@ -779,3 +779,7 @@ FLUSH PRIVILEGES;
 #### Q5: How to config tableList when we build mysql-cdc source in datastream API?
 
 The tableList is using full path rather than table name in datastream API. For mysql-cdc, the tableList is like 'my_db.my_table'.
+
+#### Q6: How to config mysql server timezone in DataStream API?
+
+User who use DataStream API should deal the timezone in their custom deserializer like RowDataDebeziumDeserializeSchema.

--- a/docs/content/connectors/postgres-cdc.md
+++ b/docs/content/connectors/postgres-cdc.md
@@ -373,6 +373,6 @@ Data Type Mapping
 FAQ
 --------
 
-#### Q1: How to config tableList when we build postgres-cdc source in datastream API?
+#### Q1: How to config `tableList` option when build Postgres CDC source in DataStream API?
 
-The tableList is using full path rather than table name in datastream API. For postgres-cdc, the tableList is like 'my_schema.my_table'.
+The `tableList` option requires table name with schema name rather than table name in DataStream API. For Postgres CDC source, the `tableList` option value should  like 'my_schema.my_table'.

--- a/docs/content/connectors/postgres-cdc.md
+++ b/docs/content/connectors/postgres-cdc.md
@@ -368,3 +368,11 @@ Data Type Mapping
     </tbody>
 </table>
 </div>
+
+
+FAQ
+--------
+
+#### Q1: How to config tableList when we build postgres-cdc source in datastream API?
+
+The tableList is using full path rather than table name in datastream API. For postgres-cdc, the tableList is like 'my_schema.my_table'.


### PR DESCRIPTION
## What is the purpose of the change 
Add FAQ that  the tableList is using full path rather than table name in datastream API #356

- Add mysql-cdc tableList config description into mysql-cdc.md FAQ list.
- Add postgres-cdc tableList config description into postgres-cdc.md FAQ list.
