### PR TITLE
[mysql] add an interface to get MySqlSourceConfigFactory

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSource.java
@@ -75,7 +75,7 @@ import static com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils.openJdbc
  *
  * <pre>{@code
  * MySqlSource
- *     .<RowData>builder()
+ *     .<String>builder()
  *     .hostname("localhost")
  *     .port(3306)
  *     .databaseList("mydb")
@@ -115,6 +115,10 @@ public class MySqlSource<T>
             DebeziumDeserializationSchema<T> deserializationSchema) {
         this.configFactory = configFactory;
         this.deserializationSchema = deserializationSchema;
+    }
+
+    public MySqlSourceConfigFactory getConfigFactory() {
+        return configFactory;
     }
 
     @Override


### PR DESCRIPTION
Expose an interface for user to use the MySqlSourceConfigFactory#createConfig.

Some discussion can be found here [0]

[0] https://github.com/ververica/flink-cdc-connectors/pull/638

Signed-off-by: 元组 <zhaojunwang.zjw@alibaba-inc.com>