### PR TITLE
[tidb] fix RowKind.INSERT judgement condition in DeserializatonSchema

### DIFF
--- a/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/table/RowDataTiKVChangeEventDeserializationSchema.java
+++ b/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/table/RowDataTiKVChangeEventDeserializationSchema.java
@@ -81,7 +81,7 @@ public class RowDataTiKVChangeEventDeserializationSchema
                                     row.getValue().toByteArray(),
                                     RowKey.decode(row.getKey().toByteArray()).getHandle(),
                                     tableInfo);
-                    if (row.getOldValue() == null) {
+                    if (row.getOldValue() == null || row.getOldValue().isEmpty()) {
                         RowData rowDataUpdateBefore =
                                 (RowData) physicalConverter.convert(tikvValues, tableInfo, null);
                         rowDataUpdateBefore.setRowKind(RowKind.INSERT);


### PR DESCRIPTION
RowKind.INSERT is decided via `if (row.getOldValue() == null)` in `RowDataTiKVChangeEventDeserializationSchema:84`. 

But when performing INSERT statements in TiDB, it produced a Row record with NOT NULL return value from  `row.getOldValue()` but `Internal.EMPTY_BYTE_ARRAY`(a String[0] array) return value from `row.getOldValue().toByteArray()`, which will produce wrong RowKind (expect `INSERT` but actual `UPDATE_AFTER`) of the emitted RowData.

Hence it should add a length judgement condition for INSERT.