### PR TITLE
[mysql] startup mode support of  timestamp and earliest

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/DebeziumUtils.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/DebeziumUtils.java
@@ -101,14 +101,16 @@ public class DebeziumUtils {
     public static BinlogOffset earliestBinlogOffset(JdbcConnection jdbc) {
         final String purgedStmt = "SELECT @@global.gtid_purged";
         try {
-            String gtidSet = jdbc.queryAndMap(purgedStmt, rs -> {
-                if (rs.next() && rs.getMetaData().getColumnCount() > 0) {
-                    return rs.getString(1);
-                }
-                return null;
-            });
-            return new BinlogOffset("", 0, 0,
-                    0, 0, gtidSet, null);
+            String gtidSet =
+                    jdbc.queryAndMap(
+                            purgedStmt,
+                            rs -> {
+                                if (rs.next() && rs.getMetaData().getColumnCount() > 0) {
+                                    return rs.getString(1);
+                                }
+                                return null;
+                            });
+            return new BinlogOffset("", 0, 0, 0, 0, gtidSet, null);
         } catch (SQLException e) {
             throw new FlinkRuntimeException(
                     "Cannot read gtidSet via '"

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSource.java
@@ -195,7 +195,7 @@ public class MySqlSource<T>
             case LATEST_OFFSET:
             case EARLIEST_OFFSET:
             case TIMESTAMP:
-                splitAssigner = new MySqlBinlogSplitAssigner(sourceConfig);;
+                splitAssigner = new MySqlBinlogSplitAssigner(sourceConfig);
                 break;
             default:
                 throw new UnsupportedOperationException(

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSource.java
@@ -193,14 +193,9 @@ public class MySqlSource<T>
                 }
                 break;
             case LATEST_OFFSET:
-                splitAssigner = new MySqlBinlogSplitAssigner(sourceConfig);
-                break;
             case EARLIEST_OFFSET:
             case TIMESTAMP:
-                splitAssigner =
-                        new MySqlBinlogSplitAssigner(
-                                sourceConfig,
-                                MySqlBinlogSplitAssigner.BinlogOffsetReadingMode.EARLIEST_OFFSET);
+                splitAssigner = new MySqlBinlogSplitAssigner(sourceConfig);;
                 break;
             default:
                 throw new UnsupportedOperationException(

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
@@ -20,9 +20,7 @@ package com.ververica.cdc.connectors.mysql.source;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import com.ververica.cdc.connectors.mysql.SeekBinlogToTimestampFilter;
 import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfigFactory;
-import com.ververica.cdc.connectors.mysql.table.StartupMode;
 import com.ververica.cdc.connectors.mysql.table.StartupOptions;
 import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
 

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
@@ -239,12 +239,6 @@ public class MySqlSourceBuilder<T> {
      * @return a MySqlParallelSource with the settings made for this builder.
      */
     public MySqlSource<T> build() {
-        if (this.deserializer != null
-                && this.startupOptions != null
-                && this.startupOptions.startupMode == StartupMode.TIMESTAMP) {
-            Long startupTimestampMillis = this.startupOptions.startupTimestampMillis;
-            deserializer = new SeekBinlogToTimestampFilter<>(startupTimestampMillis, deserializer);
-        }
         return new MySqlSource<>(configFactory, checkNotNull(deserializer));
     }
 }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlBinlogSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlBinlogSplitAssigner.java
@@ -56,17 +56,23 @@ public class MySqlBinlogSplitAssigner implements MySqlSplitAssigner {
         this(sourceConfig, false, BinlogOffsetReadingMode.LATEST_OFFSET);
     }
 
-    public MySqlBinlogSplitAssigner(MySqlSourceConfig sourceConfig, BinlogOffsetReadingMode binlogOffsetReadingMode) {
+    public MySqlBinlogSplitAssigner(
+            MySqlSourceConfig sourceConfig, BinlogOffsetReadingMode binlogOffsetReadingMode) {
         this(sourceConfig, false, binlogOffsetReadingMode);
     }
 
     public MySqlBinlogSplitAssigner(
             MySqlSourceConfig sourceConfig, BinlogPendingSplitsState checkpoint) {
-        this(sourceConfig, checkpoint.isBinlogSplitAssigned(), BinlogOffsetReadingMode.LATEST_OFFSET);
+        this(
+                sourceConfig,
+                checkpoint.isBinlogSplitAssigned(),
+                BinlogOffsetReadingMode.LATEST_OFFSET);
     }
 
     private MySqlBinlogSplitAssigner(
-            MySqlSourceConfig sourceConfig, boolean isBinlogSplitAssigned, BinlogOffsetReadingMode binlogOffsetReadingMode) {
+            MySqlSourceConfig sourceConfig,
+            boolean isBinlogSplitAssigned,
+            BinlogOffsetReadingMode binlogOffsetReadingMode) {
         this.sourceConfig = sourceConfig;
         this.isBinlogSplitAssigned = isBinlogSplitAssigned;
         this.binlogOffsetReadingMode = binlogOffsetReadingMode;
@@ -81,9 +87,9 @@ public class MySqlBinlogSplitAssigner implements MySqlSplitAssigner {
             return Optional.empty();
         } else {
             isBinlogSplitAssigned = true;
-            if (binlogOffsetReadingMode == BinlogOffsetReadingMode.EARLIEST_OFFSET){
+            if (binlogOffsetReadingMode == BinlogOffsetReadingMode.EARLIEST_OFFSET) {
                 return Optional.of(createBinlogSplitFromEarliest());
-            }else{
+            } else {
                 return Optional.of(createBinlogSplitFromLatest());
             }
         }
@@ -164,9 +170,7 @@ public class MySqlBinlogSplitAssigner implements MySqlSplitAssigner {
         }
     }
 
-    /**
-     * Reading mode for binlog offset
-     */
+    /** Reading mode for binlog offset */
     public enum BinlogOffsetReadingMode {
         LATEST_OFFSET,
         EARLIEST_OFFSET

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlBinlogSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlBinlogSplitAssigner.java
@@ -44,10 +44,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils.*;
+import static com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils.currentBinlogOffset;
+import static com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils.earliestBinlogOffset;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_STARTUP_MODE;
 
-/** A {@link MySqlSplitAssigner} which only read binlog from current binlog position. */
+/** {@link MySqlSplitAssigner} which only read binlog from current binlog position. */
 public class MySqlBinlogSplitAssigner implements MySqlSplitAssigner {
 
     private static final Logger LOG = LoggerFactory.getLogger(MySqlBinlogSplitAssigner.class);
@@ -176,7 +177,7 @@ public class MySqlBinlogSplitAssigner implements MySqlSplitAssigner {
         final long beginTimestampMills = System.currentTimeMillis();
         LOG.info("Begin to find binlog offset by timestamp {}", startupTimestampMillis);
         try (JdbcConnection jdbc = DebeziumUtils.openJdbcConnection(sourceConfig)) {
-            BinlogOffset maxBinlogOffset = DebeziumUtils.currentBinlogOffset(jdbc);
+            BinlogOffset maxBinlogOffset = currentBinlogOffset(jdbc);
             String binlogFile = maxBinlogOffset.getFilename();
             BinlogOffset seekBinlogOffset = null;
             boolean shouldBreak = false;

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlBinlogSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlBinlogSplitAssigner.java
@@ -170,7 +170,7 @@ public class MySqlBinlogSplitAssigner implements MySqlSplitAssigner {
         }
     }
 
-    /** Reading mode for binlog offset */
+    /** Reading mode for binlog offset . */
     public enum BinlogOffsetReadingMode {
         LATEST_OFFSET,
         EARLIEST_OFFSET

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlBinlogSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlBinlogSplitAssigner.java
@@ -89,23 +89,23 @@ public class MySqlBinlogSplitAssigner implements MySqlSplitAssigner {
         } else {
             isBinlogSplitAssigned = true;
             StartupMode startupMode = this.sourceConfig.getStartupOptions().startupMode;
-            if (startupMode == StartupMode.EARLIEST_OFFSET) {
-                return Optional.of(createBinlogSplitFromEarliest());
-            } else if (startupMode == StartupMode.LATEST_OFFSET) {
-                return Optional.of(createBinlogSplitFromLatest());
-            } else if (startupMode == StartupMode.TIMESTAMP) {
-                return Optional.of(createBinlogSplitFromTimestamp());
-            } else {
-                throw new ValidationException(
-                        String.format(
-                                "Invalid value for MySqlBinlogSplitAssigner '%s'. Supported values are [%s, %s, %s], but was: %s",
-                                SCAN_STARTUP_MODE.key(),
-                                StartupMode.EARLIEST_OFFSET,
-                                StartupMode.LATEST_OFFSET,
-                                StartupMode.TIMESTAMP,
-                                startupMode.name()));
+            switch (startupMode){
+                case EARLIEST_OFFSET:
+                    return Optional.of(createBinlogSplitFromEarliest());
+                case LATEST_OFFSET:
+                    return Optional.of(createBinlogSplitFromLatest());
+                case TIMESTAMP:
+                    return Optional.of(createBinlogSplitFromTimestamp());
+                default:
+                    throw new ValidationException(
+                            String.format(
+                                    "Invalid value for MySqlBinlogSplitAssigner '%s'. Supported values are [%s, %s, %s], but was: %s",
+                                    SCAN_STARTUP_MODE.key(),
+                                    StartupMode.EARLIEST_OFFSET,
+                                    StartupMode.LATEST_OFFSET,
+                                    StartupMode.TIMESTAMP,
+                                    startupMode.name()));
             }
-
         }
     }
 

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlBinlogSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlBinlogSplitAssigner.java
@@ -89,10 +89,11 @@ public class MySqlBinlogSplitAssigner implements MySqlSplitAssigner {
             switch (startupMode) {
                 case EARLIEST_OFFSET:
                     return Optional.of(createBinlogSplitFromEarliest());
-                case LATEST_OFFSET:
-                    return Optional.of(createBinlogSplitFromLatest());
                 case TIMESTAMP:
                     return Optional.of(createBinlogSplitFromTimestamp());
+                case INITIAL:
+                case LATEST_OFFSET:
+                    return Optional.of(createBinlogSplitFromLatest());
                 default:
                     throw new ValidationException(
                             String.format(

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
@@ -228,6 +228,8 @@ public class MySqlSourceConfigFactory implements Serializable {
         switch (startupOptions.startupMode) {
             case INITIAL:
             case LATEST_OFFSET:
+            case EARLIEST_OFFSET:
+            case TIMESTAMP:
                 break;
             default:
                 throw new UnsupportedOperationException(

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/offset/SeekBinlogByTimestampListener.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/offset/SeekBinlogByTimestampListener.java
@@ -35,7 +35,8 @@ public class SeekBinlogByTimestampListener implements BinaryLogClient.EventListe
     private BinlogOffset binlogOffset;
     private BinlogOffset lastBinlogOffset;
 
-    public SeekBinlogByTimestampListener(long seekTimestamp, BinaryLogClient client, BinlogOffset maxBinlogOffset) {
+    public SeekBinlogByTimestampListener(
+            long seekTimestamp, BinaryLogClient client, BinlogOffset maxBinlogOffset) {
         this.seekTimestamp = seekTimestamp;
         this.client = client;
         this.maxBinlogOffset = maxBinlogOffset;
@@ -56,16 +57,21 @@ public class SeekBinlogByTimestampListener implements BinaryLogClient.EventListe
 
             // The first event binlogTimestamp > seekTimestamp , we skip this binlog file directly
             if (eventType == EventType.FORMAT_DESCRIPTION && seekTimestamp < binlogTimestamp) {
-                LOG.info("skip this binlog file {} directly , binlogTimestamp = {}, seekTimestamp = {}",
-                        client.getBinlogFilename(),binlogTimestamp, seekTimestamp);
+                LOG.info(
+                        "skip this binlog file {} directly , binlogTimestamp = {}, seekTimestamp = {}",
+                        client.getBinlogFilename(),
+                        binlogTimestamp,
+                        seekTimestamp);
                 client.disconnect();
             }
 
             // up to the binlog file max position , exit it
             if (client.getBinlogPosition() >= maxBinlogOffset.getPosition()
                     && client.getBinlogFilename().equals(maxBinlogOffset.getFilename())) {
-                LOG.info("up to the binlog file max position , exit it , binlogFile = {}, binlogPosition = {}",
-                        client.getBinlogPosition(), client.getBinlogFilename());
+                LOG.info(
+                        "up to the binlog file max position , exit it , binlogFile = {}, binlogPosition = {}",
+                        client.getBinlogPosition(),
+                        client.getBinlogFilename());
                 client.disconnect();
             }
 
@@ -75,9 +81,13 @@ public class SeekBinlogByTimestampListener implements BinaryLogClient.EventListe
                     && seekTimestamp / 1000 >= lastBinlogOffset.getTimestamp()
                     && seekTimestamp <= binlogTimestamp) {
                 binlogOffset = buildBinlogOffset(binlogTimestamp);
-                LOG.info("found the binlog offset , lastBinlogOffset = {}, " +
-                        "currentBinlogOffset = {}, seekTimestamp = {}" +
-                        "", lastBinlogOffset, binlogOffset, seekTimestamp);
+                LOG.info(
+                        "found the binlog offset , lastBinlogOffset = {}, "
+                                + "currentBinlogOffset = {}, seekTimestamp = {}"
+                                + "",
+                        lastBinlogOffset,
+                        binlogOffset,
+                        seekTimestamp);
                 client.disconnect();
             }
 
@@ -88,8 +98,13 @@ public class SeekBinlogByTimestampListener implements BinaryLogClient.EventListe
     }
 
     private BinlogOffset buildBinlogOffset(long binlogTimestamp) {
-        return new BinlogOffset(client.getBinlogFilename(), client.getBinlogPosition(),
-                0, 0, binlogTimestamp / 1000, client.getGtidSet(),
+        return new BinlogOffset(
+                client.getBinlogFilename(),
+                client.getBinlogPosition(),
+                0,
+                0,
+                binlogTimestamp / 1000,
+                client.getGtidSet(),
                 ((Long) client.getServerId()).intValue());
     }
 

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/offset/SeekBinlogByTimestampListener.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/offset/SeekBinlogByTimestampListener.java
@@ -25,6 +25,7 @@ import com.github.shyiko.mysql.binlog.event.EventType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** event listener to seek binlog offset by timestamp . */
 public class SeekBinlogByTimestampListener implements BinaryLogClient.EventListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(SeekBinlogByTimestampListener.class);

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/offset/SeekBinlogByTimestampListener.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/offset/SeekBinlogByTimestampListener.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mysql.source.offset;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.EventHeader;
+import com.github.shyiko.mysql.binlog.event.EventType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SeekBinlogByTimestampListener implements BinaryLogClient.EventListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SeekBinlogByTimestampListener.class);
+
+    private final long seekTimestamp;
+    private final BinaryLogClient client;
+    private final BinlogOffset maxBinlogOffset;
+    private BinlogOffset binlogOffset;
+    private BinlogOffset lastBinlogOffset;
+
+    public SeekBinlogByTimestampListener(long seekTimestamp, BinaryLogClient client, BinlogOffset maxBinlogOffset) {
+        this.seekTimestamp = seekTimestamp;
+        this.client = client;
+        this.maxBinlogOffset = maxBinlogOffset;
+    }
+
+    @Override
+    public void onEvent(Event event) {
+        try {
+            EventHeader header = event.getHeader();
+            EventType eventType = header.getEventType();
+            long binlogTimestamp = header.getTimestamp();
+
+            // Get the min binlog offset of this binlog file
+            if (binlogOffset == null && eventType == EventType.ROTATE) {
+                binlogOffset = buildBinlogOffset(binlogTimestamp);
+                return;
+            }
+
+            // The first event binlogTimestamp > seekTimestamp , we skip this binlog file directly
+            if (eventType == EventType.FORMAT_DESCRIPTION && seekTimestamp < binlogTimestamp) {
+                LOG.info("skip this binlog file {} directly , binlogTimestamp = {}, seekTimestamp = {}",
+                        client.getBinlogFilename(),binlogTimestamp, seekTimestamp);
+                client.disconnect();
+            }
+
+            // up to the binlog file max position , exit it
+            if (client.getBinlogPosition() >= maxBinlogOffset.getPosition()
+                    && client.getBinlogFilename().equals(maxBinlogOffset.getFilename())) {
+                LOG.info("up to the binlog file max position , exit it , binlogFile = {}, binlogPosition = {}",
+                        client.getBinlogPosition(), client.getBinlogFilename());
+                client.disconnect();
+            }
+
+            if ((eventType == EventType.QUERY || eventType == EventType.XID)
+                    && lastBinlogOffset != null
+                    && lastBinlogOffset.getTimestamp() > 0
+                    && seekTimestamp / 1000 >= lastBinlogOffset.getTimestamp()
+                    && seekTimestamp <= binlogTimestamp) {
+                binlogOffset = buildBinlogOffset(binlogTimestamp);
+                LOG.info("found the binlog offset , lastBinlogOffset = {}, " +
+                        "currentBinlogOffset = {}, seekTimestamp = {}" +
+                        "", lastBinlogOffset, binlogOffset, seekTimestamp);
+                client.disconnect();
+            }
+
+            lastBinlogOffset = buildBinlogOffset(binlogTimestamp);
+        } catch (Exception e) {
+            LOG.info("Exception while disconnect binary log client", e);
+        }
+    }
+
+    private BinlogOffset buildBinlogOffset(long binlogTimestamp) {
+        return new BinlogOffset(client.getBinlogFilename(), client.getBinlogPosition(),
+                0, 0, binlogTimestamp / 1000, client.getGtidSet(),
+                ((Long) client.getServerId()).intValue());
+    }
+
+    public BinlogOffset getBinlogOffset() {
+        return this.binlogOffset;
+    }
+}

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactory.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactory.java
@@ -199,8 +199,12 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
                 return StartupOptions.latest();
 
             case SCAN_STARTUP_MODE_VALUE_EARLIEST:
-            case SCAN_STARTUP_MODE_VALUE_SPECIFIC_OFFSET:
+                return StartupOptions.earliest();
+
             case SCAN_STARTUP_MODE_VALUE_TIMESTAMP:
+                return StartupOptions.timestamp(config.get(SCAN_STARTUP_TIMESTAMP_MILLIS));
+
+            case SCAN_STARTUP_MODE_VALUE_SPECIFIC_OFFSET:
                 throw new ValidationException(
                         String.format(
                                 "Unsupported option value '%s', the options [%s, %s, %s] are not supported correctly, please do not use them until they're correctly supported",
@@ -233,9 +237,11 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
         // validate mode
         Preconditions.checkState(
                 startupOptions.startupMode == StartupMode.INITIAL
-                        || startupOptions.startupMode == StartupMode.LATEST_OFFSET,
+                        || startupOptions.startupMode == StartupMode.LATEST_OFFSET
+                        || startupOptions.startupMode == StartupMode.EARLIEST_OFFSET
+                        || startupOptions.startupMode == StartupMode.TIMESTAMP,
                 String.format(
-                        "MySql Parallel Source only supports startup mode 'initial' and 'latest-offset',"
+                        "MySql Parallel Source only supports startup mode ['initial','latest-offset','earliest-offset','timestamp']"
                                 + " but actual is %s",
                         startupOptions.startupMode));
     }

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceExampleTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceExampleTest.java
@@ -18,10 +18,10 @@
 
 package com.ververica.cdc.connectors.mysql.source;
 
-import com.ververica.cdc.connectors.mysql.table.StartupOptions;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
+import com.ververica.cdc.connectors.mysql.table.StartupOptions;
 import com.ververica.cdc.connectors.mysql.testutils.UniqueDatabase;
 import com.ververica.cdc.debezium.JsonDebeziumDeserializationSchema;
 import org.junit.Ignore;

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
@@ -351,35 +351,73 @@ public class MySqlTableSourceFactoryTest {
 
     @Test
     public void testStartupFromEarliestOffset() {
-        try {
-            Map<String, String> properties = getAllOptions();
-            properties.put("scan.startup.mode", "earliest-offset");
-            createTableSource(properties);
-            fail("exception expected");
-        } catch (Throwable t) {
-            assertTrue(
-                    ExceptionUtils.findThrowableWithMessage(
-                                    t,
-                                    "Unsupported option value 'earliest-offset', the options [earliest-offset, specific-offset, timestamp] are not supported correctly, please do not use them until they're correctly supported")
-                            .isPresent());
-        }
+        Map<String, String> properties = getAllOptions();
+        properties.put("scan.startup.mode", "earliest-offset");
+
+        // validation for source
+        DynamicTableSource actualSource = createTableSource(properties);
+        MySqlTableSource expectedSource =
+                new MySqlTableSource(
+                        SCHEMA,
+                        3306,
+                        MY_LOCALHOST,
+                        MY_DATABASE,
+                        MY_TABLE,
+                        MY_USERNAME,
+                        MY_PASSWORD,
+                        ZoneId.of("UTC"),
+                        PROPERTIES,
+                        null,
+                        false,
+                        SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE.defaultValue(),
+                        CHUNK_META_GROUP_SIZE.defaultValue(),
+                        SCAN_SNAPSHOT_FETCH_SIZE.defaultValue(),
+                        CONNECT_TIMEOUT.defaultValue(),
+                        CONNECT_MAX_RETRIES.defaultValue(),
+                        CONNECTION_POOL_SIZE.defaultValue(),
+                        SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND.defaultValue(),
+                        SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND.defaultValue(),
+                        StartupOptions.earliest(),
+                        false,
+                        new Properties(),
+                        HEARTBEAT_INTERVAL.defaultValue());
+        assertEquals(expectedSource, actualSource);
     }
 
     @Test
     public void testStartupFromSpecificTimestamp() {
-        try {
-            Map<String, String> properties = getAllOptions();
-            properties.put("scan.startup.mode", "timestamp");
-            properties.put("scan.startup.timestamp-millis", "0");
-            createTableSource(properties);
-            fail("exception expected");
-        } catch (Throwable t) {
-            assertTrue(
-                    ExceptionUtils.findThrowableWithMessage(
-                                    t,
-                                    "Unsupported option value 'timestamp', the options [earliest-offset, specific-offset, timestamp] are not supported correctly, please do not use them until they're correctly supported")
-                            .isPresent());
-        }
+        Map<String, String> properties = getAllOptions();
+        properties.put("scan.startup.mode", "timestamp");
+        properties.put("scan.startup.timestamp-millis", "0");
+
+        // validation for source
+        DynamicTableSource actualSource = createTableSource(properties);
+        MySqlTableSource expectedSource =
+                new MySqlTableSource(
+                        SCHEMA,
+                        3306,
+                        MY_LOCALHOST,
+                        MY_DATABASE,
+                        MY_TABLE,
+                        MY_USERNAME,
+                        MY_PASSWORD,
+                        ZoneId.of("UTC"),
+                        PROPERTIES,
+                        null,
+                        false,
+                        SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE.defaultValue(),
+                        CHUNK_META_GROUP_SIZE.defaultValue(),
+                        SCAN_SNAPSHOT_FETCH_SIZE.defaultValue(),
+                        CONNECT_TIMEOUT.defaultValue(),
+                        CONNECT_MAX_RETRIES.defaultValue(),
+                        CONNECTION_POOL_SIZE.defaultValue(),
+                        SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND.defaultValue(),
+                        SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND.defaultValue(),
+                        StartupOptions.timestamp(0L),
+                        false,
+                        new Properties(),
+                        HEARTBEAT_INTERVAL.defaultValue());
+        assertEquals(expectedSource, actualSource);
     }
 
     @Test


### PR DESCRIPTION
### feature 
1. startup mode support of  timestamp and earliest
2. support of gtid mode

### demo in java
```java
MySqlSource<String> mySqlSource =
                MySqlSource.<String>builder()
                        .hostname("172.23.218.236")
                        .port(3308)
                        .databaseList("db_test") // set captured database
                        .tableList("db_test.t_user") // set captured table
                        .username("test")
                        .password("123")
                        .serverId("5401-5404")
                        .startupOptions(StartupOptions.earliest())
                        .deserializer(new JsonDebeziumDeserializationSchema())
                        .includeSchemaChanges(true) // output the schema changes as well
                        .build();

StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
env.enableCheckpointing(10000);

env.fromSource(mySqlSource, WatermarkStrategy.noWatermarks(), "mysqlBinlogSource") .print() .setParallelism(1);

env.execute("Print MySQL Snapshot + Binlog");
```

### demo in sql
```sql
CREATE TABLE t_user (
    id int,
    name varchar,
    age int,
    create_time timestamp,
    PRIMARY KEY(id) NOT ENFORCED
) WITH (
    'connector' = 'mysql-cdc',
    'scan.startup.mode' = 'timestamp',
    'scan.startup.timestamp-millis' = '1652068405000',
    'hostname' = '172.23.211.64',
    'port' = '3307',
    'username' = 'test',
    'password' = '123',
    'database-name' = 'db_test',
    'table-name' = '.*'
)
```
