### PR TITLE
[mysql] rename dispatchHighWatermark to dispatchBinlogEndWatermark

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
@@ -124,7 +124,7 @@ public class SnapshotSplitReader implements DebeziumReader<SourceRecord, MySqlSp
                                         .getEndingOffset()
                                         .isAfter(backfillBinlogSplit.getStartingOffset());
                         if (!binlogBackfillRequired) {
-                            dispatchHighWatermark(backfillBinlogSplit);
+                            dispatchBinlogEndWatermark(backfillBinlogSplit);
                             currentTaskRunning = false;
                             return;
                         }
@@ -196,7 +196,7 @@ public class SnapshotSplitReader implements DebeziumReader<SourceRecord, MySqlSp
                 backfillBinlogSplit);
     }
 
-    private void dispatchHighWatermark(MySqlBinlogSplit backFillBinlogSplit)
+    private void dispatchBinlogEndWatermark(MySqlBinlogSplit backFillBinlogSplit)
             throws InterruptedException {
         final SignalEventDispatcher signalEventDispatcher =
                 new SignalEventDispatcher(


### PR DESCRIPTION
If no need to read binlog, a BINLOG_END event is appended to the
event queue, `dispatchHighWatermark` is kind of confusing, so
change it to `dispatchBinlogEndWatermark`.

Signed-off-by: 元组 <zhaojunwang.zjw@alibaba-inc.com>