### PR TITLE
Fix the type information of source funtion and add tests

### DIFF
--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
@@ -135,8 +135,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
         RowType physicalDataType =
                 (RowType) physicalSchema.toPhysicalRowDataType().getLogicalType();
         MetadataConverter[] metadataConverters = getMetadataConverters();
-        TypeInformation<RowData> typeInfo =
-                scanContext.createTypeInformation(physicalSchema.toPhysicalRowDataType());
+        TypeInformation<RowData> typeInfo = scanContext.createTypeInformation(producedDataType);
 
         DebeziumDeserializationSchema<RowData> deserializer =
                 new MongoDBConnectorDeserializationSchema(

--- a/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
+++ b/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
@@ -29,10 +29,15 @@ import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.Factory;
 import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.util.ExceptionUtils;
 
+import com.ververica.cdc.debezium.DebeziumSourceFunction;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -42,6 +47,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static com.ververica.cdc.connectors.utils.AssertUtils.assertProducedTypeOfSourceFunction;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -202,6 +208,13 @@ public class OracleTableSourceFactoryTest {
                 Arrays.asList("op_ts", "database_name", "table_name", "schema_name");
 
         assertEquals(expectedSource, actualSource);
+
+        ScanTableSource.ScanRuntimeProvider provider =
+                oracleTableSource.getScanRuntimeProvider(ScanRuntimeProviderContext.INSTANCE);
+        DebeziumSourceFunction<RowData> debeziumSourceFunction =
+                (DebeziumSourceFunction<RowData>)
+                        ((SourceFunctionProvider) provider).createSourceFunction();
+        assertProducedTypeOfSourceFunction(debeziumSourceFunction, expectedSource.producedDataType);
     }
 
     @Test

--- a/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/table/PostgreSQLTableFactoryTest.java
+++ b/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/table/PostgreSQLTableFactoryTest.java
@@ -29,10 +29,15 @@ import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.Factory;
 import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.util.ExceptionUtils;
 
+import com.ververica.cdc.debezium.DebeziumSourceFunction;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -42,6 +47,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static com.ververica.cdc.connectors.utils.AssertUtils.assertProducedTypeOfSourceFunction;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -160,6 +166,13 @@ public class PostgreSQLTableFactoryTest {
                 Arrays.asList("op_ts", "database_name", "schema_name", "table_name");
 
         assertEquals(expectedSource, actualSource);
+
+        ScanTableSource.ScanRuntimeProvider provider =
+                postgreSQLTableSource.getScanRuntimeProvider(ScanRuntimeProviderContext.INSTANCE);
+        DebeziumSourceFunction<RowData> debeziumSourceFunction =
+                (DebeziumSourceFunction<RowData>)
+                        ((SourceFunctionProvider) provider).createSourceFunction();
+        assertProducedTypeOfSourceFunction(debeziumSourceFunction, expectedSource.producedDataType);
     }
 
     @Test

--- a/flink-connector-test-util/pom.xml
+++ b/flink-connector-test-util/pom.xml
@@ -47,6 +47,12 @@ under the License.
             <artifactId>flink-test-utils_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/flink-connector-test-util/src/main/java/com/ververica/cdc/connectors/utils/AssertUtils.java
+++ b/flink-connector-test-util/src/main/java/com/ververica/cdc/connectors/utils/AssertUtils.java
@@ -18,15 +18,23 @@
 
 package com.ververica.cdc.connectors.utils;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.DataType;
+
+import com.ververica.cdc.debezium.DebeziumSourceFunction;
 import io.debezium.data.Envelope;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-/** Utilities for asserting {@link SourceRecord}. */
+/** Utilities for asserting {@link SourceRecord} and {@link DebeziumSourceFunction}. */
 public class AssertUtils {
     /**
      * Verify that the given {@link SourceRecord} is a {@link Envelope.Operation#CREATE
@@ -219,5 +227,22 @@ public class AssertUtils {
     public static void assertDelete(SourceRecord record, String pkField, int pk) {
         hasValidKey(record, pkField, pk);
         assertDelete(record, true);
+    }
+
+    /**
+     * Verify that the given produced data type of {@code DebeziumSourceFunction<RowData>} matches
+     * the resolved schema data type.
+     *
+     * @param debeziumSourceFunction the actual DebeziumSourceFunction
+     * @param expectedProducedType expected DataType of resolved schema
+     */
+    public static void assertProducedTypeOfSourceFunction(
+            DebeziumSourceFunction<RowData> debeziumSourceFunction, DataType expectedProducedType) {
+        TypeInformation<RowData> producedType = debeziumSourceFunction.getProducedType();
+        assertThat(producedType, instanceOf(InternalTypeInfo.class));
+        InternalTypeInfo<RowData> rowDataInternalTypeInfo =
+                (InternalTypeInfo<RowData>) producedType;
+        DataType producedDataType = rowDataInternalTypeInfo.getDataType();
+        assertEquals(expectedProducedType.toString(), producedDataType.toString());
     }
 }


### PR DESCRIPTION
![Snipaste_2022-01-05_21-26-41](https://user-images.githubusercontent.com/36807946/148224989-23e9cc70-14c0-4056-b929-ced26369b341.png)
During the test, I found that the typeInfo created by the OracleTableSource was incorrect, because the producedDataType processed by #applyReadableMetadata was not used.

I added a test method to ensure that the data type of the source funtion matches the expected schema data type.