### PR TITLE
[oracle] let oracle-cdc connect to PDB CDB old non-CDB successfully

### DIFF
--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/OracleValidator.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/OracleValidator.java
@@ -70,6 +70,6 @@ public class OracleValidator implements Validator {
         String userName = properties.getProperty("database.user");
         String userpwd = properties.getProperty("database.password");
         return DriverManager.getConnection(
-                "jdbc:oracle:thin:@" + hostname + ":" + port + ":" + dbname, userName, userpwd);
+                "jdbc:oracle:thin:@" + hostname + ":" + port + "/" + dbname, userName, userpwd);
     }
 }


### PR DESCRIPTION
[oracle] The general **dbname** should be SERVICE_NAME but not INSTANCE_NAME in the _lsnrctl status_ output, especially connect to PDB in CDB  it must be SERVICE_NAME now, of course we should support both of the two features in the future.