### PR TITLE
Added option for MysqlSource to dispatch watermark event at the beginning of binlog split

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/dispatcher/SignalEventDispatcher.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/dispatcher/SignalEventDispatcher.java
@@ -111,6 +111,7 @@ public class SignalEventDispatcher {
     public enum WatermarkKind {
         LOW,
         HIGH,
+        BINLOG_START,
         BINLOG_END;
 
         public WatermarkKind fromString(String kindString) {
@@ -118,6 +119,8 @@ public class SignalEventDispatcher {
                 return LOW;
             } else if (HIGH.name().equalsIgnoreCase(kindString)) {
                 return HIGH;
+            } else if (BINLOG_START.name().equalsIgnoreCase(kindString)) {
+                return BINLOG_START;
             } else {
                 return BINLOG_END;
             }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
@@ -107,6 +107,7 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecord, MySqlSpli
                         (MySqlStreamingChangeEventSourceMetrics)
                                 statefulTaskContext.getStreamingChangeEventSourceMetrics(),
                         statefulTaskContext.getTopicSelector().getPrimaryTopic(),
+                        statefulTaskContext.shouldDispatchWatermarkOnBinlogStart(),
                         currentBinlogSplit);
 
         executor.submit(

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
@@ -193,6 +193,7 @@ public class SnapshotSplitReader implements DebeziumReader<SourceRecord, MySqlSp
                 (MySqlStreamingChangeEventSourceMetrics)
                         statefulTaskContext.getStreamingChangeEventSourceMetrics(),
                 statefulTaskContext.getTopicSelector().getPrimaryTopic(),
+                false,
                 backfillBinlogSplit);
     }
 

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
@@ -76,6 +76,12 @@ public class StatefulTaskContext {
     private final MySqlConnection connection;
     private final BinaryLogClient binaryLogClient;
 
+    public boolean shouldDispatchWatermarkOnBinlogStart() {
+        return dispatchWatermarkOnBinlogStart;
+    }
+
+    private final boolean dispatchWatermarkOnBinlogStart;
+
     private MySqlDatabaseSchema databaseSchema;
     private MySqlTaskContextImpl taskContext;
     private MySqlOffsetContext offsetContext;
@@ -92,6 +98,7 @@ public class StatefulTaskContext {
             MySqlConnection connection) {
         this.sourceConfig = sourceConfig;
         this.connectorConfig = sourceConfig.getMySqlConnectorConfig();
+        this.dispatchWatermarkOnBinlogStart = sourceConfig.shouldDispatchWatermarkOnBinlogStart();
         this.schemaNameAdjuster = SchemaNameAdjuster.create();
         this.metadataProvider = new MySqlEventMetadataProvider();
         this.binaryLogClient = binaryLogClient;

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
@@ -190,6 +190,16 @@ public class MySqlSourceBuilder<T> {
         return this;
     }
 
+    /**
+     * Whether the {@link MySqlSource} should dispatch watermark at the beginning of binlog split or
+     * not.
+     */
+    public MySqlSourceBuilder<T> dispatchWatermarkOnBinlogStart(
+            boolean dispatchWatermarkOnBinlogStart) {
+        this.configFactory.dispatchWatermarkOnBinlogStart(dispatchWatermarkOnBinlogStart);
+        return this;
+    }
+
     /** Specifies the startup options. */
     public MySqlSourceBuilder<T> startupOptions(StartupOptions startupOptions) {
         this.configFactory.startupOptions(startupOptions);

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
@@ -55,6 +55,7 @@ public class MySqlSourceConfig implements Serializable {
     private final double distributionFactorUpper;
     private final double distributionFactorLower;
     private final boolean includeSchemaChanges;
+    private final boolean dispatchWatermarkOnBinlogStart;
 
     // --------------------------------------------------------------------------------------------
     // Debezium Configurations
@@ -82,6 +83,7 @@ public class MySqlSourceConfig implements Serializable {
             double distributionFactorUpper,
             double distributionFactorLower,
             boolean includeSchemaChanges,
+            boolean dispatchWatermarkOnBinlogStart,
             Properties dbzProperties) {
         this.hostname = checkNotNull(hostname);
         this.port = port;
@@ -101,9 +103,14 @@ public class MySqlSourceConfig implements Serializable {
         this.distributionFactorUpper = distributionFactorUpper;
         this.distributionFactorLower = distributionFactorLower;
         this.includeSchemaChanges = includeSchemaChanges;
+        this.dispatchWatermarkOnBinlogStart = dispatchWatermarkOnBinlogStart;
         this.dbzProperties = checkNotNull(dbzProperties);
         this.dbzConfiguration = Configuration.from(dbzProperties);
         this.dbzMySqlConfig = new MySqlConnectorConfig(dbzConfiguration);
+    }
+
+    public boolean shouldDispatchWatermarkOnBinlogStart() {
+        return dispatchWatermarkOnBinlogStart;
     }
 
     public String getHostname() {

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
@@ -68,6 +68,7 @@ public class MySqlSourceConfigFactory implements Serializable {
     private double distributionFactorLower =
             SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND.defaultValue();
     private boolean includeSchemaChanges = false;
+    private boolean dispatchWatermarkOnBinlogStart = false;
     private Properties dbzProperties;
 
     public MySqlSourceConfigFactory hostname(String hostname) {
@@ -207,6 +208,16 @@ public class MySqlSourceConfigFactory implements Serializable {
         return this;
     }
 
+    /**
+     * Whether the {@link MySqlSource} should dispatch a watermark event to downstream when a binlog
+     * split is executed.
+     */
+    public MySqlSourceConfigFactory dispatchWatermarkOnBinlogStart(
+            boolean dispatchWatermarkOnBinlogStart) {
+        this.dispatchWatermarkOnBinlogStart = dispatchWatermarkOnBinlogStart;
+        return this;
+    }
+
     /** Specifies the startup options. */
     public MySqlSourceConfigFactory startupOptions(StartupOptions startupOptions) {
         switch (startupOptions.startupMode) {
@@ -303,6 +314,7 @@ public class MySqlSourceConfigFactory implements Serializable {
                 distributionFactorUpper,
                 distributionFactorLower,
                 includeSchemaChanges,
+                dispatchWatermarkOnBinlogStart,
                 props);
     }
 }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
@@ -39,6 +39,7 @@ import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.getFet
 import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.getHistoryRecord;
 import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.getMessageTimestamp;
 import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.getWatermark;
+import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isBinlogStartWatermarkEvent;
 import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isDataChangeRecord;
 import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isHighWatermarkEvent;
 import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isSchemaChangeEvent;
@@ -79,6 +80,9 @@ public final class MySqlRecordEmitter<T>
             BinlogOffset watermark = getWatermark(element);
             if (isHighWatermarkEvent(element) && splitState.isSnapshotSplitState()) {
                 splitState.asSnapshotSplitState().setHighWatermark(watermark);
+            }
+            if (isBinlogStartWatermarkEvent(element)) {
+                emitElement(element, output);
             }
         } else if (isSchemaChangeEvent(element) && splitState.isBinlogSplitState()) {
             HistoryRecord historyRecord = getHistoryRecord(element);

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/RecordUtils.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/RecordUtils.java
@@ -252,6 +252,14 @@ public class RecordUtils {
         return false;
     }
 
+    public static boolean isBinlogStartWatermarkEvent(SourceRecord record) {
+        Optional<WatermarkKind> watermarkKind = getWatermarkKind(record);
+        if (watermarkKind.isPresent() && watermarkKind.get() == WatermarkKind.BINLOG_START) {
+            return true;
+        }
+        return false;
+    }
+
     public static BinlogOffset getWatermark(SourceRecord watermarkEvent) {
         return getBinlogPosition(watermarkEvent.sourceOffset());
     }


### PR DESCRIPTION
When we enter binlog phase in a cdc job, the SplitAssigner only assigns a binlog split to one of the SourceReaders, namely the first reader waiting for splits in the queue. Therefore, there are use cases where we want to automatically scale in or out based on whether the sync job has entered binlog phase. A possible scenario would be as follows:

1. The user start a cdc job to sync two tables in the target database with a parallelism of 16
2. All snapshot splits has been emitted and a complete checkpoint has succeeded so that all records are consumed in the sink
3. A savepoint is triggered and the cdc job is restarted with a parallelism of 1.
4. The user wants to add new tables to the cdc job as in [this PR](https://github.com/ververica/flink-cdc-connectors/pull/777). A savepoint is triggered again and the job is restarted with 100 tables added and a parallelism of 128 for parallel reading splits
5. All the new snapshot splits has been emitted and a complete checkpoint has succeeded. 
6. A savepoint is triggered again and the job is restarted with a parallelism of 1 to consume binlog records


