### PR TITLE
[mysql] change MySqlSource constructor's accessibility from package-private to public

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSource.java
@@ -75,7 +75,7 @@ import static com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils.openJdbc
  *
  * <pre>{@code
  * MySqlSource
- *     .<RowData>builder()
+ *     .<String>builder()
  *     .hostname("localhost")
  *     .port(3306)
  *     .databaseList("mydb")
@@ -110,7 +110,7 @@ public class MySqlSource<T>
         return new MySqlSourceBuilder<>();
     }
 
-    MySqlSource(
+    public MySqlSource(
             MySqlSourceConfigFactory configFactory,
             DebeziumDeserializationSchema<T> deserializationSchema) {
         this.configFactory = configFactory;


### PR DESCRIPTION

By applying this change, the user can construct a
MySqlSourceConfigFactory first, and use the constructor
to construct the MySqlSource, which can reduce the work
to maintain some other MySqlSourceConfig code.

Signed-off-by: 元组 <zhaojunwang.zjw@alibaba-inc.com>