### PR TITLE
[mysql] add heartbeat support

### DIFF
--- a/docs/content/connectors/mysql-cdc.md
+++ b/docs/content/connectors/mysql-cdc.md
@@ -375,6 +375,14 @@ After the server you monitored fails in MySQL cluster, you only need to change t
 
 It's recommended to configure a DNS(Domain Name Service) or VIP(Virtual IP Address) for your MySQL cluster, using the DNS or VIP address for ```mysql-cdc``` connector, the DNS or VIP would automatically route the network request to the active MySQL server. In this way, you don't need to modify the address and restart your pipeline anymore.
 
+#### MySQL Heartbeat Event Support
+
+If the table updates infrequently, the binlog file or GTID set may have been cleaned in its last committed binlog position.
+The CDC job restart fails in this case. So the heartbeat event will update binlog position. It's recommended to configure `debezium.heartbeat.interval.ms`.
+```
+debezium.heartbeat.interval.ms=3000
+```
+
 #### How Incremental Snapshot Reading works
 
 When the MySQL CDC source is started, it reads snapshot of table parallelly and then reads binlog of table with single parallelism.

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
@@ -27,7 +27,6 @@ import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.base.ChangeEventQueue;
-import io.debezium.connector.mysql.GtidSet;
 import io.debezium.connector.mysql.MySqlChangeEventSourceMetricsFactory;
 import io.debezium.connector.mysql.MySqlConnection;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
@@ -185,59 +184,6 @@ public class StatefulTaskContext {
     }
 
     private boolean isBinlogAvailable(MySqlOffsetContext offset) {
-        String gtidStr = offset.gtidSet();
-        if (gtidStr != null) {
-            return checkGtidSet(offset);
-        }
-
-        return checkBinlogFilename(offset);
-    }
-
-    private boolean checkGtidSet(MySqlOffsetContext offset) {
-        String gtidStr = offset.gtidSet();
-
-        if (gtidStr.trim().isEmpty()) {
-            return true; // start at beginning ...
-        }
-
-        String availableGtidStr = connection.knownGtidSet();
-        if (availableGtidStr == null || availableGtidStr.trim().isEmpty()) {
-            // Last offsets had GTIDs but the server does not use them ...
-            LOG.warn(
-                    "Connector used GTIDs previously, but MySQL does not know of any GTIDs or they are not enabled");
-            return false;
-        }
-        // GTIDs are enabled
-        GtidSet gtidSet = new GtidSet(gtidStr);
-        // Get the GTID set that is available in the server ...
-        GtidSet availableGtidSet = new GtidSet(availableGtidStr);
-        if (gtidSet.isContainedWithin(availableGtidSet)) {
-            LOG.info(
-                    "MySQL current GTID set {} does contain the GTID set {} required by the connector.",
-                    availableGtidSet,
-                    gtidSet);
-            // The replication is concept of mysql master-slave replication protocol ...
-            final GtidSet gtidSetToReplicate =
-                    connection.subtractGtidSet(availableGtidSet, gtidSet);
-            final GtidSet purgedGtidSet = connection.purgedGtidSet();
-            LOG.info("Server has already purged {} GTIDs", purgedGtidSet);
-            final GtidSet nonPurgedGtidSetToReplicate =
-                    connection.subtractGtidSet(gtidSetToReplicate, purgedGtidSet);
-            LOG.info(
-                    "GTID set {} known by the server but not processed yet, for replication are available only GTID set {}",
-                    gtidSetToReplicate,
-                    nonPurgedGtidSetToReplicate);
-            if (!gtidSetToReplicate.equals(nonPurgedGtidSetToReplicate)) {
-                LOG.warn("Some of the GTIDs needed to replicate have been already purged");
-                return false;
-            }
-            return true;
-        }
-        LOG.info("Connector last known GTIDs are {}, but MySQL has {}", gtidSet, availableGtidSet);
-        return false;
-    }
-
-    private boolean checkBinlogFilename(MySqlOffsetContext offset) {
         String binlogFilename = offset.getSourceInfo().getString(BINLOG_FILENAME_OFFSET_KEY);
         if (binlogFilename == null) {
             return true; // start at current position

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
@@ -27,6 +27,7 @@ import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.mysql.GtidSet;
 import io.debezium.connector.mysql.MySqlChangeEventSourceMetricsFactory;
 import io.debezium.connector.mysql.MySqlConnection;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
@@ -184,6 +185,51 @@ public class StatefulTaskContext {
     }
 
     private boolean isBinlogAvailable(MySqlOffsetContext offset) {
+        String gtidStr = offset.gtidSet();
+        if (gtidStr != null) {
+            if (gtidStr.trim().isEmpty()) {
+                return true; // start at beginning ...
+            }
+            String availableGtidStr = connection.knownGtidSet();
+            if (availableGtidStr == null || availableGtidStr.trim().isEmpty()) {
+                // Last offsets had GTIDs but the server does not use them ...
+                LOG.info(
+                        "Connector used GTIDs previously, but MySQL does not know of any GTIDs or they are not enabled");
+                return false;
+            }
+            // GTIDs are enabled
+            GtidSet gtidSet = new GtidSet(gtidStr);
+            // Get the GTID set that is available in the server ...
+            GtidSet availableGtidSet = new GtidSet(availableGtidStr);
+            if (gtidSet.isContainedWithin(availableGtidSet)) {
+                LOG.info(
+                        "MySQL current GTID set {} does contain the GTID set required by the connector {}",
+                        availableGtidSet,
+                        gtidSet);
+                final GtidSet knownServerSet = availableGtidSet;
+                final GtidSet gtidSetToReplicate =
+                        connection.subtractGtidSet(knownServerSet, gtidSet);
+                final GtidSet purgedGtidSet = connection.purgedGtidSet();
+                LOG.info("Server has already purged {} GTIDs", purgedGtidSet);
+                final GtidSet nonPurgedGtidSetToReplicate =
+                        connection.subtractGtidSet(gtidSetToReplicate, purgedGtidSet);
+                LOG.info(
+                        "GTIDs known by the server but not processed yet {}, for replication are available only {}",
+                        gtidSetToReplicate,
+                        nonPurgedGtidSetToReplicate);
+                if (!gtidSetToReplicate.equals(nonPurgedGtidSetToReplicate)) {
+                    LOG.info("Some of the GTIDs needed to replicate have been already purged");
+                    return false;
+                }
+                return true;
+            }
+            LOG.info(
+                    "Connector last known GTIDs are {}, but MySQL has {}",
+                    gtidSet,
+                    availableGtidSet);
+            return false;
+        }
+
         String binlogFilename = offset.getSourceInfo().getString(BINLOG_FILENAME_OFFSET_KEY);
         if (binlogFilename == null) {
             return true; // start at current position

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
@@ -187,49 +187,57 @@ public class StatefulTaskContext {
     private boolean isBinlogAvailable(MySqlOffsetContext offset) {
         String gtidStr = offset.gtidSet();
         if (gtidStr != null) {
-            if (gtidStr.trim().isEmpty()) {
-                return true; // start at beginning ...
-            }
-            String availableGtidStr = connection.knownGtidSet();
-            if (availableGtidStr == null || availableGtidStr.trim().isEmpty()) {
-                // Last offsets had GTIDs but the server does not use them ...
-                LOG.info(
-                        "Connector used GTIDs previously, but MySQL does not know of any GTIDs or they are not enabled");
-                return false;
-            }
-            // GTIDs are enabled
-            GtidSet gtidSet = new GtidSet(gtidStr);
-            // Get the GTID set that is available in the server ...
-            GtidSet availableGtidSet = new GtidSet(availableGtidStr);
-            if (gtidSet.isContainedWithin(availableGtidSet)) {
-                LOG.info(
-                        "MySQL current GTID set {} does contain the GTID set required by the connector {}",
-                        availableGtidSet,
-                        gtidSet);
-                final GtidSet knownServerSet = availableGtidSet;
-                final GtidSet gtidSetToReplicate =
-                        connection.subtractGtidSet(knownServerSet, gtidSet);
-                final GtidSet purgedGtidSet = connection.purgedGtidSet();
-                LOG.info("Server has already purged {} GTIDs", purgedGtidSet);
-                final GtidSet nonPurgedGtidSetToReplicate =
-                        connection.subtractGtidSet(gtidSetToReplicate, purgedGtidSet);
-                LOG.info(
-                        "GTIDs known by the server but not processed yet {}, for replication are available only {}",
-                        gtidSetToReplicate,
-                        nonPurgedGtidSetToReplicate);
-                if (!gtidSetToReplicate.equals(nonPurgedGtidSetToReplicate)) {
-                    LOG.info("Some of the GTIDs needed to replicate have been already purged");
-                    return false;
-                }
-                return true;
-            }
-            LOG.info(
-                    "Connector last known GTIDs are {}, but MySQL has {}",
-                    gtidSet,
-                    availableGtidSet);
-            return false;
+            return checkGtidSet(offset);
         }
 
+        return checkBinlogFileName(offset);
+    }
+
+    private boolean checkGtidSet(MySqlOffsetContext offset) {
+        String gtidStr = offset.gtidSet();
+
+        if (gtidStr.trim().isEmpty()) {
+            return true; // start at beginning ...
+        }
+
+        String availableGtidStr = connection.knownGtidSet();
+        if (availableGtidStr == null || availableGtidStr.trim().isEmpty()) {
+            // Last offsets had GTIDs but the server does not use them ...
+            LOG.warn(
+                    "Connector used GTIDs previously, but MySQL does not know of any GTIDs or they are not enabled");
+            return false;
+        }
+        // GTIDs are enabled
+        GtidSet gtidSet = new GtidSet(gtidStr);
+        // Get the GTID set that is available in the server ...
+        GtidSet availableGtidSet = new GtidSet(availableGtidStr);
+        if (gtidSet.isContainedWithin(availableGtidSet)) {
+            LOG.info(
+                    "MySQL current GTID set {} does contain the GTID set {} required by the connector.",
+                    availableGtidSet,
+                    gtidSet);
+            // The replication is concept of mysql master-slave replication protocol ...
+            final GtidSet gtidSetToReplicate =
+                    connection.subtractGtidSet(availableGtidSet, gtidSet);
+            final GtidSet purgedGtidSet = connection.purgedGtidSet();
+            LOG.info("Server has already purged {} GTIDs", purgedGtidSet);
+            final GtidSet nonPurgedGtidSetToReplicate =
+                    connection.subtractGtidSet(gtidSetToReplicate, purgedGtidSet);
+            LOG.info(
+                    "GTID set {} known by the server but not processed yet, for replication are available only GTID set {}",
+                    gtidSetToReplicate,
+                    nonPurgedGtidSetToReplicate);
+            if (!gtidSetToReplicate.equals(nonPurgedGtidSetToReplicate)) {
+                LOG.warn("Some of the GTIDs needed to replicate have been already purged");
+                return false;
+            }
+            return true;
+        }
+        LOG.info("Connector last known GTIDs are {}, but MySQL has {}", gtidSet, availableGtidSet);
+        return false;
+    }
+
+    private boolean checkBinlogFileName(MySqlOffsetContext offset) {
         String binlogFilename = offset.getSourceInfo().getString(BINLOG_FILENAME_OFFSET_KEY);
         if (binlogFilename == null) {
             return true; // start at current position

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
@@ -190,7 +190,7 @@ public class StatefulTaskContext {
             return checkGtidSet(offset);
         }
 
-        return checkBinlogFileName(offset);
+        return checkBinlogFilename(offset);
     }
 
     private boolean checkGtidSet(MySqlOffsetContext offset) {
@@ -237,7 +237,7 @@ public class StatefulTaskContext {
         return false;
     }
 
-    private boolean checkBinlogFileName(MySqlOffsetContext offset) {
+    private boolean checkBinlogFilename(MySqlOffsetContext offset) {
         String binlogFilename = offset.getSourceInfo().getString(BINLOG_FILENAME_OFFSET_KEY);
         if (binlogFilename == null) {
             return true; // start at current position

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSource.java
@@ -159,7 +159,8 @@ public class MySqlSource<T>
                 new MySqlRecordEmitter<>(
                         deserializationSchema,
                         sourceReaderMetrics,
-                        sourceConfig.isIncludeSchemaChanges()),
+                        sourceConfig.isIncludeSchemaChanges(),
+                        sourceConfig.isHeartbeatEvent()),
                 readerContext.getConfiguration(),
                 mySqlSourceReaderContext,
                 sourceConfig);

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -200,5 +201,9 @@ public class MySqlSourceConfig implements Serializable {
 
     public RelationalTableFilters getTableFilters() {
         return dbzMySqlConfig.getTableFilters();
+    }
+
+    public boolean isHeartbeatEvent() {
+        return Optional.ofNullable(dbzConfiguration.getString("heartbeat.interval.ms")).isPresent();
     }
 }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
@@ -40,6 +40,7 @@ import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.getHis
 import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.getMessageTimestamp;
 import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.getWatermark;
 import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isDataChangeRecord;
+import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isHeartbeatEvent;
 import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isHighWatermarkEvent;
 import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isSchemaChangeEvent;
 import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isWatermarkEvent;
@@ -61,14 +62,17 @@ public final class MySqlRecordEmitter<T>
     private final MySqlSourceReaderMetrics sourceReaderMetrics;
     private final boolean includeSchemaChanges;
     private final OutputCollector<T> outputCollector;
+    private final boolean heartbeatEvent;
 
     public MySqlRecordEmitter(
             DebeziumDeserializationSchema<T> debeziumDeserializationSchema,
             MySqlSourceReaderMetrics sourceReaderMetrics,
-            boolean includeSchemaChanges) {
+            boolean includeSchemaChanges,
+            boolean heartbeatEvent) {
         this.debeziumDeserializationSchema = debeziumDeserializationSchema;
         this.sourceReaderMetrics = sourceReaderMetrics;
         this.includeSchemaChanges = includeSchemaChanges;
+        this.heartbeatEvent = heartbeatEvent;
         this.outputCollector = new OutputCollector<>();
     }
 
@@ -98,6 +102,11 @@ public final class MySqlRecordEmitter<T>
             }
             reportMetrics(element);
             emitElement(element, output);
+        } else if (heartbeatEvent && isHeartbeatEvent(element)) {
+            if (splitState.isBinlogSplitState()) {
+                BinlogOffset position = getBinlogPosition(element);
+                splitState.asBinlogSplitState().setStartingOffset(position);
+            }
         } else {
             // unknown element
             LOG.info("Meet unknown element {}, just skip.", element);

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/RecordUtils.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/RecordUtils.java
@@ -62,6 +62,8 @@ public class RecordUtils {
 
     public static final String SCHEMA_CHANGE_EVENT_KEY_NAME =
             "io.debezium.connector.mysql.SchemaChangeKey";
+    public static final String SCHEMA_HEARTBEAT_EVENT_KEY_NAME =
+            "io.debezium.connector.common.Heartbeat";
     private static final DocumentReader DOCUMENT_READER = DocumentReader.defaultReader();
 
     /** Converts a {@link ResultSet} row to an array of Objects. */
@@ -293,6 +295,15 @@ public class RecordUtils {
     public static boolean isSchemaChangeEvent(SourceRecord sourceRecord) {
         Schema keySchema = sourceRecord.keySchema();
         if (keySchema != null && SCHEMA_CHANGE_EVENT_KEY_NAME.equalsIgnoreCase(keySchema.name())) {
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean isHeartbeatEvent(SourceRecord record) {
+        Schema keySchema = record.keySchema();
+        if (keySchema != null
+                && SCHEMA_HEARTBEAT_EVENT_KEY_NAME.equalsIgnoreCase(keySchema.name())) {
             return true;
         }
         return false;

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
@@ -258,7 +258,8 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
                 new MySqlRecordEmitter<>(
                         new ForwardDeserializeSchema(),
                         new MySqlSourceReaderMetrics(metricGroup),
-                        configuration.isIncludeSchemaChanges());
+                        configuration.isIncludeSchemaChanges(),
+                        configuration.isHeartbeatEvent());
         final MySqlSourceReaderContext mySqlSourceReaderContext =
                 new MySqlSourceReaderContext(readerContext);
         return new MySqlSourceReader<>(


### PR DESCRIPTION
If the table updates infrequently, the binlog file or GTID set may have been cleaned in its last committed binlog position. The CDC job restart fails in this case. So the heartbeat event will update binlog position. #641 