### PR TITLE
[mysql] Optimize pure binlog phase check logic to improve performance

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
@@ -43,9 +43,11 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -74,6 +76,7 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecord, MySqlSpli
     private Map<TableId, List<FinishedSnapshotSplitInfo>> finishedSplitsInfo;
     // tableId -> the max splitHighWatermark
     private Map<TableId, BinlogOffset> maxSplitHighWatermarkMap;
+    private final Set<TableId> pureBinlogPhaseTables;
     private Tables.TableFilter capturedTableFilter;
 
     public BinlogSplitReader(StatefulTaskContext statefulTaskContext, int subTaskId) {
@@ -82,6 +85,7 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecord, MySqlSpli
                 new ThreadFactoryBuilder().setNameFormat("debezium-reader-" + subTaskId).build();
         this.executor = Executors.newSingleThreadExecutor(threadFactory);
         this.currentTaskRunning = true;
+        this.pureBinlogPhaseTables = new HashSet<>();
     }
 
     public void submitSplit(MySqlSplit mySqlSplit) {
@@ -226,9 +230,13 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecord, MySqlSpli
     }
 
     private boolean hasEnterPureBinlogPhase(TableId tableId, BinlogOffset position) {
+        if (pureBinlogPhaseTables.contains(tableId)) {
+            return true;
+        }
         // the existed tables those have finished snapshot reading
         if (maxSplitHighWatermarkMap.containsKey(tableId)
                 && position.isAtOrAfter(maxSplitHighWatermarkMap.get(tableId))) {
+            pureBinlogPhaseTables.add(tableId);
             return true;
         }
         // capture dynamically new added tables
@@ -269,6 +277,7 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecord, MySqlSpli
         }
         this.finishedSplitsInfo = splitsInfoMap;
         this.maxSplitHighWatermarkMap = tableIdBinlogPositionMap;
+        this.pureBinlogPhaseTables.clear();
     }
 
     public void stopBinlogReadTask() {


### PR DESCRIPTION
**Pure binlog phase performace opt**
Our online business found that the performance of the binlog phase of Flink jobs could not meet the demand. Through performance analysis, we found that the performance bottleneck in the phase was the comparison of binlog offset. For each binlog data, mysql-cdc needs to judge whether the offset of the binlog data is after the end of the full snapshot phase (max split high watermark). If so, it is in pure binlog phase, and can be directly output to the downstream. The comparison between binlog data offset and max split high watermark consumes CPU very much and has become a performance bottleneck (see the following figure).
Further analysis of the internal logic of mysql-cdc shows that for each mysql-cdc table, the state of incremental synchronization will remain unchanged after entering the pure binlog phase. Therefore, it is sufficient to keep a flag for each table to judge whether the table has entered pure binlog phase, so as to avoid binlog offset comparison of each data in the pure binlog phase, Improve the performance of incremental data synchronization.
![image](https://user-images.githubusercontent.com/5181963/180339834-d9b09158-21d4-45c3-b93b-4cac0bcb6728.png)

**Performance improvement**
In the actual online scenario test (more than 180 tables are synchronized with many table fields in a flink job), the performance is improved by 3 times (from 5k/s to 2w/s), which meets the real-time synchronization needs of our business.
