### PR TITLE
WIP [mysql] add MySqlSourceEnumeratorMetrics

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssigner.java
@@ -21,6 +21,7 @@ package com.ververica.cdc.connectors.mysql.source.assigners;
 import com.ververica.cdc.connectors.mysql.source.assigners.state.HybridPendingSplitsState;
 import com.ververica.cdc.connectors.mysql.source.assigners.state.PendingSplitsState;
 import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfig;
+import com.ververica.cdc.connectors.mysql.source.metrics.MySqlSourceEnumeratorMetrics;
 import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
 import com.ververica.cdc.connectors.mysql.source.split.FinishedSnapshotSplitInfo;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlBinlogSplit;
@@ -58,10 +59,15 @@ public class MySqlHybridSplitAssigner implements MySqlSplitAssigner {
             MySqlSourceConfig sourceConfig,
             int currentParallelism,
             List<TableId> remainingTables,
-            boolean isTableIdCaseSensitive) {
+            boolean isTableIdCaseSensitive,
+            MySqlSourceEnumeratorMetrics sourceEnumeratorMetrics) {
         this(
                 new MySqlSnapshotSplitAssigner(
-                        sourceConfig, currentParallelism, remainingTables, isTableIdCaseSensitive),
+                        sourceConfig,
+                        currentParallelism,
+                        remainingTables,
+                        isTableIdCaseSensitive,
+                        sourceEnumeratorMetrics),
                 false,
                 sourceConfig.getSplitMetaGroupSize());
     }
@@ -69,10 +75,14 @@ public class MySqlHybridSplitAssigner implements MySqlSplitAssigner {
     public MySqlHybridSplitAssigner(
             MySqlSourceConfig sourceConfig,
             int currentParallelism,
-            HybridPendingSplitsState checkpoint) {
+            HybridPendingSplitsState checkpoint,
+            MySqlSourceEnumeratorMetrics sourceEnumeratorMetrics) {
         this(
                 new MySqlSnapshotSplitAssigner(
-                        sourceConfig, currentParallelism, checkpoint.getSnapshotPendingSplits()),
+                        sourceConfig,
+                        currentParallelism,
+                        checkpoint.getSnapshotPendingSplits(),
+                        sourceEnumeratorMetrics),
                 checkpoint.isBinlogSplitAssigned(),
                 sourceConfig.getSplitMetaGroupSize());
     }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/metrics/MySqlSourceEnumeratorMetrics.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/metrics/MySqlSourceEnumeratorMetrics.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mysql.source.metrics;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+
+import com.ververica.cdc.connectors.mysql.source.enumerator.MySqlSourceEnumerator;
+
+/** A collection class for handling metrics in {@link MySqlSourceEnumerator}. */
+public class MySqlSourceEnumeratorMetrics {
+    private final MetricGroup metricGroup;
+
+    public MySqlSourceEnumeratorMetrics(MetricGroup metricGroup) {
+        this.metricGroup = metricGroup;
+    }
+
+    private volatile long alreadyProcessedTablesNum = 0L;
+    private volatile long remainingTablesNum = 0L;
+    private volatile long remainingSplitsNum = 0L;
+    private volatile long assignedSplitsNum = 0L;
+    private volatile long finishedSplitsNum = 0L;
+    private volatile boolean assignerFinished = false;
+
+    public void registerMetrics() {
+        metricGroup.gauge(
+                "alreadyProcessedTablesNum", (Gauge<Long>) this::getAlreadyProcessedTablesNum);
+        metricGroup.gauge("remainingTablesNum", (Gauge<Long>) this::getRemainingTablesNum);
+        metricGroup.gauge("remainingSplitsNum", (Gauge<Long>) this::getRemainingSplitsNum);
+        metricGroup.gauge("assignedSplitsNum", (Gauge<Long>) this::getAssignedSplitsNum);
+        metricGroup.gauge("finishedSplitsNum", (Gauge<Long>) this::getFinishedSplitsNum);
+        metricGroup.gauge("assignerFinished", (Gauge<Boolean>) this::getAssignerFinished);
+    }
+
+    public long getAlreadyProcessedTablesNum() {
+        return alreadyProcessedTablesNum;
+    }
+
+    public long getRemainingTablesNum() {
+        return remainingTablesNum;
+    }
+
+    public long getRemainingSplitsNum() {
+        return remainingSplitsNum;
+    }
+
+    public long getAssignedSplitsNum() {
+        return assignedSplitsNum;
+    }
+
+    public long getFinishedSplitsNum() {
+        return finishedSplitsNum;
+    }
+
+    public boolean getAssignerFinished() {
+        return assignerFinished;
+    }
+
+    public void recordAlreadyProcessedTablesNum(long alreadyProcessedTablesNum) {
+        this.alreadyProcessedTablesNum = alreadyProcessedTablesNum;
+    }
+
+    public void recordRemainingTablesNum(final long remainingTablesNum) {
+        this.remainingTablesNum = remainingTablesNum;
+    }
+
+    public void recordRemainingSplitsNum(long remainingSplitsNum) {
+        this.remainingSplitsNum = remainingSplitsNum;
+    }
+
+    public void recordAssignedSplits(long assignedSplitsNum) {
+        this.assignedSplitsNum = assignedSplitsNum;
+    }
+
+    public void recordFinishedSplits(long finishedSplitsNum) {
+        this.finishedSplitsNum = finishedSplitsNum;
+    }
+
+    public void recordAssignerFinished(boolean assignerFinished) {
+        this.assignerFinished = assignerFinished;
+    }
+}

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
@@ -541,7 +541,7 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
 
         final MySqlSnapshotSplitAssigner assigner =
                 new MySqlSnapshotSplitAssigner(
-                        sourceConfig, DEFAULT_PARALLELISM, remainingTables, false);
+                        sourceConfig, DEFAULT_PARALLELISM, remainingTables, false, null);
         assigner.open();
         List<MySqlSnapshotSplit> mySqlSplits = new ArrayList<>();
         while (true) {

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
@@ -218,7 +218,7 @@ public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
                         .collect(Collectors.toList());
         final MySqlSnapshotSplitAssigner assigner =
                 new MySqlSnapshotSplitAssigner(
-                        sourceConfig, DEFAULT_PARALLELISM, remainingTables, false);
+                        sourceConfig, DEFAULT_PARALLELISM, remainingTables, false, null);
         assigner.open();
         List<MySqlSplit> mySqlSplitList = new ArrayList<>();
         while (true) {

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssignerTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssignerTest.java
@@ -112,7 +112,7 @@ public class MySqlHybridSplitAssignerTest extends MySqlSourceTestBase {
         HybridPendingSplitsState checkpoint =
                 new HybridPendingSplitsState(snapshotPendingSplitsState, false);
         final MySqlHybridSplitAssigner assigner =
-                new MySqlHybridSplitAssigner(configuration, DEFAULT_PARALLELISM, checkpoint);
+                new MySqlHybridSplitAssigner(configuration, DEFAULT_PARALLELISM, checkpoint, null);
 
         // step 2. Get the MySqlBinlogSplit after all snapshot splits finished
         Optional<MySqlSplit> binlogSplit = assigner.getNext();

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssignerTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssignerTest.java
@@ -342,7 +342,7 @@ public class MySqlSnapshotSplitAssignerTest extends MySqlSourceTestBase {
                 Arrays.stream(captureTables).map(TableId::parse).collect(Collectors.toList());
         final MySqlSnapshotSplitAssigner assigner =
                 new MySqlSnapshotSplitAssigner(
-                        configuration, DEFAULT_PARALLELISM, remainingTables, false);
+                        configuration, DEFAULT_PARALLELISM, remainingTables, false, null);
 
         assigner.open();
         List<MySqlSplit> sqlSplits = new ArrayList<>();

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
@@ -164,7 +164,8 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
                         sourceConfig,
                         DEFAULT_PARALLELISM,
                         Collections.singletonList(TableId.parse(tableName)),
-                        false);
+                        false,
+                        null);
         assigner.open();
         MySqlSnapshotSplit snapshotSplit = (MySqlSnapshotSplit) assigner.getNext().get();
         // should contain only one split


### PR DESCRIPTION
It will be great if we expose MySqlSnapshotSplitAssigner's status
to metrics, people can see the snapshot progress on flink's UI.

Unfortunately, `enumContext.metricGroup())` returns null, make
it impossible to register the metrics.

I checked the flink source code a little bit, seems
`SourceCoordinatorContext.metricGroup()` returns null directly.

I open this PR and make it WIP, trying to understand FLIP-27
more deeply, I hope I can get it solved soon.

BTW, if any one think this idea is undoable, I'd be appreciate
if you can tell me the reason.

Signed-off-by: 元组 <zhaojunwang.zjw@alibaba-inc.com>