### PR TITLE
[oracle] Fix the data type of type info created by oracle table source

### DIFF
--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSource.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSource.java
@@ -113,8 +113,7 @@ public class OracleTableSource implements ScanTableSource, SupportsReadingMetada
         RowType physicalDataType =
                 (RowType) physicalSchema.toPhysicalRowDataType().getLogicalType();
         MetadataConverter[] metadataConverters = getMetadataConverters();
-        TypeInformation<RowData> typeInfo =
-                scanContext.createTypeInformation(physicalSchema.toRowDataType());
+        TypeInformation<RowData> typeInfo = scanContext.createTypeInformation(producedDataType);
 
         DebeziumDeserializationSchema<RowData> deserializer =
                 RowDataDebeziumDeserializeSchema.newBuilder()


### PR DESCRIPTION
![Snipaste_2022-01-05_21-26-41](https://user-images.githubusercontent.com/36807946/148224989-23e9cc70-14c0-4056-b929-ced26369b341.png)
During the test, I found that the `typeInfo` created by the `OracleTableSource` was incorrect, because the `producedDataType` processed by `#applyReadableMetadata` was not used.