### PR TITLE
[oceanbase][test] Use memory mode of obcdc and double startup timeout

### DIFF
--- a/docs/content/connectors/oceanbase-cdc.md
+++ b/docs/content/connectors/oceanbase-cdc.md
@@ -85,7 +85,9 @@ Flink SQL> CREATE TABLE orders (
     'port' = '2881',
     'rootserver-list' = '127.0.0.1:2882:2881',
     'logproxy.host' = '127.0.0.1',
-    'logproxy.port' = '2983');
+    'logproxy.port' = '2983',
+    'working-mode' = 'memory'
+);
 
 -- read snapshot and binlogs from orders table
 Flink SQL> SELECT * FROM orders;
@@ -316,7 +318,9 @@ CREATE TABLE products (
    'port' = '2881',
    'rootserver-list' = '127.0.0.1:2882:2881',
    'logproxy.host' = '127.0.0.1',
-   'logproxy.port' = '2983');
+   'logproxy.port' = '2983',
+   'working-mode' = 'memory'
+);
 ```
 
 Features

--- a/docs/content/quickstart/oceanbase-tutorial.md
+++ b/docs/content/quickstart/oceanbase-tutorial.md
@@ -139,7 +139,9 @@ Flink SQL> CREATE TABLE orders (
     'port' = '2881',
     'rootserver-list' = '127.0.0.1:2882:2881',
     'logproxy.host' = 'localhost',
-    'logproxy.port' = '2983');
+    'logproxy.port' = '2983',
+    'working-mode' = 'memory'
+ );
 
 -- create products table
 Flink SQL> CREATE TABLE products (
@@ -159,7 +161,9 @@ Flink SQL> CREATE TABLE products (
     'port' = '2881',
     'rootserver-list' = '127.0.0.1:2882:2881',
     'logproxy.host' = 'localhost',
-    'logproxy.port' = '2983');
+    'logproxy.port' = '2983',
+    'working-mode' = 'memory'
+ );
 
 -- create flat table enriched_orders
 Flink SQL> CREATE TABLE enriched_orders (

--- a/docs/content/快速上手/oceanbase-tutorial-zh.md
+++ b/docs/content/快速上手/oceanbase-tutorial-zh.md
@@ -137,7 +137,9 @@ Flink SQL> CREATE TABLE orders (
     'port' = '2881',
     'rootserver-list' = '127.0.0.1:2882:2881',
     'logproxy.host' = 'localhost',
-    'logproxy.port' = '2983');
+    'logproxy.port' = '2983',
+    'working-mode' = 'memory'
+ );
 
 -- 创建商品表 
 Flink SQL> CREATE TABLE products (
@@ -157,7 +159,9 @@ Flink SQL> CREATE TABLE products (
     'port' = '2881',
     'rootserver-list' = '127.0.0.1:2882:2881',
     'logproxy.host' = 'localhost',
-    'logproxy.port' = '2983');
+    'logproxy.port' = '2983',
+    'working-mode' = 'memory'
+  );
 
 -- 创建关联后的订单数据表
 Flink SQL> CREATE TABLE enriched_orders (

--- a/flink-connector-oceanbase-cdc/src/test/java/com/ververica/cdc/connectors/oceanbase/OceanBaseTestBase.java
+++ b/flink-connector-oceanbase-cdc/src/test/java/com/ververica/cdc/connectors/oceanbase/OceanBaseTestBase.java
@@ -54,6 +54,7 @@ public class OceanBaseTestBase extends TestLogger {
     private static final Logger LOG = LoggerFactory.getLogger(OceanBaseTestBase.class);
 
     private static final Pattern COMMENT_PATTERN = Pattern.compile("^(.*)--.*$");
+    private static final Duration CONTAINER_STARTUP_TIMEOUT = Duration.ofMinutes(4);
 
     public static final int OB_SERVER_SQL_PORT = 2881;
     public static final int OB_SERVER_RPC_PORT = 2882;
@@ -112,7 +113,7 @@ public class OceanBaseTestBase extends TestLogger {
                     .withExposedPorts(OB_SERVER_SQL_PORT, OB_SERVER_RPC_PORT)
                     .withEnv("OB_ROOT_PASSWORD", OB_SYS_PASSWORD)
                     .waitingFor(Wait.forLogMessage(".*boot success!.*", 1))
-                    .withStartupTimeout(Duration.ofSeconds(120))
+                    .withStartupTimeout(CONTAINER_STARTUP_TIMEOUT)
                     .withLogConsumer(new Slf4jLogConsumer(LOG));
 
     @ClassRule
@@ -123,7 +124,7 @@ public class OceanBaseTestBase extends TestLogger {
                     .withEnv("OB_SYS_USERNAME", OB_SYS_USERNAME)
                     .withEnv("OB_SYS_PASSWORD", OB_SYS_PASSWORD)
                     .waitingFor(Wait.forLogMessage(".*boot success!.*", 1))
-                    .withStartupTimeout(Duration.ofSeconds(120))
+                    .withStartupTimeout(CONTAINER_STARTUP_TIMEOUT)
                     .withLogConsumer(new Slf4jLogConsumer(LOG));
 
     @BeforeClass

--- a/flink-connector-oceanbase-cdc/src/test/java/com/ververica/cdc/connectors/oceanbase/table/OceanBaseConnectorITCase.java
+++ b/flink-connector-oceanbase-cdc/src/test/java/com/ververica/cdc/connectors/oceanbase/table/OceanBaseConnectorITCase.java
@@ -97,7 +97,8 @@ public class OceanBaseConnectorITCase extends OceanBaseTestBase {
                                 + " 'port' = '%s',"
                                 + " 'logproxy.host' = '%s',"
                                 + " 'logproxy.port' = '%s',"
-                                + " 'rootserver-list' = '%s'"
+                                + " 'rootserver-list' = '%s',"
+                                + " 'working-mode' = 'memory'"
                                 + ")",
                         getUsername(),
                         getPassword(),
@@ -220,7 +221,8 @@ public class OceanBaseConnectorITCase extends OceanBaseTestBase {
                                 + " 'port' = '%s',"
                                 + " 'logproxy.host' = '%s',"
                                 + " 'logproxy.port' = '%s',"
-                                + " 'rootserver-list' = '%s'"
+                                + " 'rootserver-list' = '%s',"
+                                + " 'working-mode' = 'memory'"
                                 + ")",
                         getUsername(),
                         getPassword(),
@@ -342,7 +344,8 @@ public class OceanBaseConnectorITCase extends OceanBaseTestBase {
                                 + " 'port' = '%s',"
                                 + " 'logproxy.host' = '%s',"
                                 + " 'logproxy.port' = '%s',"
-                                + " 'rootserver-list' = '%s'"
+                                + " 'rootserver-list' = '%s',"
+                                + " 'working-mode' = 'memory'"
                                 + ")",
                         getUsername(),
                         getPassword(),


### PR DESCRIPTION
As the `storage` mode of `obcdc` will store the log data on the disk, which may waste the disk space. It's better to use `memory` mode for testing.

Fix #1473 
