### PR TITLE
[oceanbase] use utc offset as timezone by default

### DIFF
--- a/docs/content/connectors/oceanbase-cdc.md
+++ b/docs/content/connectors/oceanbase-cdc.md
@@ -201,9 +201,9 @@ The OceanBase CDC Connector contains some options for both sql and stream api as
             <tr>
                 <td>server-time-zone</td>
                 <td>optional</td>
-                <td style="word-wrap: break-word;">UTC</td>
+                <td style="word-wrap: break-word;">+00:00</td>
                 <td>String</td>
-                <td>The session time zone in database server, e.g. "Asia/Shanghai". It controls how the TIMESTAMP type in OceanBase converted to STRING in snapshot reading, please make sure to set it same with the timezone of `oblogproxy` deployment. </td>
+                <td>The session timezone which controls how temporal types are converted to STRING in OceanBase. Can be UTC offset in format "±hh:mm" or tz database name like "Asia/Shanghai".</td>
             </tr>
             <tr>
                 <td>logproxy.host</td>

--- a/docs/content/connectors/oceanbase-cdc.md
+++ b/docs/content/connectors/oceanbase-cdc.md
@@ -203,7 +203,7 @@ The OceanBase CDC Connector contains some options for both sql and stream api as
                 <td>optional</td>
                 <td style="word-wrap: break-word;">+00:00</td>
                 <td>String</td>
-                <td>The session timezone which controls how temporal types are converted to STRING in OceanBase. Can be UTC offset in format "±hh:mm" or tz database name like "Asia/Shanghai".</td>
+                <td>The session timezone which controls how temporal types are converted to STRING in OceanBase. Can be UTC offset in format "±hh:mm", or named time zones if the time zone information tables in the mysql database have been created and populated.</td>
             </tr>
             <tr>
                 <td>logproxy.host</td>

--- a/flink-connector-oceanbase-cdc/src/main/java/com/ververica/cdc/connectors/oceanbase/OceanBaseSource.java
+++ b/flink-connector-oceanbase-cdc/src/main/java/com/ververica/cdc/connectors/oceanbase/OceanBaseSource.java
@@ -200,7 +200,7 @@ public class OceanBaseSource {
             }
 
             if (serverTimeZone == null) {
-                serverTimeZone = "UTC";
+                serverTimeZone = "+00:00";
             }
             ZoneOffset zoneOffset = ZoneId.of(serverTimeZone).getRules().getOffset(Instant.now());
 
@@ -235,7 +235,7 @@ public class OceanBaseSource {
             obReaderConfig.setUsername(username);
             obReaderConfig.setPassword(password);
             obReaderConfig.setStartTimestamp(startupTimestamp);
-            obReaderConfig.setTimezone(zoneOffset.getId());
+            obReaderConfig.setTimezone(serverTimeZone);
 
             return new OceanBaseRichSourceFunction<T>(
                     StartupMode.INITIAL.equals(startupMode),

--- a/flink-connector-oceanbase-cdc/src/main/java/com/ververica/cdc/connectors/oceanbase/table/OceanBaseTableSourceFactory.java
+++ b/flink-connector-oceanbase-cdc/src/main/java/com/ververica/cdc/connectors/oceanbase/table/OceanBaseTableSourceFactory.java
@@ -84,7 +84,7 @@ public class OceanBaseTableSourceFactory implements DynamicTableSourceFactory {
     public static final ConfigOption<String> SERVER_TIME_ZONE =
             ConfigOptions.key("server-time-zone")
                     .stringType()
-                    .defaultValue("UTC")
+                    .defaultValue("+00:00")
                     .withDescription("The session time zone in database server.");
 
     public static final ConfigOption<Duration> CONNECT_TIMEOUT =

--- a/flink-connector-oceanbase-cdc/src/test/java/com/ververica/cdc/connectors/oceanbase/table/OceanBaseConnectorITCase.java
+++ b/flink-connector-oceanbase-cdc/src/test/java/com/ververica/cdc/connectors/oceanbase/table/OceanBaseConnectorITCase.java
@@ -35,9 +35,7 @@ import org.junit.Test;
 
 import java.sql.Connection;
 import java.sql.Statement;
-import java.time.Instant;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 
@@ -286,13 +284,12 @@ public class OceanBaseConnectorITCase extends OceanBaseTestBase {
 
     @Test
     public void testAllDataTypes() throws Exception {
-        ZoneId serverTimeZone = ZoneId.systemDefault();
-        ZoneOffset zoneOffset = serverTimeZone.getRules().getOffset(Instant.now());
+        String serverTimeZone = "+00:00";
         try (Connection connection = getJdbcConnection("");
                 Statement statement = connection.createStatement()) {
-            statement.execute(String.format("SET GLOBAL time_zone = '%s';", zoneOffset.getId()));
+            statement.execute(String.format("SET GLOBAL time_zone = '%s';", serverTimeZone));
         }
-        tEnv.getConfig().setLocalTimeZone(serverTimeZone);
+        tEnv.getConfig().setLocalTimeZone(ZoneId.of(serverTimeZone));
         initializeTable("column_type_test");
         String sourceDDL =
                 String.format(

--- a/flink-connector-oceanbase-cdc/src/test/java/com/ververica/cdc/connectors/oceanbase/table/OceanBaseTableFactoryTest.java
+++ b/flink-connector-oceanbase-cdc/src/test/java/com/ververica/cdc/connectors/oceanbase/table/OceanBaseTableFactoryTest.java
@@ -78,7 +78,7 @@ public class OceanBaseTableFactoryTest {
     private static final String DATABASE_NAME = "db[0-9]";
     private static final String TABLE_NAME = "table[0-9]";
     private static final String TABLE_LIST = "db.table";
-    private static final String SERVER_TIME_ZONE = "UTC";
+    private static final String SERVER_TIME_ZONE = "+00:00";
     private static final String CONNECT_TIMEOUT = "30s";
     private static final String HOSTNAME = "127.0.0.1";
     private static final Integer PORT = 2881;


### PR DESCRIPTION
Similar to [MySQL](https://dev.mysql.com/doc/refman/5.7/en/time-zone-support.html#time-zone-variables), OceanBase may not support named timezone like 'UTC' and 'PST'. So it's better to use UTC offset here.
