### PR TITLE
[oceanbase] remove mysql connector dependency and add fall back for driver name

### DIFF
--- a/docs/content/connectors/oceanbase-cdc.md
+++ b/docs/content/connectors/oceanbase-cdc.md
@@ -7,6 +7,10 @@ Dependencies
 
 In order to setup the OceanBase CDC connector, the following table provides dependency information for both projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
 
+Note that `mysql-connector-java` is only used for reading snapshot data, you can ignore it if you only deal with the log data. `5.1.47` is the recommended version of MySQL driver, and later versions may have type incompatibility issues. The cdc connector will preferentially use `com.mysql.jdbc.Driver` as the driver name and fall back to `com.mysql.cj.jdbc.Driver` on failure.
+
+### Maven dependency
+
 ```xml
 <dependency>
   <groupId>com.ververica</groupId>
@@ -14,13 +18,20 @@ In order to setup the OceanBase CDC connector, the following table provides depe
   <!-- The dependency is available only for stable releases, SNAPSHOT dependency need build by yourself. -->
   <version>2.3-SNAPSHOT</version>
 </dependency>
+<dependency>
+  <groupId>mysql</groupId>
+  <artifactId>mysql-connector-java</artifactId>
+  <version>5.1.47</version>
+</dependency>
 ```
 
 ### SQL Client JAR
 
 ```Download link is available only for stable releases.```
 
-Download [flink-sql-connector-oceanbase-cdc-2.3-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-oceanbase-cdc/2.3-SNAPSHOT/flink-sql-connector-oceanbase-cdc-2.3-SNAPSHOT.jar) and put it under `<FLINK_HOME>/lib/`.
+Download following jar files and put them under `<FLINK_HOME>/lib/`.
+- [flink-sql-connector-oceanbase-cdc-2.3-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-oceanbase-cdc/2.3-SNAPSHOT/flink-sql-connector-oceanbase-cdc-2.3-SNAPSHOT.jar)
+- [mysql-connector-java-5.1.47.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar)
 
 **Note:** flink-sql-connector-oceanbase-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users need to download the source code and compile the corresponding jar. Users should use the released version, such as [flink-sql-connector-oceanbase-cdc-XXX.jar](https://mvnrepository.com/artifact/com.ververica/flink-connector-oceanbase-cdc), the released version will be available in the Maven central warehouse.
 

--- a/docs/content/quickstart/oceanbase-tutorial.md
+++ b/docs/content/quickstart/oceanbase-tutorial.md
@@ -108,6 +108,7 @@ VALUES (default, '2020-07-30 10:08:22', 'Jark', 50.50, 102, false),
 
 - [flink-sql-connector-elasticsearch7_2.11-1.13.2.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7_2.11/1.13.2/flink-sql-connector-elasticsearch7_2.11-1.13.2.jar)
 - [flink-sql-connector-oceanbase-cdc-2.3-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-oceanbase-cdc/2.3-SNAPSHOT/flink-sql-connector-oceanbase-cdc-2.3-SNAPSHOT.jar)
+- [mysql-connector-java-5.1.47.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar)
 
 ### Use Flink DDL to create dynamic table in Flink SQL CLI
 

--- a/docs/content/快速上手/oceanbase-tutorial-zh.md
+++ b/docs/content/快速上手/oceanbase-tutorial-zh.md
@@ -106,6 +106,7 @@ VALUES (default, '2020-07-30 10:08:22', 'Jark', 50.50, 102, false),
 
 - [flink-sql-connector-elasticsearch7_2.11-1.13.2.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7_2.11/1.13.2/flink-sql-connector-elasticsearch7_2.11-1.13.2.jar)
 - [flink-sql-connector-oceanbase-cdc-2.3-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-oceanbase-cdc/2.3-SNAPSHOT/flink-sql-connector-oceanbase-cdc-2.3-SNAPSHOT.jar)
+- [mysql-connector-java-5.1.47.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar)
 
 ### 在 Flink SQL CLI 中使用 Flink DDL 创建表
 

--- a/flink-connector-oceanbase-cdc/pom.xml
+++ b/flink-connector-oceanbase-cdc/pom.xml
@@ -48,19 +48,6 @@ under the License.
             <groupId>com.oceanbase.logclient</groupId>
             <artifactId>logproxy-client</artifactId>
             <version>${oblogclient.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>logback-classic</artifactId>
-                    <groupId>ch.qos.logback</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <!-- The MySQL JDBC driver for reading snapshot-->
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.47</version>
         </dependency>
 
         <!-- test dependencies on Flink -->
@@ -128,6 +115,14 @@ under the License.
             <artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- The MySQL JDBC driver for reading snapshot-->
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.47</version>
             <scope>test</scope>
         </dependency>
 

--- a/flink-connector-oceanbase-cdc/src/main/java/com/ververica/cdc/connectors/oceanbase/source/OceanBaseConnection.java
+++ b/flink-connector-oceanbase-cdc/src/main/java/com/ververica/cdc/connectors/oceanbase/source/OceanBaseConnection.java
@@ -20,15 +20,18 @@ package com.ververica.cdc.connectors.oceanbase.source;
 
 import io.debezium.config.Configuration;
 import io.debezium.jdbc.JdbcConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 
 /** {@link JdbcConnection} extension to be used with OceanBase server. */
 public class OceanBaseConnection extends JdbcConnection {
 
+    private static final Logger LOG = LoggerFactory.getLogger(OceanBaseRichSourceFunction.class);
+
     protected static final String URL_PATTERN =
             "jdbc:mysql://${hostname}:${port}/?useInformationSchema=true&nullCatalogMeansCurrent=false&useSSL=false&useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8&zeroDateTimeBehavior=convertToNull&connectTimeout=${connectTimeout}";
-    protected static final String DRIVER_CLASS_NAME = "com.mysql.jdbc.Driver";
 
     public OceanBaseConnection(
             String hostname,
@@ -52,6 +55,17 @@ public class OceanBaseConnection extends JdbcConnection {
     }
 
     public static JdbcConnection.ConnectionFactory factory(ClassLoader classLoader) {
-        return JdbcConnection.patternBasedFactory(URL_PATTERN, DRIVER_CLASS_NAME, classLoader);
+        return JdbcConnection.patternBasedFactory(URL_PATTERN, getDriverClassName(), classLoader);
+    }
+
+    public static String getDriverClassName() {
+        try {
+            Class.forName("com.mysql.jdbc.Driver");
+            return "com.mysql.jdbc.Driver";
+        } catch (ClassNotFoundException e) {
+            LOG.warn(
+                    "Can't find class 'com.mysql.jdbc.Driver', try to use 'com.mysql.cj.jdbc.Driver' instead");
+            return "com.mysql.cj.jdbc.Driver";
+        }
     }
 }

--- a/flink-connector-oceanbase-cdc/src/main/java/com/ververica/cdc/connectors/oceanbase/source/OceanBaseRichSourceFunction.java
+++ b/flink-connector-oceanbase-cdc/src/main/java/com/ververica/cdc/connectors/oceanbase/source/OceanBaseRichSourceFunction.java
@@ -32,7 +32,6 @@ import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import com.mysql.jdbc.ResultSetMetaData;
 import com.oceanbase.clogproxy.client.LogProxyClient;
 import com.oceanbase.clogproxy.client.config.ClientConf;
 import com.oceanbase.clogproxy.client.config.ObReaderConfig;
@@ -49,6 +48,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
@@ -215,7 +215,7 @@ public class OceanBaseRichSourceFunction<T> extends RichSourceFunction<T>
             snapshotConnection.query(
                     selectSql,
                     rs -> {
-                        ResultSetMetaData metaData = (ResultSetMetaData) rs.getMetaData();
+                        ResultSetMetaData metaData = rs.getMetaData();
                         String[] columnNames = new String[metaData.getColumnCount()];
                         int[] jdbcTypes = new int[metaData.getColumnCount()];
                         for (int i = 0; i < metaData.getColumnCount(); i++) {

--- a/flink-sql-connector-oceanbase-cdc/pom.xml
+++ b/flink-sql-connector-oceanbase-cdc/pom.xml
@@ -57,7 +57,6 @@ under the License.
                                     <include>io.debezium:debezium-core</include>
                                     <include>com.ververica:flink-connector-debezium</include>
                                     <include>com.ververica:flink-connector-oceanbase-cdc</include>
-                                    <include>mysql:mysql-connector-java</include>
                                     <include>com.oceanbase.logclient:*</include>
                                     <include>io.netty:netty-all</include>
                                     <include>com.google.protobuf:protobuf-java</include>


### PR DESCRIPTION
Update about MySQL driver.
- Remove the `mysql-connector-java` dependency from oceanbase cdc connector, this makes users be able to choose the driver according to their requirements in the future. 
- Add a fall back logic for driver class selection, and a startup option like `jdbc.driverClassName` should be added after other drivers are fully tested.