### PR TITLE
[build] Decrease the azure job timeout to reasonable 40 minutes

### DIFF
--- a/tools/azure-pipelines/jobs-template-for-self-hosted-agent.yml
+++ b/tools/azure-pipelines/jobs-template-for-self-hosted-agent.yml
@@ -24,7 +24,7 @@ jobs:
     # succeeded() is needed to allow job cancellation
     condition: and(succeeded(), not(eq(variables['MODE'], 'e2e')))
     pool: ${{parameters.test_pool_definition}}
-    timeoutInMinutes: 240
+    timeoutInMinutes: 40
     cancelTimeoutInMinutes: 1
     workspace:
       clean: all # this cleans the entire workspace directory before running a new job
@@ -68,7 +68,7 @@ jobs:
     dependsOn: compile_${{parameters.stage_name}}
     condition: and(succeeded(), not(eq(variables['MODE'], 'e2e')))
     pool: ${{parameters.test_pool_definition}}
-    timeoutInMinutes: 240
+    timeoutInMinutes: 40
     cancelTimeoutInMinutes: 1
     workspace:
       clean: all

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -24,7 +24,7 @@ jobs:
     # succeeded() is needed to allow job cancellation
     condition: and(succeeded(), not(eq(variables['MODE'], 'e2e')))
     pool: ${{parameters.test_pool_definition}}
-    timeoutInMinutes: 240
+    timeoutInMinutes: 40
     cancelTimeoutInMinutes: 1
     workspace:
       clean: all # this cleans the entire workspace directory before running a new job
@@ -68,7 +68,7 @@ jobs:
     dependsOn: compile_${{parameters.stage_name}}
     condition: and(succeeded(), not(eq(variables['MODE'], 'e2e')))
     pool: ${{parameters.test_pool_definition}}
-    timeoutInMinutes: 240
+    timeoutInMinutes: 40
     cancelTimeoutInMinutes: 1
     workspace:
       clean: all


### PR DESCRIPTION
Current azure job timeout is 240 mins which is too long which lead to some bad case hang and waste the machine resource. As the max cost time of job is about  22 minutes now, I suggest reducing to 40 minutes. 


Normal case : https://dev.azure.com/ververica/flink-cdc-connectors/_build/results?buildId=1342&view=results


Bad case: https://dev.azure.com/ververica/flink-cdc-connectors/_build/results?buildId=1343&view=results