### PR TITLE
[mysql] Let the records of snapshot split don't cross checkpoints

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
@@ -28,6 +28,7 @@ import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
 import com.ververica.cdc.connectors.mysql.source.split.FinishedSnapshotSplitInfo;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlBinlogSplit;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
+import com.ververica.cdc.connectors.mysql.source.split.SourceRecords;
 import com.ververica.cdc.connectors.mysql.source.utils.ChunkUtils;
 import com.ververica.cdc.connectors.mysql.source.utils.RecordUtils;
 import io.debezium.connector.base.ChangeEventQueue;
@@ -63,7 +64,7 @@ import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isData
  * A Debezium binlog reader implementation that also support reads binlog and filter overlapping
  * snapshot data that {@link SnapshotSplitReader} read.
  */
-public class BinlogSplitReader implements DebeziumReader<SourceRecord, MySqlSplit> {
+public class BinlogSplitReader implements DebeziumReader<SourceRecords, MySqlSplit> {
 
     private static final Logger LOG = LoggerFactory.getLogger(BinlogSplitReader.class);
     private final StatefulTaskContext statefulTaskContext;
@@ -145,7 +146,7 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecord, MySqlSpli
 
     @Nullable
     @Override
-    public Iterator<SourceRecord> pollSplitRecords() throws InterruptedException {
+    public Iterator<SourceRecords> pollSplitRecords() throws InterruptedException {
         checkReadException();
         final List<SourceRecord> sourceRecords = new ArrayList<>();
         if (currentTaskRunning) {
@@ -155,7 +156,9 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecord, MySqlSpli
                     sourceRecords.add(event.getRecord());
                 }
             }
-            return sourceRecords.iterator();
+            Set<SourceRecords> sourceRecordsSet = new HashSet<>();
+            sourceRecordsSet.add(new SourceRecords(sourceRecords));
+            return sourceRecordsSet.iterator();
         } else {
             return null;
         }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
@@ -156,7 +156,7 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecords, MySqlSpl
                     sourceRecords.add(event.getRecord());
                 }
             }
-            Set<SourceRecords> sourceRecordsSet = new HashSet<>();
+            List<SourceRecords> sourceRecordsSet = new ArrayList<>();
             sourceRecordsSet.add(new SourceRecords(sourceRecords));
             return sourceRecordsSet.iterator();
         } else {

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
@@ -50,11 +50,9 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -292,7 +290,7 @@ public class SnapshotSplitReader implements DebeziumReader<SourceRecords, MySqlS
             normalizedRecords.addAll(formatMessageTimestamp(snapshotRecords.values()));
             normalizedRecords.add(highWatermark);
 
-            final Set<SourceRecords> sourceRecordsSet = new HashSet<>();
+            final List<SourceRecords> sourceRecordsSet = new ArrayList<>();
             sourceRecordsSet.add(new SourceRecords(normalizedRecords));
             return sourceRecordsSet.iterator();
         }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSource.java
@@ -51,11 +51,11 @@ import com.ververica.cdc.connectors.mysql.source.reader.MySqlSourceReaderContext
 import com.ververica.cdc.connectors.mysql.source.reader.MySqlSplitReader;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplitSerializer;
+import com.ververica.cdc.connectors.mysql.source.split.SourceRecords;
 import com.ververica.cdc.connectors.mysql.table.StartupMode;
 import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.TableId;
-import org.apache.kafka.connect.source.SourceRecord;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -133,7 +133,7 @@ public class MySqlSource<T>
         // create source config for the given subtask (e.g. unique server id)
         MySqlSourceConfig sourceConfig =
                 configFactory.createConfig(readerContext.getIndexOfSubtask());
-        FutureCompletingBlockingQueue<RecordsWithSplitIds<SourceRecord>> elementsQueue =
+        FutureCompletingBlockingQueue<RecordsWithSplitIds<SourceRecords>> elementsQueue =
                 new FutureCompletingBlockingQueue<>();
 
         final Method metricGroupMethod = readerContext.getClass().getMethod("metricGroup");

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
@@ -23,6 +23,7 @@ import org.apache.flink.util.Collector;
 import com.ververica.cdc.connectors.mysql.source.metrics.MySqlSourceReaderMetrics;
 import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplitState;
+import com.ververica.cdc.connectors.mysql.source.split.SourceRecords;
 import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
 import com.ververica.cdc.debezium.history.FlinkJsonTableChangeSerializer;
 import io.debezium.document.Array;
@@ -31,6 +32,8 @@ import io.debezium.relational.history.TableChanges;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
 
 import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.getBinlogPosition;
 import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.getFetchTimestamp;
@@ -50,7 +53,7 @@ import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isWate
  * emit records rather than emit the records directly.
  */
 public final class MySqlRecordEmitter<T>
-        implements RecordEmitter<SourceRecord, T, MySqlSplitState> {
+        implements RecordEmitter<SourceRecords, T, MySqlSplitState> {
 
     private static final Logger LOG = LoggerFactory.getLogger(MySqlRecordEmitter.class);
     private static final FlinkJsonTableChangeSerializer TABLE_CHANGE_SERIALIZER =
@@ -72,7 +75,18 @@ public final class MySqlRecordEmitter<T>
     }
 
     @Override
-    public void emitRecord(SourceRecord element, SourceOutput<T> output, MySqlSplitState splitState)
+    public void emitRecord(
+            SourceRecords sourceRecords, SourceOutput<T> output, MySqlSplitState splitState)
+            throws Exception {
+        final Iterator<SourceRecord> elementIterator =
+                sourceRecords.getSourceRecordList().iterator();
+        while (elementIterator.hasNext()) {
+            processElement(elementIterator.next(), output, splitState);
+        }
+    }
+
+    private void processElement(
+            SourceRecord element, SourceOutput<T> output, MySqlSplitState splitState)
             throws Exception {
         if (isWatermarkEvent(element)) {
             BinlogOffset watermark = getWatermark(element);

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
@@ -78,8 +78,7 @@ public final class MySqlRecordEmitter<T>
     public void emitRecord(
             SourceRecords sourceRecords, SourceOutput<T> output, MySqlSplitState splitState)
             throws Exception {
-        final Iterator<SourceRecord> elementIterator =
-                sourceRecords.getSourceRecordList().iterator();
+        final Iterator<SourceRecord> elementIterator = sourceRecords.iterator();
         while (elementIterator.hasNext()) {
             processElement(elementIterator.next(), output, splitState);
         }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReader.java
@@ -45,11 +45,11 @@ import com.ververica.cdc.connectors.mysql.source.split.MySqlSnapshotSplit;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSnapshotSplitState;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplitState;
+import com.ververica.cdc.connectors.mysql.source.split.SourceRecords;
 import com.ververica.cdc.connectors.mysql.source.utils.TableDiscoveryUtils;
 import io.debezium.connector.mysql.MySqlConnection;
 import io.debezium.relational.TableId;
 import io.debezium.relational.history.TableChanges;
-import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +71,7 @@ import static com.ververica.cdc.connectors.mysql.source.utils.ChunkUtils.getNext
 /** The source reader for MySQL source splits. */
 public class MySqlSourceReader<T>
         extends SingleThreadMultiplexSourceReaderBase<
-                SourceRecord, T, MySqlSplit, MySqlSplitState> {
+                SourceRecords, T, MySqlSplit, MySqlSplitState> {
 
     private static final Logger LOG = LoggerFactory.getLogger(MySqlSourceReader.class);
 
@@ -83,9 +83,9 @@ public class MySqlSourceReader<T>
     private MySqlBinlogSplit suspendedBinlogSplit;
 
     public MySqlSourceReader(
-            FutureCompletingBlockingQueue<RecordsWithSplitIds<SourceRecord>> elementQueue,
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<SourceRecords>> elementQueue,
             Supplier<MySqlSplitReader> splitReaderSupplier,
-            RecordEmitter<SourceRecord, T, MySqlSplitState> recordEmitter,
+            RecordEmitter<SourceRecords, T, MySqlSplitState> recordEmitter,
             Configuration config,
             MySqlSourceReaderContext context,
             MySqlSourceConfig sourceConfig) {

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSplitReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSplitReader.java
@@ -30,8 +30,8 @@ import com.ververica.cdc.connectors.mysql.source.MySqlSource;
 import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfig;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlRecords;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
+import com.ververica.cdc.connectors.mysql.source.split.SourceRecords;
 import io.debezium.connector.mysql.MySqlConnection;
-import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +46,7 @@ import static com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils.createBi
 import static com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils.createMySqlConnection;
 
 /** The {@link SplitReader} implementation for the {@link MySqlSource}. */
-public class MySqlSplitReader implements SplitReader<SourceRecord, MySqlSplit> {
+public class MySqlSplitReader implements SplitReader<SourceRecords, MySqlSplit> {
 
     private static final Logger LOG = LoggerFactory.getLogger(MySqlSplitReader.class);
     private final Queue<MySqlSplit> splits;
@@ -54,7 +54,7 @@ public class MySqlSplitReader implements SplitReader<SourceRecord, MySqlSplit> {
     private final int subtaskId;
     private final MySqlSourceReaderContext context;
 
-    @Nullable private DebeziumReader<SourceRecord, MySqlSplit> currentReader;
+    @Nullable private DebeziumReader<SourceRecords, MySqlSplit> currentReader;
     @Nullable private String currentSplitId;
 
     public MySqlSplitReader(
@@ -66,12 +66,12 @@ public class MySqlSplitReader implements SplitReader<SourceRecord, MySqlSplit> {
     }
 
     @Override
-    public RecordsWithSplitIds<SourceRecord> fetch() throws IOException {
+    public RecordsWithSplitIds<SourceRecords> fetch() throws IOException {
 
         checkSplitOrStartNext();
         checkNeedStopBinlogReader();
 
-        Iterator<SourceRecord> dataIt;
+        Iterator<SourceRecords> dataIt;
         try {
             dataIt = currentReader.pollSplitRecords();
         } catch (InterruptedException e) {

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlRecords.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlRecords.java
@@ -18,8 +18,6 @@ package com.ververica.cdc.connectors.mysql.source.split;
 
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 
-import org.apache.kafka.connect.source.SourceRecord;
-
 import javax.annotation.Nullable;
 
 import java.util.Collections;
@@ -29,11 +27,11 @@ import java.util.Set;
 /**
  * An implementation of {@link RecordsWithSplitIds} which contains the records of one table split.
  */
-public final class MySqlRecords implements RecordsWithSplitIds<SourceRecord> {
+public final class MySqlRecords implements RecordsWithSplitIds<SourceRecords> {
 
     @Nullable private String splitId;
-    @Nullable private Iterator<SourceRecord> recordsForCurrentSplit;
-    @Nullable private final Iterator<SourceRecord> recordsForSplit;
+    @Nullable private Iterator<SourceRecords> recordsForCurrentSplit;
+    @Nullable private final Iterator<SourceRecords> recordsForSplit;
     private final Set<String> finishedSnapshotSplits;
 
     public MySqlRecords(
@@ -59,8 +57,8 @@ public final class MySqlRecords implements RecordsWithSplitIds<SourceRecord> {
 
     @Nullable
     @Override
-    public SourceRecord nextRecordFromSplit() {
-        final Iterator<SourceRecord> recordsForSplit = this.recordsForCurrentSplit;
+    public SourceRecords nextRecordFromSplit() {
+        final Iterator<SourceRecords> recordsForSplit = this.recordsForCurrentSplit;
         if (recordsForSplit != null) {
             if (recordsForSplit.hasNext()) {
                 return recordsForSplit.next();
@@ -78,7 +76,7 @@ public final class MySqlRecords implements RecordsWithSplitIds<SourceRecord> {
     }
 
     public static MySqlRecords forRecords(
-            final String splitId, final Iterator<SourceRecord> recordsForSplit) {
+            final String splitId, final Iterator<SourceRecords> recordsForSplit) {
         return new MySqlRecords(splitId, recordsForSplit, Collections.emptySet());
     }
 

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/SourceRecords.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/SourceRecords.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2022 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/SourceRecords.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/SourceRecords.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mysql.source.split;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/** Data structure to describe a set of {@link SourceRecord}. */
+public final class SourceRecords {
+
+    private final List<SourceRecord> sourceRecords;
+
+    public SourceRecords(List<SourceRecord> sourceRecords) {
+        this.sourceRecords = sourceRecords;
+    }
+
+    public List<SourceRecord> getSourceRecordList() {
+        return sourceRecords;
+    }
+
+    public Iterator<SourceRecord> iterator() {
+        return sourceRecords.iterator();
+    }
+
+    public static SourceRecords fromSingleRecord(SourceRecord record) {
+        final List<SourceRecord> records = new ArrayList<>();
+        records.add(record);
+        return new SourceRecords(records);
+    }
+}

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
@@ -29,6 +29,7 @@ import com.ververica.cdc.connectors.mysql.source.assigners.MySqlSnapshotSplitAss
 import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfig;
 import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfigFactory;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
+import com.ververica.cdc.connectors.mysql.source.split.SourceRecords;
 import com.ververica.cdc.connectors.mysql.testutils.RecordsFormatter;
 import com.ververica.cdc.connectors.mysql.testutils.UniqueDatabase;
 import io.debezium.connector.mysql.MySqlConnection;
@@ -397,11 +398,11 @@ public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
             if (snapshotSplitReader.isFinished()) {
                 snapshotSplitReader.submitSplit(sqlSplit);
             }
-            Iterator<SourceRecord> res;
+            Iterator<SourceRecords> res;
             while ((res = snapshotSplitReader.pollSplitRecords()) != null) {
                 while (res.hasNext()) {
-                    SourceRecord sourceRecord = res.next();
-                    result.add(sourceRecord);
+                    SourceRecords sourceRecords = res.next();
+                    result.addAll(sourceRecords.getSourceRecordList());
                 }
             }
         }

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceITCase.java
@@ -306,7 +306,7 @@ public class MySqlSourceITCase extends MySqlSourceTestBase {
         DataStreamSource<RowData> source =
                 env.fromSource(sleepingSource, WatermarkStrategy.noWatermarks(), "selfSource");
 
-        String[] snapshotForSingleTable =
+        String[] expectedSnapshotData =
                 new String[] {
                     "+I[101, user_1, Shanghai, 123567891234]",
                     "+I[102, user_2, Shanghai, 123567891234]",
@@ -358,11 +358,10 @@ public class MySqlSourceITCase extends MySqlSourceTestBase {
                     () -> sleepMs(100));
         }
 
-        List<String> expectedSnapshotData = new ArrayList<>(Arrays.asList(snapshotForSingleTable));
-
         // Check all snapshot records are sent with exactly-once semantics
         assertEqualsInAnyOrder(
-                expectedSnapshotData, fetchRowData(iterator, expectedSnapshotData.size()));
+                Arrays.asList(expectedSnapshotData),
+                fetchRowData(iterator, expectedSnapshotData.length));
         jobClient.cancel().get();
     }
 

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlRecordEmitterTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlRecordEmitterTest.java
@@ -25,6 +25,7 @@ import com.ververica.cdc.connectors.mysql.source.metrics.MySqlSourceReaderMetric
 import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlBinlogSplit;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlBinlogSplitState;
+import com.ververica.cdc.connectors.mysql.source.split.SourceRecords;
 import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
 import io.debezium.heartbeat.Heartbeat;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -50,7 +51,10 @@ public class MySqlRecordEmitterTest {
                 fakeOffset.getOffset(),
                 record -> {
                     try {
-                        recordEmitter.emitRecord(record, new TestingReaderOutput<>(), splitState);
+                        recordEmitter.emitRecord(
+                                SourceRecords.fromSingleRecord(record),
+                                new TestingReaderOutput<>(),
+                                splitState);
                     } catch (Exception e) {
                         throw new RuntimeException("Failed to emit heartbeat record", e);
                     }

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
@@ -30,6 +31,7 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
 
 import com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils;
 import com.ververica.cdc.connectors.mysql.source.MySqlSourceTestBase;
@@ -38,20 +40,28 @@ import com.ververica.cdc.connectors.mysql.source.assigners.MySqlSnapshotSplitAss
 import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfig;
 import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfigFactory;
 import com.ververica.cdc.connectors.mysql.source.metrics.MySqlSourceReaderMetrics;
+import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlBinlogSplit;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSnapshotSplit;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
+import com.ververica.cdc.connectors.mysql.source.split.MySqlSplitState;
+import com.ververica.cdc.connectors.mysql.source.split.SourceRecords;
 import com.ververica.cdc.connectors.mysql.source.utils.TableDiscoveryUtils;
 import com.ververica.cdc.connectors.mysql.table.StartupOptions;
 import com.ververica.cdc.connectors.mysql.testutils.RecordsFormatter;
 import com.ververica.cdc.connectors.mysql.testutils.UniqueDatabase;
 import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import com.ververica.cdc.debezium.history.FlinkJsonTableChangeSerializer;
 import io.debezium.connector.mysql.MySqlConnection;
+import io.debezium.document.Array;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.TableId;
+import io.debezium.relational.history.HistoryRecord;
 import io.debezium.relational.history.TableChanges;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.sql.Connection;
@@ -62,12 +72,23 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.getBinlogPosition;
+import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.getFetchTimestamp;
+import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.getHistoryRecord;
+import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.getMessageTimestamp;
+import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.getWatermark;
+import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isDataChangeRecord;
+import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isHeartbeatEvent;
+import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isHighWatermarkEvent;
+import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isSchemaChangeEvent;
+import static com.ververica.cdc.connectors.mysql.source.utils.RecordUtils.isWatermarkEvent;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -100,10 +121,6 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
                             createBinlogSplit(sourceConfig).asBinlogSplit(), tableSchemas);
         }
 
-        MySqlSourceReader<SourceRecord> reader = createReader(sourceConfig);
-        reader.start();
-        reader.addSplits(Arrays.asList(binlogSplit));
-
         // step-1: make 6 change events in one MySQL transaction
         TableId tableId = binlogSplit.getTableSchemas().keySet().iterator().next();
         makeBinlogEventsInOneTransaction(sourceConfig, tableId.toString());
@@ -115,7 +132,10 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
                     "+U[103, user_3, Hangzhou, 123567891234]"
                 };
         // the 2 records are produced by 1 operations
-        List<String> actualRecords = consumeRecords(reader, dataType, 1);
+        MySqlSourceReader<SourceRecord> reader = createReader(sourceConfig, 1);
+        reader.start();
+        reader.addSplits(Arrays.asList(binlogSplit));
+        List<String> actualRecords = consumeRecords(reader, dataType);
         assertEqualsInOrder(Arrays.asList(expectedRecords), actualRecords);
         List<MySqlSplit> splitsState = reader.snapshotState(1L);
         // check the binlog split state
@@ -123,7 +143,7 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
         reader.close();
 
         // step-3: mock failover from a restored state
-        MySqlSourceReader<SourceRecord> restartReader = createReader(sourceConfig);
+        MySqlSourceReader<SourceRecord> restartReader = createReader(sourceConfig, 3);
         restartReader.start();
         restartReader.addSplits(splitsState);
 
@@ -136,7 +156,67 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
                     "+U[103, user_3, Shanghai, 123567891234]"
                 };
         // the 4 records are produced by 3 operations
-        List<String> restRecords = consumeRecords(restartReader, dataType, 3);
+        List<String> restRecords = consumeRecords(restartReader, dataType);
+        assertEqualsInOrder(Arrays.asList(expectedRestRecords), restRecords);
+        restartReader.close();
+    }
+
+    @Test
+    public void testBinlogReadFailoverCrossCheckpoint() throws Exception {
+        customerDatabase.createAndInitialize();
+        final MySqlSourceConfig sourceConfig = getConfig(new String[] {"customers"});
+        final DataType dataType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("id", DataTypes.BIGINT()),
+                        DataTypes.FIELD("name", DataTypes.STRING()),
+                        DataTypes.FIELD("address", DataTypes.STRING()),
+                        DataTypes.FIELD("phone_number", DataTypes.STRING()));
+        MySqlSplit binlogSplit;
+        try (MySqlConnection jdbc = DebeziumUtils.createMySqlConnection(sourceConfig)) {
+            Map<TableId, TableChanges.TableChange> tableSchemas =
+                    TableDiscoveryUtils.discoverCapturedTableSchemas(sourceConfig, jdbc);
+            binlogSplit =
+                    MySqlBinlogSplit.fillTableSchemas(
+                            createBinlogSplit(sourceConfig).asBinlogSplit(), tableSchemas);
+        }
+
+        // step-1: make 6 change events in one MySQL transaction
+        TableId tableId = binlogSplit.getTableSchemas().keySet().iterator().next();
+        makeBinlogEventsInOneTransaction(sourceConfig, tableId.toString());
+
+        // step-2: fetch the first 2 records belong to the snapshot split
+        String[] expectedRecords =
+                new String[] {
+                    "-U[103, user_3, Shanghai, 123567891234]",
+                    "+U[103, user_3, Hangzhou, 123567891234]"
+                };
+        // the 2 records are produced by 1 operations
+        MySqlSourceReader<SourceRecord> reader = createReader(sourceConfig, 1);
+        reader.start();
+        reader.addSplits(Arrays.asList(binlogSplit));
+        List<String> actualRecords = consumeRecords(reader, dataType);
+        assertEqualsInOrder(Arrays.asList(expectedRecords), actualRecords);
+        List<MySqlSplit> splitsState = reader.snapshotState(1L);
+
+        // check the snapshot split state
+        assertEquals(1, splitsState.size());
+        reader.close();
+
+        // step-3: mock failover from a restored state
+        MySqlSourceReader<SourceRecord> restartReader = createReader(sourceConfig, 3);
+        restartReader.start();
+        restartReader.addSplits(splitsState);
+
+        // step-4: fetch all records belong to the snapshot split
+        String[] expectedRestRecords =
+                new String[] {
+                    "-D[102, user_2, Shanghai, 123567891234]",
+                    "+I[102, user_2, Shanghai, 123567891234]",
+                    "-U[103, user_3, Hangzhou, 123567891234]",
+                    "+U[103, user_3, Shanghai, 123567891234]"
+                };
+        // the 4 records are produced by 3 operations
+        List<String> restRecords = consumeRecords(restartReader, dataType);
         assertEqualsInOrder(Arrays.asList(expectedRestRecords), restRecords);
         restartReader.close();
     }
@@ -175,7 +255,8 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
         final AtomicBoolean finishReading = new AtomicBoolean(false);
         final CountDownLatch updatingExecuted = new CountDownLatch(1);
         TestingReaderContext testingReaderContext = new TestingReaderContext();
-        MySqlSourceReader<SourceRecord> reader = createReader(sourceConfig, testingReaderContext);
+        MySqlSourceReader<SourceRecord> reader =
+                createReader(sourceConfig, testingReaderContext, 0);
         reader.start();
 
         Thread updateWorker =
@@ -237,25 +318,31 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
         }
     }
 
-    private MySqlSourceReader<SourceRecord> createReader(MySqlSourceConfig configuration)
+    private MySqlSourceReader<SourceRecord> createReader(MySqlSourceConfig configuration, int limit)
             throws Exception {
-        return createReader(configuration, new TestingReaderContext());
+        return createReader(configuration, new TestingReaderContext(), limit);
     }
 
     private MySqlSourceReader<SourceRecord> createReader(
-            MySqlSourceConfig configuration, SourceReaderContext readerContext) throws Exception {
-        final FutureCompletingBlockingQueue<RecordsWithSplitIds<SourceRecord>> elementsQueue =
+            MySqlSourceConfig configuration, SourceReaderContext readerContext, int limit)
+            throws Exception {
+        final FutureCompletingBlockingQueue<RecordsWithSplitIds<SourceRecords>> elementsQueue =
                 new FutureCompletingBlockingQueue<>();
         // make  SourceReaderContext#metricGroup compatible between Flink 1.13 and Flink 1.14
         final Method metricGroupMethod = readerContext.getClass().getMethod("metricGroup");
         metricGroupMethod.setAccessible(true);
         final MetricGroup metricGroup = (MetricGroup) metricGroupMethod.invoke(readerContext);
-
-        final MySqlRecordEmitter<SourceRecord> recordEmitter =
-                new MySqlRecordEmitter<>(
-                        new ForwardDeserializeSchema(),
-                        new MySqlSourceReaderMetrics(metricGroup),
-                        configuration.isIncludeSchemaChanges());
+        final RecordEmitter<SourceRecords, SourceRecord, MySqlSplitState> recordEmitter =
+                limit > 0
+                        ? new MysqlLimitedRecordEmitter(
+                                new ForwardDeserializeSchema(),
+                                new MySqlSourceReaderMetrics(metricGroup),
+                                configuration.isIncludeSchemaChanges(),
+                                limit)
+                        : new MySqlRecordEmitter<>(
+                                new ForwardDeserializeSchema(),
+                                new MySqlSourceReaderMetrics(metricGroup),
+                                configuration.isIncludeSchemaChanges());
         final MySqlSourceReaderContext mySqlSourceReaderContext =
                 new MySqlSourceReaderContext(readerContext);
         return new MySqlSourceReader<>(
@@ -314,11 +401,10 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
     }
 
     private List<String> consumeRecords(
-            MySqlSourceReader<SourceRecord> sourceReader, DataType recordType, int changeEventNum)
-            throws Exception {
+            MySqlSourceReader<SourceRecord> sourceReader, DataType recordType) throws Exception {
         // Poll all the n records of the single split.
         final SimpleReaderOutput output = new SimpleReaderOutput();
-        while (output.getResults().size() < changeEventNum) {
+        while (output.getResults().size() == 0) {
             sourceReader.pollNext(output);
         }
         final RecordsFormatter formatter = new RecordsFormatter(recordType);
@@ -379,6 +465,129 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
         @Override
         public TypeInformation<SourceRecord> getProducedType() {
             return TypeInformation.of(SourceRecord.class);
+        }
+    }
+
+    private static class MysqlLimitedRecordEmitter
+            implements RecordEmitter<SourceRecords, SourceRecord, MySqlSplitState> {
+
+        private static final Logger LOG = LoggerFactory.getLogger(MySqlRecordEmitter.class);
+        private static final FlinkJsonTableChangeSerializer TABLE_CHANGE_SERIALIZER =
+                new FlinkJsonTableChangeSerializer();
+
+        private final DebeziumDeserializationSchema<SourceRecord> debeziumDeserializationSchema;
+        private final MySqlSourceReaderMetrics sourceReaderMetrics;
+        private final boolean includeSchemaChanges;
+        private final OutputCollector<SourceRecord> outputCollector;
+        private final int limit;
+
+        public MysqlLimitedRecordEmitter(
+                DebeziumDeserializationSchema<SourceRecord> debeziumDeserializationSchema,
+                MySqlSourceReaderMetrics sourceReaderMetrics,
+                boolean includeSchemaChanges,
+                int limit) {
+            this.debeziumDeserializationSchema = debeziumDeserializationSchema;
+            this.sourceReaderMetrics = sourceReaderMetrics;
+            this.includeSchemaChanges = includeSchemaChanges;
+            this.outputCollector = new OutputCollector<>();
+            Preconditions.checkState(limit > 0);
+            this.limit = limit;
+        }
+
+        @Override
+        public void emitRecord(
+                SourceRecords sourceRecords,
+                SourceOutput<SourceRecord> output,
+                MySqlSplitState splitState)
+                throws Exception {
+            final Iterator<SourceRecord> elementIterator =
+                    sourceRecords.getSourceRecordList().iterator();
+            int sendCnt = 0;
+            while (elementIterator.hasNext()) {
+                if (sendCnt >= limit) {
+                    return;
+                }
+                processElement(elementIterator.next(), output, splitState);
+                sendCnt++;
+            }
+        }
+
+        private void processElement(
+                SourceRecord element, SourceOutput<SourceRecord> output, MySqlSplitState splitState)
+                throws Exception {
+            if (isWatermarkEvent(element)) {
+                BinlogOffset watermark = getWatermark(element);
+                if (isHighWatermarkEvent(element) && splitState.isSnapshotSplitState()) {
+                    splitState.asSnapshotSplitState().setHighWatermark(watermark);
+                }
+            } else if (isSchemaChangeEvent(element) && splitState.isBinlogSplitState()) {
+                HistoryRecord historyRecord = getHistoryRecord(element);
+                Array tableChanges =
+                        historyRecord.document().getArray(HistoryRecord.Fields.TABLE_CHANGES);
+                TableChanges changes = TABLE_CHANGE_SERIALIZER.deserialize(tableChanges, true);
+                for (TableChanges.TableChange tableChange : changes) {
+                    splitState.asBinlogSplitState().recordSchema(tableChange.getId(), tableChange);
+                }
+                if (includeSchemaChanges) {
+                    BinlogOffset position = getBinlogPosition(element);
+                    splitState.asBinlogSplitState().setStartingOffset(position);
+                    emitElement(element, output);
+                }
+            } else if (isDataChangeRecord(element)) {
+                updateStartingOffsetForSplit(splitState, element);
+                reportMetrics(element);
+                emitElement(element, output);
+            } else if (isHeartbeatEvent(element)) {
+                updateStartingOffsetForSplit(splitState, element);
+            } else {
+                // unknown element
+                LOG.info("Meet unknown element {}, just skip.", element);
+            }
+        }
+
+        private void updateStartingOffsetForSplit(
+                MySqlSplitState splitState, SourceRecord element) {
+            if (splitState.isBinlogSplitState()) {
+                BinlogOffset position = getBinlogPosition(element);
+                splitState.asBinlogSplitState().setStartingOffset(position);
+            }
+        }
+
+        private void emitElement(SourceRecord element, SourceOutput<SourceRecord> output)
+                throws Exception {
+            outputCollector.output = output;
+            debeziumDeserializationSchema.deserialize(element, outputCollector);
+        }
+
+        private void reportMetrics(SourceRecord element) {
+            long now = System.currentTimeMillis();
+            // record the latest process time
+            sourceReaderMetrics.recordProcessTime(now);
+            Long messageTimestamp = getMessageTimestamp(element);
+
+            if (messageTimestamp != null && messageTimestamp > 0L) {
+                // report fetch delay
+                Long fetchTimestamp = getFetchTimestamp(element);
+                if (fetchTimestamp != null && fetchTimestamp >= messageTimestamp) {
+                    sourceReaderMetrics.recordFetchDelay(fetchTimestamp - messageTimestamp);
+                }
+                // report emit delay
+                sourceReaderMetrics.recordEmitDelay(now - messageTimestamp);
+            }
+        }
+
+        private static class OutputCollector<T> implements Collector<T> {
+            private SourceOutput<T> output;
+
+            @Override
+            public void collect(T record) {
+                output.collect(record);
+            }
+
+            @Override
+            public void close() {
+                // do nothing
+            }
         }
     }
 }


### PR DESCRIPTION
The output records of a snapshot split should not cross checkpoints, this may lead to data duplication when failover happen, because partial snapshot records of one split may sent in last checkpoint, but this snapshot split may be re-read all snapshot records after failover, this behavior bring potential data duplication issue.