### PR TITLE
[mysql] expose Enumerator metrics via Source Event

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlBinlogSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlBinlogSplitAssigner.java
@@ -114,6 +114,31 @@ public class MySqlBinlogSplitAssigner implements MySqlSplitAssigner {
     @Override
     public void close() {}
 
+    @Override
+    public int getFinishedSplitCount() {
+        return 0;
+    }
+
+    @Override
+    public int getAssignedSplitCount() {
+        return 0;
+    }
+
+    @Override
+    public int getRemainingSplitCount() {
+        return 0;
+    }
+
+    @Override
+    public int getAlreadyProcessedTableCount() {
+        return 0;
+    }
+
+    @Override
+    public int getRemainingTableCount() {
+        return 0;
+    }
+
     // ------------------------------------------------------------------------------------------
 
     private MySqlBinlogSplit createBinlogSplit() {

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssigner.java
@@ -199,4 +199,29 @@ public class MySqlHybridSplitAssigner implements MySqlSplitAssigner {
                 new HashMap<>(),
                 finishedSnapshotSplitInfos.size());
     }
+
+    @Override
+    public int getFinishedSplitCount() {
+        return snapshotSplitAssigner.getFinishedSplitCount();
+    }
+
+    @Override
+    public int getAssignedSplitCount() {
+        return snapshotSplitAssigner.getAssignedSplitCount();
+    }
+
+    @Override
+    public int getRemainingSplitCount() {
+        return snapshotSplitAssigner.getRemainingSplitCount();
+    }
+
+    @Override
+    public int getAlreadyProcessedTableCount() {
+        return snapshotSplitAssigner.getAlreadyProcessedTableCount();
+    }
+
+    @Override
+    public int getRemainingTableCount() {
+        return snapshotSplitAssigner.getRemainingTableCount();
+    }
 }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
@@ -304,4 +304,29 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
         MySqlSchema mySqlSchema = new MySqlSchema(sourceConfig, isTableIdCaseSensitive);
         return new ChunkSplitter(mySqlSchema, sourceConfig);
     }
+
+    @Override
+    public int getFinishedSplitCount() {
+        return splitFinishedOffsets.size();
+    }
+
+    @Override
+    public int getAssignedSplitCount() {
+        return assignedSplits.size();
+    }
+
+    @Override
+    public int getRemainingSplitCount() {
+        return remainingSplits.size();
+    }
+
+    @Override
+    public int getAlreadyProcessedTableCount() {
+        return alreadyProcessedTables.size();
+    }
+
+    @Override
+    public int getRemainingTableCount() {
+        return remainingTables.size();
+    }
 }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSplitAssigner.java
@@ -61,6 +61,16 @@ public interface MySqlSplitAssigner {
      */
     List<FinishedSnapshotSplitInfo> getFinishedSplitInfos();
 
+    int getFinishedSplitCount();
+
+    int getAssignedSplitCount();
+
+    int getRemainingSplitCount();
+
+    int getAlreadyProcessedTableCount();
+
+    int getRemainingTableCount();
+
     /**
      * Callback to handle the finished splits with finished binlog offset. This is useful for
      * determine when to generate binlog split and what binlog split to generate.

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
@@ -122,7 +122,13 @@ public class MySqlSourceEnumerator implements SplitEnumerator<MySqlSplit, Pendin
             splitAssigner.onFinishedSplits(finishedOffsets);
             // send acknowledge event
             FinishedSnapshotSplitsAckEvent ackEvent =
-                    new FinishedSnapshotSplitsAckEvent(new ArrayList<>(finishedOffsets.keySet()));
+                    new FinishedSnapshotSplitsAckEvent(
+                            new ArrayList<>(finishedOffsets.keySet()),
+                            splitAssigner.getAlreadyProcessedTableCount(),
+                            splitAssigner.getRemainingTableCount(),
+                            splitAssigner.getFinishedSplitCount(),
+                            splitAssigner.getAssignedSplitCount(),
+                            splitAssigner.getRemainingSplitCount());
             context.sendEventToSourceReader(subtaskId, ackEvent);
         } else if (sourceEvent instanceof BinlogSplitMetaRequestEvent) {
             LOG.debug(

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/events/FinishedSnapshotSplitsAckEvent.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/events/FinishedSnapshotSplitsAckEvent.java
@@ -35,17 +35,66 @@ public class FinishedSnapshotSplitsAckEvent implements SourceEvent {
     private static final long serialVersionUID = 1L;
 
     private final List<String> finishedSplits;
+    private final int alreadyProcessedTableCount;
+    private final int remainingTableCount;
+    private final int finishedSplitCount;
+    private final int assignedSplitCount;
+    private final int remainingSplitCount;
 
-    public FinishedSnapshotSplitsAckEvent(List<String> finishedSplits) {
+    public FinishedSnapshotSplitsAckEvent(
+            final List<String> finishedSplits,
+            final int alreadyProcessedTableCount,
+            final int remainingTableCount,
+            final int finishedSplitCount,
+            final int assignedSplitCount,
+            final int remainingSplitCount) {
         this.finishedSplits = finishedSplits;
+        this.alreadyProcessedTableCount = alreadyProcessedTableCount;
+        this.remainingTableCount = remainingTableCount;
+        this.finishedSplitCount = finishedSplitCount;
+        this.assignedSplitCount = assignedSplitCount;
+        this.remainingSplitCount = remainingSplitCount;
     }
 
     public List<String> getFinishedSplits() {
         return finishedSplits;
     }
 
+    public int getAlreadyProcessedTableCount() {
+        return alreadyProcessedTableCount;
+    }
+
+    public int getRemainingTableCount() {
+        return remainingTableCount;
+    }
+
+    public int getFinishedSplitCount() {
+        return finishedSplitCount;
+    }
+
+    public int getAssignedSplitCount() {
+        return assignedSplitCount;
+    }
+
+    public int getRemainingSplitCount() {
+        return remainingSplitCount;
+    }
+
     @Override
     public String toString() {
-        return "FinishedSnapshotSplitsAckEvent{" + "finishedSplits=" + finishedSplits + '}';
+        return "FinishedSnapshotSplitsAckEvent{"
+                + "finishedSplits="
+                + finishedSplits
+                + ", alreadyProcessedTableCount="
+                + alreadyProcessedTableCount
+                + ", remainingTableCount="
+                + remainingTableCount
+                + ", finishedSplitCount="
+                + finishedSplitCount
+                + ", assignedSplitCount="
+                + assignedSplitCount
+                + ", remainingSplitCount="
+                + remainingSplitCount
+                + '}';
     }
 }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/metrics/MySqlSourceReaderMetrics.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/metrics/MySqlSourceReaderMetrics.java
@@ -47,6 +47,21 @@ public class MySqlSourceReaderMetrics {
      */
     private volatile long emitDelay = 0L;
 
+    /** Already processed table count for this flink Job. */
+    private volatile long alreadyProcessedTableCount = 0L;
+
+    /** Remaining table count for this flink job to handle. */
+    private volatile long remainingTableCount = 0L;
+
+    /** Already assigned split count for this flink Job. */
+    private volatile long assignedSplitCount = 0L;
+
+    /** Remaining split count for the table int process. */
+    private volatile long remainingSplitCount = 0L;
+
+    /** Already processed split count for this flink Job. */
+    private volatile long finishedSplitCount = 0L;
+
     public MySqlSourceReaderMetrics(MetricGroup metricGroup) {
         this.metricGroup = metricGroup;
     }
@@ -55,6 +70,12 @@ public class MySqlSourceReaderMetrics {
         metricGroup.gauge("currentFetchEventTimeLag", (Gauge<Long>) this::getFetchDelay);
         metricGroup.gauge("currentEmitEventTimeLag", (Gauge<Long>) this::getEmitDelay);
         metricGroup.gauge("sourceIdleTime", (Gauge<Long>) this::getIdleTime);
+        metricGroup.gauge(
+                "alreadyProcessedTableCount", (Gauge<Long>) this::getAlreadyProcessedTableCount);
+        metricGroup.gauge("remainingTableCount", (Gauge<Long>) this::getRemainingTableCount);
+        metricGroup.gauge("assignedSplitCount", (Gauge<Long>) this::getAssignedSplitCount);
+        metricGroup.gauge("remainingSplitCount", (Gauge<Long>) this::getRemainingSplitCount);
+        metricGroup.gauge("finishedSplitCount", (Gauge<Long>) this::getFinishedSplitCount);
     }
 
     public long getFetchDelay() {
@@ -73,6 +94,26 @@ public class MySqlSourceReaderMetrics {
         return System.currentTimeMillis() - processTime;
     }
 
+    public long getAlreadyProcessedTableCount() {
+        return alreadyProcessedTableCount;
+    }
+
+    public long getRemainingTableCount() {
+        return remainingTableCount;
+    }
+
+    public long getAssignedSplitCount() {
+        return assignedSplitCount;
+    }
+
+    public long getRemainingSplitCount() {
+        return remainingSplitCount;
+    }
+
+    public long getFinishedSplitCount() {
+        return finishedSplitCount;
+    }
+
     public void recordProcessTime(long processTime) {
         this.processTime = processTime;
     }
@@ -83,5 +124,25 @@ public class MySqlSourceReaderMetrics {
 
     public void recordEmitDelay(long emitDelay) {
         this.emitDelay = emitDelay;
+    }
+
+    public void recordAlreadyProcessedTableCount(final long alreadyProcessedTableCount) {
+        this.alreadyProcessedTableCount = alreadyProcessedTableCount;
+    }
+
+    public void recordRemainingTableCount(final long remainingTableCount) {
+        this.remainingTableCount = remainingTableCount;
+    }
+
+    public void recordAssignedSplitCount(final long assignedSplitCount) {
+        this.assignedSplitCount = assignedSplitCount;
+    }
+
+    public void recordRemainingSplitCount(final long remainingSplitCount) {
+        this.remainingSplitCount = remainingSplitCount;
+    }
+
+    public void recordFinishedSplitCount(final long finishedSplitCount) {
+        this.finishedSplitCount = finishedSplitCount;
     }
 }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
@@ -126,6 +126,10 @@ public final class MySqlRecordEmitter<T>
         }
     }
 
+    public MySqlSourceReaderMetrics getSourceReaderMetrics() {
+        return sourceReaderMetrics;
+    }
+
     private static class OutputCollector<T> implements Collector<T> {
         private SourceOutput<T> output;
 


### PR DESCRIPTION
I opened a PR #707 last week, which hope to expose some
Enumerator metrics directly to `SplitEnumeratorContext.metricGroup()`,
but unfortunately, it return null for the `MetricGroup`. After
some investigation of FLIP-27, it says `The SourceCoordinators
will run in the JobMaster, but not as part of the ExecutionGraph`.

So there is noway to expose the Enumerator metrics ;(

In this PR, I use the RPC Gateway, a.k.a SourceEvent to transfer
the Enumerator metrics to each SourceReader.

I add 5 metrics:

- alreadyProcessedTableCount  // Already processed table count for this flink job.
- remainingTableCount	// Remaining table count for this flink job to handle.
- finishedSplitCount	// Processed splits count for this flink job.
- assignedSplitCount	// Assigned but not finished splits count for this flink job.
- remainingSplitCount	// Remaining split count for the currently processing table.

For now I just use the `FinishedSnapshotSplitsAckEvent` to
carry the above metrics, we may alternatively send a
request event to query the metrics in `MySqlSourceReader#start`
and `MySqlSourceReader#onSplitFinished`, that might need
some future discussion.

Signed-off-by: 元组 <zhaojunwang.zjw@alibaba-inc.com>