### PR TITLE
[mysql] accelerate suspend speed

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
@@ -117,7 +117,11 @@ public class MySqlSourceEnumerator implements SplitEnumerator<MySqlSplit, Pendin
 
     @Override
     public void addReader(int subtaskId) {
-        // do nothing
+        // send SuspendBinlogReaderEvent to source reader if the assigner's status is
+        // suspended
+        if (isSuspended(splitAssigner.getAssignerStatus())) {
+            context.sendEventToSourceReader(subtaskId, new SuspendBinlogReaderEvent());
+        }
     }
 
     @Override


### PR DESCRIPTION
`suspendBinlogReaderIfNeed` broadcast `SuspendBinlogReaderEvent`
when splitAssigner is in suspend status, but there are chances
that this happens before `SourceReader` registered to
`SourceEnumerator`, in that case, we will need to wait
`CHECK_EVENT_INTERVAL` a.k.a 30s to resend the event message,
which can be annoying.

In this patch, simply send `SuspendBinlogReaderEvent` message
when `SourceReader` registers if the assigner's status is
suspended.

Signed-off-by: 元组 <zhaojunwang.zjw@alibaba-inc.com>