### PR TITLE
[mongodb][doc] Fix meta field collection_name of metadata sql example

### DIFF
--- a/docs/content/connectors/mongodb-cdc.md
+++ b/docs/content/connectors/mongodb-cdc.md
@@ -290,7 +290,7 @@ The extended CREATE TABLE example demonstrates the syntax for exposing these met
 ```sql
 CREATE TABLE products (
     db_name STRING METADATA FROM 'database_name' VIRTUAL,
-    table_name STRING METADATA  FROM 'table_name' VIRTUAL,
+    collection_name STRING METADATA  FROM 'collection_name' VIRTUAL,
     operation_ts TIMESTAMP_LTZ(3) METADATA FROM 'op_ts' VIRTUAL,
     _id STRING, // must be declared
     name STRING,


### PR DESCRIPTION
Fix [issue-1286](https://github.com/ververica/flink-cdc-connectors/issues/1286).
I change `table_nam`e to `collection_name`.