### PR TITLE
[mysql][hotfix] serialize isSuspended flag for MySqlBinlogSplit backport to 2.2

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/AssignerStatus.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/AssignerStatus.java
@@ -188,6 +188,11 @@ public enum AssignerStatus {
         return assignerStatus == INITIAL_ASSIGNING || assignerStatus == NEWLY_ADDED_ASSIGNING;
     }
 
+    /** Returns whether the split assigner is assigning newly added snapshot splits. */
+    public static boolean isNewlyAddedAssigning(AssignerStatus assignerStatus) {
+        return assignerStatus == NEWLY_ADDED_ASSIGNING;
+    }
+
     /** Returns whether the split assigner has finished its initial tables assignment. */
     public static boolean isInitialAssigningFinished(AssignerStatus assignerStatus) {
         return assignerStatus == INITIAL_ASSIGNING_FINISHED;

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReader.java
@@ -196,7 +196,9 @@ public class MySqlSourceReader<T>
         // notify split enumerator again about the finished unacked snapshot splits
         reportFinishedSnapshotSplitsIfNeed();
         // add all un-finished splits (including binlog split) to SourceReaderBase
-        super.addSplits(unfinishedSplits);
+        if (!unfinishedSplits.isEmpty()) {
+            super.addSplits(unfinishedSplits);
+        }
     }
 
     private MySqlBinlogSplit discoverTableSchemasForBinlogSplit(MySqlBinlogSplit split) {

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceITCase.java
@@ -455,9 +455,7 @@ public class MySqlSourceITCase extends MySqlSourceTestBase {
             }
 
             // trigger failover after some snapshot data read finished
-            if (failoverPhase == FailoverPhase.SNAPSHOT
-                    && TestValuesTableFactory.getRawResults("sink").size()
-                            > fetchedDataList.size()) {
+            if (failoverPhase == FailoverPhase.SNAPSHOT) {
                 triggerFailover(
                         failoverType,
                         jobClient.getJobID(),

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSplitSerializerTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSplitSerializerTest.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.ververica.cdc.connectors.mysql.source.split.MySqlBinlogSplit.toSuspendedBinlogSplit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
@@ -101,6 +102,9 @@ public class MySqlSplitSerializerTest {
                         databaseHistory,
                         finishedSplitsInfo.size());
         assertEquals(split, serializeAndDeserializeSplit(split));
+
+        final MySqlSplit suspendedBinlogSplit = toSuspendedBinlogSplit(split.asBinlogSplit());
+        assertEquals(suspendedBinlogSplit, serializeAndDeserializeSplit(suspendedBinlogSplit));
 
         final MySqlSplit unCompletedBinlogSplit =
                 new MySqlBinlogSplit(


### PR DESCRIPTION
serialize `isSuspended` field, and modify the test case to enable Snapshot failover.