### PR TITLE
[hotfix][test] Fix testMetadataColumns error in xxxConnectorITCase introduced by FLINK-20370, which will send -U records when primary keys of source and sink is different

### DIFF
--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlConnectorITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlConnectorITCase.java
@@ -854,7 +854,9 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 "+I[%s, user_table_1_1, 300, user_300, Hangzhou, 123567891234, user_300@foo.com, null]",
                                 "+U[%s, user_table_1_1, 300, user_300, Beijing, 123567891234, user_300@foo.com, null]",
                                 "+U[%s, user_table_1_2, 121, user_121, Shanghai, 88888888, null, null]",
-                                "-D[%s, user_table_1_1, 111, user_111, Shanghai, 123567891234, user_111@foo.com, null]")
+                                "-D[%s, user_table_1_1, 111, user_111, Shanghai, 123567891234, user_111@foo.com, null]",
+                                "-U[%s, user_table_1_1, 300, user_300, Hangzhou, 123567891234, user_300@foo.com, null]",
+                                "-U[%s, user_table_1_2, 121, user_121, Shanghai, 123567891234, null, null]")
                         .map(s -> String.format(s, userDatabase1.getDatabaseName()))
                         .sorted()
                         .collect(Collectors.toList());

--- a/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/table/OracleConnectorITCase.java
+++ b/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/table/OracleConnectorITCase.java
@@ -170,7 +170,8 @@ public class OracleConnectorITCase extends AbstractTestBase {
                                 + " ID INT NOT NULL,"
                                 + " NAME STRING,"
                                 + " DESCRIPTION STRING,"
-                                + " WEIGHT DECIMAL(10,3)"
+                                + " WEIGHT DECIMAL(10,3),"
+                                + " PRIMARY KEY (ID) NOT ENFORCED"
                                 + ") WITH ("
                                 + " 'connector' = 'oracle-cdc',"
                                 + " 'hostname' = '%s',"
@@ -249,6 +250,7 @@ public class OracleConnectorITCase extends AbstractTestBase {
                         "-D[XE, DEBEZIUM, PRODUCTS, 112, scooter, Big 2-wheel scooter , 5.170]");
 
         List<String> actual = TestValuesTableFactory.getRawResults("sink");
+        Collections.sort(expected);
         Collections.sort(actual);
         assertEquals(expected, actual);
         result.getJobClient().get().cancel().get();

--- a/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/table/PostgreSQLConnectorITCase.java
+++ b/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/table/PostgreSQLConnectorITCase.java
@@ -348,7 +348,8 @@ public class PostgreSQLConnectorITCase extends PostgresTestBase {
                                 + " id INT NOT NULL,"
                                 + " name STRING,"
                                 + " description STRING,"
-                                + " weight DECIMAL(10,3)"
+                                + " weight DECIMAL(10,3),"
+                                + " PRIMARY KEY (id) NOT ENFORCED"
                                 + ") WITH ("
                                 + " 'connector' = 'postgres-cdc',"
                                 + " 'hostname' = '%s',"
@@ -431,6 +432,7 @@ public class PostgreSQLConnectorITCase extends PostgresTestBase {
                         "-D(postgres,inventory,products,111,scooter,Big 2-wheel scooter ,5.170)");
         List<String> actual = TestValuesTableFactory.getRawResults("sink");
         Collections.sort(actual);
+        Collections.sort(expected);
         assertEquals(expected, actual);
         result.getJobClient().get().cancel().get();
     }

--- a/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/table/SqlServerConnectorITCase.java
+++ b/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/table/SqlServerConnectorITCase.java
@@ -285,7 +285,8 @@ public class SqlServerConnectorITCase extends SqlServerTestBase {
                                 + " id INT NOT NULL,"
                                 + " name STRING,"
                                 + " description STRING,"
-                                + " weight DECIMAL(10,3)"
+                                + " weight DECIMAL(10,3),"
+                                + " PRIMARY KEY (id) NOT ENFORCED"
                                 + ") WITH ("
                                 + " 'connector' = 'sqlserver-cdc',"
                                 + " 'hostname' = '%s',"
@@ -366,6 +367,7 @@ public class SqlServerConnectorITCase extends SqlServerTestBase {
                         "-D(inventory,dbo,products,111,scooter,Big 2-wheel scooter ,5.170)");
         List<String> actual = TestValuesTableFactory.getRawResults("sink");
         Collections.sort(actual);
+        Collections.sort(expected);
         assertEquals(expected, actual);
         result.getJobClient().get().cancel().get();
     }

--- a/flink-connector-tidb-cdc/src/test/java/com/ververica/cdc/connectors/tidb/table/TiDBConnectorITCase.java
+++ b/flink-connector-tidb-cdc/src/test/java/com/ververica/cdc/connectors/tidb/table/TiDBConnectorITCase.java
@@ -392,7 +392,8 @@ public class TiDBConnectorITCase extends TiDBTestBase {
                         "+I(inventory,products,107,rocks,box of assorted rocks,5.3000000000)",
                         "+I(inventory,products,108,jacket,water resistent black wind breaker,0.1000000000)",
                         "+I(inventory,products,109,spare tire,24 inch spare tire,22.2000000000)",
-                        "+U(inventory,products,106,hammer,18oz carpenter hammer,1.0000000000)");
+                        "+U(inventory,products,106,hammer,18oz carpenter hammer,1.0000000000)",
+                        "-U(inventory,products,106,hammer,16oz carpenter's hammer,1.0000000000)");
         List<String> actual = TestValuesTableFactory.getRawResults("sink");
         assertEqualsInAnyOrder(expected, actual);
         result.getJobClient().get().cancel().get();


### PR DESCRIPTION
Fix testMetadataColumns error in xxxConnectorITCase introduced by FLINK-20370, which will send -U records when primary keys of source and sink is different