### PR TITLE
[hotfix][mysql] Remove mysql-connector-java dependency from flink-sql-connector-mysql-cdc

### DIFF
--- a/flink-sql-connector-mysql-cdc/pom.xml
+++ b/flink-sql-connector-mysql-cdc/pom.xml
@@ -61,7 +61,6 @@ under the License.
                                     <include>com.ververica:flink-connector-mysql-cdc</include>
                                     <include>org.antlr:antlr4-runtime</include>
                                     <include>org.apache.kafka:*</include>
-                                    <include>mysql:mysql-connector-java</include>
                                     <include>com.zendesk:mysql-binlog-connector-java</include>
                                     <include>com.fasterxml.*:*</include>
                                     <include>com.google.guava:*</include>

--- a/flink-sql-connector-mysql-cdc/pom.xml
+++ b/flink-sql-connector-mysql-cdc/pom.xml
@@ -127,3 +127,4 @@ under the License.
         </plugins>
     </build>
 </project>
+

--- a/flink-sql-connector-mysql-cdc/pom.xml
+++ b/flink-sql-connector-mysql-cdc/pom.xml
@@ -127,4 +127,3 @@ under the License.
         </plugins>
     </build>
 </project>
-


### PR DESCRIPTION
This fixes #884
User should add this dependency by themselves.