### PR TITLE
There is a typo in the comments in MysqlSnapshotSplit.

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSnapshotSplit.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSnapshotSplit.java
@@ -38,7 +38,7 @@ public class MySqlSnapshotSplit extends MySqlSplit {
 
     @Nullable private final Object[] splitStart;
     @Nullable private final Object[] splitEnd;
-    /** The high watermark is not bull when the split read finished. */
+    /** The high watermark is not null when the split read finished. */
     @Nullable private final BinlogOffset highWatermark;
 
     @Nullable transient byte[] serializedFormCache;


### PR DESCRIPTION
should be "The high watermark is not null when the split read finished.", but not 'bull'.