### PR TITLE
Update log4j to fix RCE zero day.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@ under the License.
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <hamcrest.version>1.3</hamcrest.version>
         <slf4j.version>1.7.15</slf4j.version>
-        <log4j.version>2.12.1</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
         <spotless.version>2.4.2</spotless.version>
         <!-- Enforce single fork execution due to heavy mini cluster use in the tests -->
         <flink.forkCount>1</flink.forkCount>


### PR DESCRIPTION
2.0 <= Apache log4j2 <= 2.14.1 have a RCE zero day.
https://www.lunasec.io/docs/blog/log4j-zero-day/