### PR TITLE
 dont need captureNewlyAddedTables when isRemainingTablesCheckpointed is false and assign isnt finished on MySqlSnapshotSplitAssigner

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
@@ -156,8 +156,9 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
                 throw new FlinkRuntimeException(
                         "Failed to discover remaining tables to capture", e);
             }
+        } else {
+            captureNewlyAddedTables();
         }
-        captureNewlyAddedTables();
         startAsynchronouslySplit();
     }
 


### PR DESCRIPTION
dont need captureNewlyAddedTables when isRemainingTablesCheckpointed is false and assign isnt finished on MySqlSnapshotSplitAssigner