### PR TITLE
[mongodb] Match multiple database and collection names using a regular expression in MongoDB.

### DIFF
--- a/docs/content/connectors/mongodb-cdc.md
+++ b/docs/content/connectors/mongodb-cdc.md
@@ -154,14 +154,14 @@ Connector Options
       <td>required</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Name of the database to watch for changes.</td>
+      <td>Name of the database to watch for changes. If set to empty string, then all databases will be captured (databases can be filtered using the copy.existing.namespace.regex setting).</td>
     </tr>
     <tr>
       <td>collection</td>
       <td>required</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Name of the collection in the database to watch for changes.</td>
+      <td>Name of the collection in the database to watch for changes. If set to empty string, then all collections will be caputred (collections can be filtered using the copy.existing.namespace.regex setting)</td>
     </tr>
     <tr>
       <td>connection.options</td>
@@ -207,6 +207,13 @@ Connector Options
            eg. <code>[{"$match": {"closed": "false"}}]</code> ensures that 
            only documents in which the closed field is set to false are copied.
       </td>
+    </tr>
+    <tr>
+      <td>copy.existing.namespace.regex</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">16000</td>
+      <td>String</td>
+      <td>Regular expression that matches the namespaces from which to copy data. A namespace describes the database name and collection separated by a period, e.g. databaseName.collectionName.</td>
     </tr>
     <tr>
       <td>copy.existing.max.threads</td>

--- a/docs/content/connectors/mongodb-cdc.md
+++ b/docs/content/connectors/mongodb-cdc.md
@@ -151,17 +151,27 @@ Connector Options
     </tr>
     <tr>
       <td>database</td>
-      <td>required</td>
+      <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Name of the database to watch for changes. If set to empty string, then all databases will be captured (databases can be filtered using the copy.existing.namespace.regex setting).</td>
+      <td>Name of the database to watch for changes. If not set then all databases will be captured (databases can be filtered using the <code>namespace.regex</code> setting).</td>
     </tr>
     <tr>
       <td>collection</td>
-      <td>required</td>
+      <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Name of the collection in the database to watch for changes. If set to empty string, then all collections will be caputred (collections can be filtered using the copy.existing.namespace.regex setting)</td>
+      <td>Name of the collection in the database to watch for changes. If not set then all collections will be captured (collections can be filtered using the <code>namespace.regex</code> setting)</td>
+    </tr>
+    <tr>
+      <td>namespace.regex</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Regular expression that matches the namespaces from which to watch for changes. 
+          A namespace describes the database name and collection separated by a period,
+          e.g. <code>'namespace.regex' = '^(db0\\.coll0|db1\\.coll1)$'</code>.
+      </td>
     </tr>
     <tr>
       <td>connection.options</td>
@@ -198,6 +208,16 @@ Connector Options
       <td>Whether copy existing data from source collections.</td>
     </tr>
     <tr>
+      <td>copy.existing.namespace.regex</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Regular expression that matches the namespaces from which to copy data. 
+          A namespace describes the database name and collection separated by a period,
+          e.g. <code>'copy.existing.namespace.regex' = '^(db0\\.coll0|db1\\.coll1)$'</code>.
+      </td>
+    </tr>
+    <tr>
       <td>copy.existing.pipeline</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
@@ -207,13 +227,6 @@ Connector Options
            eg. <code>[{"$match": {"closed": "false"}}]</code> ensures that 
            only documents in which the closed field is set to false are copied.
       </td>
-    </tr>
-    <tr>
-      <td>copy.existing.namespace.regex</td>
-      <td>optional</td>
-      <td style="word-wrap: break-word;">16000</td>
-      <td>String</td>
-      <td>Regular expression that matches the namespaces from which to copy data. A namespace describes the database name and collection separated by a period, e.g. databaseName.collectionName.</td>
     </tr>
     <tr>
       <td>copy.existing.max.threads</td>
@@ -323,6 +336,24 @@ The MongoDB CDC connector is a Flink Source connector which will read database s
 
 The config option `copy.existing` specifies whether do snapshot when MongoDB CDC consumer startup. <br>Defaults to `true`.
 
+### MongoDB Namespaces Filters
+
+The config option `copy.existing.namespace.regex` is a regular expression that matches the namespaces from which to copy data.<br>
+
+In the following example, matches namespaces `db0.coll0` and `db1.coll1` to snapshot.
+
+```
+'copy.existing.namespace.regex' = '^(db0\\.coll0|db1\\.coll1)$'
+```
+
+The config option `namespace.regex` is a regular expression that matches the namespaces from which to watch for changes.<br>
+
+In the following example, matches namespaces `db0.coll0` and `db1.coll1` to watch.
+
+```
+'namespace.regex' = '^(db0\\.coll0|db1\\.coll1)$'
+```
+
 ### Snapshot Data Filters
 
 The config option `copy.existing.pipeline` describing the filters when copying existing data.<br>
@@ -331,7 +362,7 @@ This can filter only required data and improve the use of indexes by the copying
 In the following example, the `$match` aggregation operator ensures that only documents in which the closed field is set to false are copied.
 
 ```
-copy.existing.pipeline=[ { "$match": { "closed": "false" } } ]
+'copy.existing.pipeline' = '[ { "$match": { "closed": "false" } } ]'
 ```
 
 ### Change Streams

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/MongoDBSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/MongoDBSource.java
@@ -134,6 +134,7 @@ public class MongoDBSource {
         private Integer copyExistingMaxThreads;
         private Integer copyExistingQueueSize;
         private String copyExistingPipeline;
+        private String copyExistingNamespaceRegex;
         private Boolean errorsLogEnable;
         private String errorsTolerance;
         private Integer heartbeatIntervalMillis;
@@ -321,6 +322,18 @@ public class MongoDBSource {
             return this;
         }
 
+        /**
+         * copy.existing.namespace.regex
+         *
+         * <p>Regular expression that matches the namespaces from which to copy data. A namespace
+         * describes the database name and collection separated by a period, e.g.
+         * databaseName.collectionName.
+         */
+        public Builder<T> copyExistingNamespaceRegex(String copyExistingNamespaceRegex) {
+            this.copyExistingNamespaceRegex = copyExistingNamespaceRegex;
+            return this;
+        }
+
         /** Build connection uri. */
         @VisibleForTesting
         public ConnectionString buildConnectionUri() {
@@ -422,6 +435,12 @@ public class MongoDBSource {
             if (copyExistingPipeline != null) {
                 props.setProperty(
                         MongoSourceConfig.COPY_EXISTING_PIPELINE_CONFIG, copyExistingPipeline);
+            }
+
+            if (copyExistingNamespaceRegex != null) {
+                props.setProperty(
+                        MongoSourceConfig.COPY_EXISTING_NAMESPACE_REGEX_CONFIG,
+                        copyExistingNamespaceRegex);
             }
 
             if (heartbeatIntervalMillis != null) {

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
@@ -64,6 +64,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
     private final Boolean errorsLogEnable;
     private final String errorsTolerance;
     private final Boolean copyExisting;
+    private final String copyExistingNamespaceRegex;
     private final String copyExistingPipeline;
     private final Integer copyExistingMaxThreads;
     private final Integer copyExistingQueueSize;
@@ -93,6 +94,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
             @Nullable String errorsTolerance,
             @Nullable Boolean errorsLogEnable,
             @Nullable Boolean copyExisting,
+            @Nullable String copyExistingNamespaceRegex,
             @Nullable String copyExistingPipeline,
             @Nullable Integer copyExistingMaxThreads,
             @Nullable Integer copyExistingQueueSize,
@@ -110,6 +112,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
         this.errorsTolerance = errorsTolerance;
         this.errorsLogEnable = errorsLogEnable;
         this.copyExisting = copyExisting;
+        this.copyExistingNamespaceRegex = copyExistingNamespaceRegex;
         this.copyExistingPipeline = copyExistingPipeline;
         this.copyExistingMaxThreads = copyExistingMaxThreads;
         this.copyExistingQueueSize = copyExistingQueueSize;
@@ -155,6 +158,8 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
         Optional.ofNullable(errorsLogEnable).ifPresent(builder::errorsLogEnable);
         Optional.ofNullable(errorsTolerance).ifPresent(builder::errorsTolerance);
         Optional.ofNullable(copyExisting).ifPresent(builder::copyExisting);
+        Optional.ofNullable(copyExistingNamespaceRegex)
+                .ifPresent(builder::copyExistingNamespaceRegex);
         Optional.ofNullable(copyExistingPipeline).ifPresent(builder::copyExistingPipeline);
         Optional.ofNullable(copyExistingMaxThreads).ifPresent(builder::copyExistingMaxThreads);
         Optional.ofNullable(copyExistingQueueSize).ifPresent(builder::copyExistingQueueSize);
@@ -212,6 +217,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                         errorsTolerance,
                         errorsLogEnable,
                         copyExisting,
+                        copyExistingNamespaceRegex,
                         copyExistingPipeline,
                         copyExistingMaxThreads,
                         copyExistingQueueSize,
@@ -243,6 +249,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                 && Objects.equals(errorsTolerance, that.errorsTolerance)
                 && Objects.equals(errorsLogEnable, that.errorsLogEnable)
                 && Objects.equals(copyExisting, that.copyExisting)
+                && Objects.equals(copyExistingNamespaceRegex, that.copyExistingNamespaceRegex)
                 && Objects.equals(copyExistingPipeline, that.copyExistingPipeline)
                 && Objects.equals(copyExistingMaxThreads, that.copyExistingMaxThreads)
                 && Objects.equals(copyExistingQueueSize, that.copyExistingQueueSize)
@@ -267,6 +274,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                 errorsTolerance,
                 errorsLogEnable,
                 copyExisting,
+                copyExistingNamespaceRegex,
                 copyExistingPipeline,
                 copyExistingMaxThreads,
                 copyExistingQueueSize,

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
@@ -61,6 +61,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
     private final String password;
     private final String database;
     private final String collection;
+    private final String namespaceRegex;
     private final Boolean errorsLogEnable;
     private final String errorsTolerance;
     private final Boolean copyExisting;
@@ -88,8 +89,9 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
             String hosts,
             @Nullable String username,
             @Nullable String password,
-            String database,
-            String collection,
+            @Nullable String database,
+            @Nullable String collection,
+            @Nullable String namespaceRegex,
             @Nullable String connectionOptions,
             @Nullable String errorsTolerance,
             @Nullable Boolean errorsLogEnable,
@@ -106,8 +108,9 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
         this.hosts = checkNotNull(hosts);
         this.username = username;
         this.password = password;
-        this.database = checkNotNull(database);
-        this.collection = checkNotNull(collection);
+        this.database = database;
+        this.collection = collection;
+        this.namespaceRegex = namespaceRegex;
         this.connectionOptions = connectionOptions;
         this.errorsTolerance = errorsTolerance;
         this.errorsLogEnable = errorsLogEnable;
@@ -146,14 +149,13 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                         physicalDataType, metadataConverters, typeInfo, localTimeZone);
 
         MongoDBSource.Builder<RowData> builder =
-                MongoDBSource.<RowData>builder()
-                        .hosts(hosts)
-                        .database(database)
-                        .collection(collection)
-                        .deserializer(deserializer);
+                MongoDBSource.<RowData>builder().hosts(hosts).deserializer(deserializer);
 
         Optional.ofNullable(username).ifPresent(builder::username);
         Optional.ofNullable(password).ifPresent(builder::password);
+        Optional.ofNullable(database).ifPresent(builder::database);
+        Optional.ofNullable(collection).ifPresent(builder::collection);
+        Optional.ofNullable(namespaceRegex).ifPresent(builder::namespaceRegex);
         Optional.ofNullable(connectionOptions).ifPresent(builder::connectionOptions);
         Optional.ofNullable(errorsLogEnable).ifPresent(builder::errorsLogEnable);
         Optional.ofNullable(errorsTolerance).ifPresent(builder::errorsTolerance);
@@ -213,6 +215,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                         password,
                         database,
                         collection,
+                        namespaceRegex,
                         connectionOptions,
                         errorsTolerance,
                         errorsLogEnable,
@@ -245,6 +248,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                 && Objects.equals(password, that.password)
                 && Objects.equals(database, that.database)
                 && Objects.equals(collection, that.collection)
+                && Objects.equals(namespaceRegex, that.namespaceRegex)
                 && Objects.equals(connectionOptions, that.connectionOptions)
                 && Objects.equals(errorsTolerance, that.errorsTolerance)
                 && Objects.equals(errorsLogEnable, that.errorsLogEnable)
@@ -270,6 +274,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                 password,
                 database,
                 collection,
+                namespaceRegex,
                 connectionOptions,
                 errorsTolerance,
                 errorsLogEnable,

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
@@ -142,6 +142,15 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
                     .withDescription(
                             "The max size of the queue to use when copying data. Defaults to 16000.");
 
+    private static final ConfigOption<String> COPY_EXISTING_NAMESPACE_REGEX =
+            ConfigOptions.key("copy.existing.namespace.regex")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Regular expression that matches the namespaces from which to copy data. "
+                                    + "A namespace describes the database name and collection separated by a period, "
+                                    + "e.g. databaseName.collectionName.");
+
     private static final ConfigOption<Integer> POLL_MAX_BATCH_SIZE =
             ConfigOptions.key("poll.max.batch.size")
                     .intType()
@@ -200,6 +209,8 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
         String copyExistingPipeline = config.getOptional(COPY_EXISTING_PIPELINE).orElse(null);
         Integer copyExistingMaxThreads = config.getOptional(COPY_EXISTING_MAX_THREADS).orElse(null);
         Integer copyExistingQueueSize = config.getOptional(COPY_EXISTING_QUEUE_SIZE).orElse(null);
+        String copyExistingNamespaceRegex =
+                config.getOptional(COPY_EXISTING_NAMESPACE_REGEX).orElse(null);
 
         String zoneId = context.getConfiguration().get(TableConfigOptions.LOCAL_TIME_ZONE);
         ZoneId localTimeZone =
@@ -225,6 +236,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
                 copyExistingPipeline,
                 copyExistingMaxThreads,
                 copyExistingQueueSize,
+                copyExistingNamespaceRegex,
                 pollMaxBatchSize,
                 pollAwaitTimeMillis,
                 heartbeatIntervalMillis,
@@ -263,6 +275,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
         options.add(COPY_EXISTING_PIPELINE);
         options.add(COPY_EXISTING_MAX_THREADS);
         options.add(COPY_EXISTING_QUEUE_SIZE);
+        options.add(COPY_EXISTING_NAMESPACE_REGEX);
         options.add(POLL_MAX_BATCH_SIZE);
         options.add(POLL_AWAIT_TIME_MILLIS);
         options.add(HEARTBEAT_INTERVAL_MILLIS);

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/MongoDBTestBase.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/MongoDBTestBase.java
@@ -18,6 +18,7 @@
 
 package com.ververica.cdc.connectors.mongodb;
 
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.test.util.AbstractTestBase;
 
 import com.mongodb.ConnectionString;
@@ -125,6 +126,30 @@ public class MongoDBTestBase extends AbstractTestBase {
             return dbName;
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    protected static void waitForSnapshotStarted(String sinkName) throws InterruptedException {
+        while (sinkSize(sinkName) == 0) {
+            Thread.sleep(100);
+        }
+    }
+
+    protected static void waitForSinkSize(String sinkName, int expectedSize)
+            throws InterruptedException {
+        while (sinkSize(sinkName) < expectedSize) {
+            Thread.sleep(100);
+        }
+    }
+
+    protected static int sinkSize(String sinkName) {
+        synchronized (TestValuesTableFactory.class) {
+            try {
+                return TestValuesTableFactory.getRawResults(sinkName).size();
+            } catch (IllegalArgumentException e) {
+                // job is not started yet
+                return 0;
+            }
         }
     }
 }

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBConnectorITCase.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBConnectorITCase.java
@@ -42,14 +42,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /** Integration tests for MongoDB change stream event SQL source. */
 public class MongoDBConnectorITCase extends MongoDBTestBase {
@@ -468,43 +466,6 @@ public class MongoDBConnectorITCase extends MongoDBTestBase {
         Collections.sort(actual);
         assertEquals(expected, actual);
         result.getJobClient().get().cancel().get();
-    }
-
-    private static void waitForSnapshotStarted(String sinkName) throws InterruptedException {
-        while (sinkSize(sinkName) == 0) {
-            Thread.sleep(100);
-        }
-    }
-
-    private static void waitForSinkSize(String sinkName, int expectedSize)
-            throws InterruptedException {
-        waitForSinkSize(sinkName, expectedSize, 10, TimeUnit.MINUTES);
-    }
-
-    private static void waitForSinkSize(
-            String sinkName, int expectedSize, long timeout, TimeUnit timeUnit)
-            throws InterruptedException {
-        long deadline = System.nanoTime() + timeUnit.toNanos(timeout);
-        while (sinkSize(sinkName) < expectedSize) {
-            if (System.nanoTime() > deadline) {
-                fail(
-                        "Wait for sink size timeout, raw results: \n"
-                                + String.join(
-                                        "\n", TestValuesTableFactory.getRawResults(sinkName)));
-            }
-            Thread.sleep(100);
-        }
-    }
-
-    private static int sinkSize(String sinkName) {
-        synchronized (TestValuesTableFactory.class) {
-            try {
-                return TestValuesTableFactory.getRawResults(sinkName).size();
-            } catch (IllegalArgumentException e) {
-                // job is not started yet
-                return 0;
-            }
-        }
     }
 
     private Document productDocOf(String id, String name, String description, Double weight) {

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBNamespaceRegexITCase.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBNamespaceRegexITCase.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mongodb.table;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+
+import com.mongodb.client.MongoDatabase;
+import com.ververica.cdc.connectors.mongodb.MongoDBTestBase;
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+/** Integration tests to check mongodb-cdc works well under namespace.regex. */
+public class MongoDBNamespaceRegexITCase extends MongoDBTestBase {
+
+    private final StreamExecutionEnvironment env =
+            StreamExecutionEnvironment.getExecutionEnvironment();
+    private final StreamTableEnvironment tEnv =
+            StreamTableEnvironment.create(
+                    env,
+                    EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build());
+
+    @Before
+    public void before() {
+        TestValuesTableFactory.clearAllData();
+        env.setParallelism(1);
+    }
+
+    /**
+     * Case1: match multiple databases and collections by namespace.regex.
+     *
+     * <p>Given collections: db0.coll_a1, db0.coll_a2, db0.coll_b1, db0.coll_b2 db1.coll_a1,
+     * db1.coll_a2, db1.coll_b1, db1.coll_b2
+     *
+     * <p>Test condition: namespaceRegex = ^(db0|db1)\.coll_a\d?$
+     *
+     * <p>Assert collections: snapshot: db0.coll_a1, db0.coll_a2, db1.coll_a1, db1.coll_a2 watch:
+     * db0.coll_a1, db0.coll_a2, db1.coll_a1, db1.coll_a2
+     */
+    @Test
+    public void testNamespaceRegexCase1() throws Exception {
+        // 1. Given collections:
+        // db0.coll_a1, db0.coll_a2, db0.coll_b1, db0.coll_b2
+        String db0 = executeCommandFileInSeparateDatabase("ns_regex");
+        // db1.coll_a1, db1.coll_a2, db1.coll_b1, db1.coll_b2
+        String db1 = executeCommandFileInSeparateDatabase("ns_regex");
+
+        // 2. Test match: db0.coll_a1, db0.coll_a2, db1.coll_a1, db1.coll_a2
+        // ^(db0|db1)\.coll_a\d?$
+        String namespaceRegex = String.format("^(%s|%s)\\.coll_a\\d?$", db0, db1);
+        TableResult result = submitTestCase(null, null, namespaceRegex, null);
+
+        // 3. Wait snapshot finished
+        waitForSinkSize("mongodb_sink", 4);
+
+        // 4. Insert new records in database
+        // db0: coll_a1.A102, coll_a2.A202, coll_b1.B102, coll_b1.B102
+        insertRecordsInDatabase(db0);
+        // db1: coll_a1.A102, coll_a2.A202, coll_b1.B102, coll_b1.B102
+        insertRecordsInDatabase(db1);
+
+        // 5. Wait change stream records come
+        waitForSinkSize("mongodb_sink", 8);
+
+        // 6. Check results
+        String[] expected =
+                new String[] {
+                    // Expect snapshot collections:
+                    // db0.coll_a1, db0.coll_a2, db1.coll_a1,db1.coll_a2
+                    String.format("+I[%s, coll_a1, A101]", db0),
+                    String.format("+I[%s, coll_a2, A201]", db0),
+                    String.format("+I[%s, coll_a1, A101]", db1),
+                    String.format("+I[%s, coll_a2, A201]", db1),
+                    // Expect watch collections:
+                    // db0.coll_a1, db0.coll_a2, db1.coll_a1, db1.coll_a2
+                    String.format("+I[%s, coll_a1, A102]", db0),
+                    String.format("+I[%s, coll_a2, A202]", db0),
+                    String.format("+I[%s, coll_a1, A102]", db1),
+                    String.format("+I[%s, coll_a2, A202]", db1)
+                };
+
+        List<String> actual = TestValuesTableFactory.getResults("mongodb_sink");
+        assertThat(actual, containsInAnyOrder(expected));
+
+        result.getJobClient().get().cancel().get();
+    }
+
+    /**
+     * Case2: match single database and multiple collections by namespace.regex.
+     *
+     * <p>Given collections: db0.coll_a1, db0.coll_a2, db0.coll_b1, db0.coll_b2 db1.coll_a1,
+     * db1.coll_a2, db1.coll_b1, db1.coll_b2
+     *
+     * <p>Test condition: namespaceRegex = ^db0\.coll_b\d?$
+     *
+     * <p>Assert collections: snapshot: db0.coll_b1, db0.coll_b2 watch: db0.coll_b1, db0.coll_b2
+     */
+    @Test
+    public void testNamespaceRegexCase2() throws Exception {
+        // 1. Given collections:
+        // db0.coll_a1, db0.coll_a2, db0.coll_b1, db0.coll_b2
+        String db0 = executeCommandFileInSeparateDatabase("ns_regex");
+        // db1.coll_a1, db1.coll_a2, db1.coll_b1, db1.coll_b2
+        String db1 = executeCommandFileInSeparateDatabase("ns_regex");
+
+        // 2. Test match: db0.coll_b1, db0.coll_b2
+        // ^(db0|db1)\.coll_a\d?$
+        String namespaceRegex = String.format("^%s\\.coll_b\\d?$", db0);
+        TableResult result = submitTestCase(null, null, namespaceRegex, null);
+
+        // 3. Wait snapshot finished
+        waitForSinkSize("mongodb_sink", 2);
+
+        // 4. Insert new records in database
+        // db0: coll_a1.A102, coll_a2.A202, coll_b1.B102, coll_b1.B102
+        insertRecordsInDatabase(db0);
+        // db1: coll_a1.A102, coll_a2.A202, coll_b1.B102, coll_b1.B102
+        insertRecordsInDatabase(db1);
+
+        // 5. Wait change stream records come
+        waitForSinkSize("mongodb_sink", 4);
+
+        // 6. Check results
+        String[] expected =
+                new String[] {
+                    // Expect snapshot collections: db0.coll_b1, db0.coll_b2
+                    String.format("+I[%s, coll_b1, B101]", db0),
+                    String.format("+I[%s, coll_b2, B201]", db0),
+                    // Expect watch collections: db0.coll_b1, db0.coll_b2
+                    String.format("+I[%s, coll_b1, B102]", db0),
+                    String.format("+I[%s, coll_b2, B202]", db0)
+                };
+
+        List<String> actual = TestValuesTableFactory.getResults("mongodb_sink");
+        assertThat(actual, containsInAnyOrder(expected));
+
+        result.getJobClient().get().cancel().get();
+    }
+
+    /**
+     * Case3: match multiple databases and collections by namespace.regex and
+     * copy.existing.namespace.regex.
+     *
+     * <p>Given collections: db0.coll_a1, db0.coll_a2, db0.coll_b1, db0.coll_b2 db1.coll_a1,
+     * db1.coll_a2, db1.coll_b1, db1.coll_b2
+     *
+     * <p>Test condition: namespaceRegex = ^(db0|db1)\.coll_a\d?$, copyExistingNamespaceRegex =
+     * ^db0\.coll_a\d?$
+     *
+     * <p>Assert collections: snapshot: db0.coll_a1, db0.coll_a2 watch: db0.coll_a1, db0.coll_a2,
+     * db1.coll_a1, db1.coll_a2
+     */
+    @Test
+    public void testNamespaceRegexCase3() throws Exception {
+        // 1. Given collections:
+        // db0.coll_a1, db0.coll_a2, db0.coll_b1, db0.coll_b2
+        String db0 = executeCommandFileInSeparateDatabase("ns_regex");
+        // db1.coll_a1, db1.coll_a2, db1.coll_b1, db1.coll_b2
+        String db1 = executeCommandFileInSeparateDatabase("ns_regex");
+
+        // 2.1. Test watch: db0.coll_a1, db0.coll_a2, db1.coll_a1, db1.coll_a2
+        // ^(db0|db1)\.coll_a\d?$
+        String namespaceRegex = String.format("^(%s|%s)\\.coll_a\\d?$", db0, db1);
+        // 2.2. Test snapshot: db0.coll_a1, db0.coll_a2
+        // ^db0\.coll_a\d?$
+        String copyExistingNamespaceRegex = String.format("^%s\\.coll_a\\d?$", db0, db1);
+        TableResult result = submitTestCase(null, null, namespaceRegex, copyExistingNamespaceRegex);
+
+        // 3. Wait snapshot finished
+        waitForSinkSize("mongodb_sink", 2);
+
+        // 4. Insert new records in database
+        // db0: coll_a1.A102, coll_a2.A202, coll_b1.B102, coll_b1.B102
+        insertRecordsInDatabase(db0);
+        // db1: coll_a1.A102, coll_a2.A202, coll_b1.B102, coll_b1.B102
+        insertRecordsInDatabase(db1);
+
+        // 5. Wait change stream records come
+        waitForSinkSize("mongodb_sink", 6);
+
+        // 6. Check results
+        String[] expected =
+                new String[] {
+                    // Expect snapshot collections: db0.coll_a1, db0.coll_a2
+                    String.format("+I[%s, coll_a1, A101]", db0),
+                    String.format("+I[%s, coll_a2, A201]", db0),
+                    // Expect watch collections: db0.coll_a1, db0.coll_a2, db1.coll_a1, db1.coll_a2
+                    String.format("+I[%s, coll_a1, A102]", db0),
+                    String.format("+I[%s, coll_a2, A202]", db0),
+                    String.format("+I[%s, coll_a1, A102]", db1),
+                    String.format("+I[%s, coll_a2, A202]", db1)
+                };
+
+        List<String> actual = TestValuesTableFactory.getResults("mongodb_sink");
+        assertThat(actual, containsInAnyOrder(expected));
+
+        result.getJobClient().get().cancel().get();
+    }
+
+    private TableResult submitTestCase(
+            String database,
+            String collection,
+            String namespaceRegex,
+            String copyExistingNamespaceRegex)
+            throws Exception {
+        String sourceDDL =
+                "CREATE TABLE mongodb_source ("
+                        + " _id STRING NOT NULL,"
+                        + " seq STRING,"
+                        + " db_name STRING METADATA FROM 'database_name' VIRTUAL,"
+                        + " coll_name STRING METADATA FROM 'collection_name' VIRTUAL,"
+                        + " PRIMARY KEY (_id) NOT ENFORCED"
+                        + ") WITH ("
+                        + ignoreIfNull("hosts", MONGODB_CONTAINER.getHostAndPort())
+                        + ignoreIfNull("username", FLINK_USER)
+                        + ignoreIfNull("password", FLINK_USER_PASSWORD)
+                        + ignoreIfNull("database", database)
+                        + ignoreIfNull("collection", collection)
+                        + ignoreIfNull("namespace.regex", namespaceRegex)
+                        + ignoreIfNull("copy.existing.namespace.regex", copyExistingNamespaceRegex)
+                        + " 'connector' = 'mongodb-cdc'"
+                        + ")";
+
+        String sinkDDL =
+                "CREATE TABLE mongodb_sink ("
+                        + " db_name STRING,"
+                        + " coll_name STRING,"
+                        + " seq STRING,"
+                        + " PRIMARY KEY (db_name, coll_name, seq) NOT ENFORCED"
+                        + ") WITH ("
+                        + " 'connector' = 'values',"
+                        + " 'sink-insert-only' = 'false'"
+                        + ")";
+        tEnv.executeSql(sourceDDL);
+        tEnv.executeSql(sinkDDL);
+
+        // async submit job
+        TableResult result =
+                tEnv.executeSql(
+                        "INSERT INTO mongodb_sink SELECT db_name, coll_name, seq FROM mongodb_source");
+
+        waitForSnapshotStarted("mongodb_sink");
+
+        return result;
+    }
+
+    private String ignoreIfNull(String configName, String configValue) {
+        return configValue != null ? String.format(" '%s' = '%s',", configName, configValue) : "";
+    }
+
+    private void insertRecordsInDatabase(String database) {
+        MongoDatabase db = getMongoDatabase(database);
+        db.getCollection("coll_a1").insertOne(new Document("seq", "A102"));
+        db.getCollection("coll_a2").insertOne(new Document("seq", "A202"));
+        db.getCollection("coll_b1").insertOne(new Document("seq", "B102"));
+        db.getCollection("coll_b2").insertOne(new Document("seq", "B202"));
+    }
+}

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
@@ -99,6 +99,7 @@ public class MongoDBTableFactoryTest {
                         MY_DATABASE,
                         MY_TABLE,
                         null,
+                        null,
                         ERROR_TOLERANCE,
                         ERROR_LOGS_ENABLE,
                         COPY_EXISTING,
@@ -117,13 +118,14 @@ public class MongoDBTableFactoryTest {
     public void testOptionalProperties() {
         Map<String, String> options = getAllOptions();
         options.put("connection.options", "replicaSet=test&connectTimeoutMS=300000");
+        options.put("namespace.regex", "^db\\.coll_.*$");
         options.put("errors.tolerance", "all");
         options.put("errors.log.enable", "false");
         options.put("copy.existing", "false");
         options.put("copy.existing.pipeline", "[ { \"$match\": { \"closed\": \"false\" } } ]");
         options.put("copy.existing.max.threads", "1");
         options.put("copy.existing.queue.size", "101");
-        options.put("copy.existing.namespace.regex", ".*");
+        options.put("copy.existing.namespace.regex", "^db\\.coll_1.*$");
         options.put("poll.max.batch.size", "102");
         options.put("poll.await.time.ms", "103");
         options.put("heartbeat.interval.ms", "104");
@@ -137,11 +139,12 @@ public class MongoDBTableFactoryTest {
                         PASSWORD,
                         MY_DATABASE,
                         MY_TABLE,
+                        "^db\\.coll_.*$",
                         "replicaSet=test&connectTimeoutMS=300000",
                         ERROR_TOLERANCE_ALL,
                         false,
                         false,
-                        ".*",
+                        "^db\\.coll_1.*$",
                         "[ { \"$match\": { \"closed\": \"false\" } } ]",
                         1,
                         101,
@@ -172,6 +175,7 @@ public class MongoDBTableFactoryTest {
                         PASSWORD,
                         MY_DATABASE,
                         MY_TABLE,
+                        null,
                         null,
                         ERROR_TOLERANCE,
                         ERROR_LOGS_ENABLE,

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
@@ -105,6 +105,7 @@ public class MongoDBTableFactoryTest {
                         null,
                         null,
                         null,
+                        null,
                         POLL_MAX_BATCH_SIZE_DEFAULT,
                         POLL_AWAIT_TIME_MILLIS_DEFAULT,
                         null,
@@ -122,6 +123,7 @@ public class MongoDBTableFactoryTest {
         options.put("copy.existing.pipeline", "[ { \"$match\": { \"closed\": \"false\" } } ]");
         options.put("copy.existing.max.threads", "1");
         options.put("copy.existing.queue.size", "101");
+        options.put("copy.existing.namespace.regex", ".*");
         options.put("poll.max.batch.size", "102");
         options.put("poll.await.time.ms", "103");
         options.put("heartbeat.interval.ms", "104");
@@ -139,6 +141,7 @@ public class MongoDBTableFactoryTest {
                         ERROR_TOLERANCE_ALL,
                         false,
                         false,
+                        ".*",
                         "[ { \"$match\": { \"closed\": \"false\" } } ]",
                         1,
                         101,
@@ -173,6 +176,7 @@ public class MongoDBTableFactoryTest {
                         ERROR_TOLERANCE,
                         ERROR_LOGS_ENABLE,
                         COPY_EXISTING,
+                        null,
                         null,
                         null,
                         null,

--- a/flink-connector-mongodb-cdc/src/test/resources/ddl/ns_regex.js
+++ b/flink-connector-mongodb-cdc/src/test/resources/ddl/ns_regex.js
@@ -1,0 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+db.getCollection('coll_a1').insertOne({"seq": "A101"});
+db.getCollection('coll_a2').insertOne({"seq": "A201"});
+db.getCollection('coll_b1').insertOne({"seq": "B101"});
+db.getCollection('coll_b2').insertOne({"seq": "B201"});


### PR DESCRIPTION
I made a little modification in the #475.  

Provided `namespace.regex` to filter namespaces to watch for change.
Provided `copy.exising.namespace.regex` to filter namespaces to snapshot.

Related:
#699 
