### PR TITLE
Remove redundant environment variable in tutorial

### DIFF
--- a/docs/content/quickstart/mysql-postgres-tutorial.md
+++ b/docs/content/quickstart/mysql-postgres-tutorial.md
@@ -26,7 +26,6 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - POSTGRES_PASSWORD=1234
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres

--- a/docs/content/快速上手/mysql-postgres-tutorial-zh.md
+++ b/docs/content/快速上手/mysql-postgres-tutorial-zh.md
@@ -23,7 +23,6 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - POSTGRES_PASSWORD=1234
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres


### PR DESCRIPTION
In `mysql-postgres-tutorial.md`, environment variable `POSTGRES_PASSWORD` is defined twice with different values. This is not only redundant, but it could also lead to errors if/when the wrong value is used.

This PR removes the wrong value and only keeps the right one.