### PR TITLE
upgrade the version of debezium to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@ under the License.
 
     <properties>
         <flink.version>1.13.3</flink.version>
-        <debezium.version>1.5.4.Final</debezium.version>
+        <debezium.version>1.8.0.Final</debezium.version>
         <geometry.version>2.2.0</geometry.version>
         <!-- OracleE2eITCase will report "container cannot be accessed" error when running in Azure Pipeline with 1.16.1 testconainters.
           This might be a conflicts with "wnameless/oracle-xe-11g-r2" and 1.16 testcontainers.


### PR DESCRIPTION
From my sides,  there'are many fixes for oracle in debezium 1.6, 1.7, 1.8
https://debezium.io/releases/1.6/release-notes
https://debezium.io/releases/1.7/release-notes
https://debezium.io/releases/1.8/release-notes

And also, debezium 1.7 introduce a feature that enables us to manage the events read form LogMiner by ourselfs .
https://issues.redhat.com/browse/DBZ-3752