### PR TITLE
[mysql][support-multi-table] support set separator to distinguish different tables

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceOptions.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceOptions.java
@@ -65,6 +65,12 @@ public class MySqlSourceOptions {
                     .noDefaultValue()
                     .withDescription("Table name of the MySQL database to monitor.");
 
+    public static final ConfigOption<String> TABLE_SEPARATOR =
+            ConfigOptions.key("table-separator")
+                    .stringType()
+                    .defaultValue(",")
+                    .withDescription("The separator to distinguish different table.");
+
     public static final ConfigOption<String> SERVER_TIME_ZONE =
             ConfigOptions.key("server-time-zone")
                     .stringType()

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSource.java
@@ -39,6 +39,7 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -62,6 +63,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
     private final String database;
     private final String username;
     private final String password;
+    private final String tableSeparator;
     private final String serverId;
     private final String tableName;
     private final ZoneId serverTimeZone;
@@ -97,6 +99,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
             String hostname,
             String database,
             String tableName,
+            String tableSeparator,
             String username,
             String password,
             ZoneId serverTimeZone,
@@ -119,6 +122,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                 hostname,
                 database,
                 tableName,
+                tableSeparator,
                 username,
                 password,
                 serverTimeZone,
@@ -146,6 +150,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
             String hostname,
             String database,
             String tableName,
+            String tableSeparator,
             String username,
             String password,
             ZoneId serverTimeZone,
@@ -170,6 +175,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
         this.hostname = checkNotNull(hostname);
         this.database = checkNotNull(database);
         this.tableName = checkNotNull(tableName);
+        this.tableSeparator = tableSeparator;
         this.username = checkNotNull(username);
         this.password = checkNotNull(password);
         this.serverId = serverId;
@@ -227,7 +233,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                             .hostname(hostname)
                             .port(port)
                             .databaseList(database)
-                            .tableList(database + "." + tableName)
+                            .tableList(getAllMonitorTables(database, tableName, tableSeparator))
                             .username(username)
                             .password(password)
                             .serverTimeZone(serverTimeZone.toString())
@@ -255,7 +261,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                             .hostname(hostname)
                             .port(port)
                             .databaseList(database)
-                            .tableList(database + "." + tableName)
+                            .tableList(getAllMonitorTables(database, tableName, tableSeparator))
                             .username(username)
                             .password(password)
                             .serverTimeZone(serverTimeZone.toString())
@@ -299,6 +305,16 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
         this.producedDataType = producedDataType;
     }
 
+    public String[] getAllMonitorTables(
+            String dataBaseName, String tableNames, String tableSeparator) {
+        String[] captureTables = tableNames.split(tableSeparator);
+        String[] captureTableIds =
+                Arrays.stream(captureTables)
+                        .map(tableName -> String.format("%s.%s", dataBaseName, tableName))
+                        .toArray(String[]::new);
+        return captureTableIds;
+    }
+
     @Override
     public DynamicTableSource copy() {
         MySqlTableSource source =
@@ -308,6 +324,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                         hostname,
                         database,
                         tableName,
+                        tableSeparator,
                         username,
                         password,
                         serverTimeZone,

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
@@ -53,6 +53,7 @@ import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOption
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_SNAPSHOT_FETCH_SIZE;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.TABLE_SEPARATOR;
 import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -90,6 +91,8 @@ public class MySqlTableSourceFactoryTest {
     private static final String MY_PASSWORD = "flinkpw";
     private static final String MY_DATABASE = "myDB";
     private static final String MY_TABLE = "myTable";
+    private static final String MY_TABLE_1 = "myTable1";
+    private static final String TABLE_SEPARATOR = ",";
     private static final Properties PROPERTIES = new Properties();
 
     @Test
@@ -105,6 +108,7 @@ public class MySqlTableSourceFactoryTest {
                         MY_LOCALHOST,
                         MY_DATABASE,
                         MY_TABLE,
+                        TABLE_SEPARATOR,
                         MY_USERNAME,
                         MY_PASSWORD,
                         ZoneId.systemDefault(),
@@ -149,6 +153,7 @@ public class MySqlTableSourceFactoryTest {
                         MY_LOCALHOST,
                         MY_DATABASE,
                         MY_TABLE,
+                        TABLE_SEPARATOR,
                         MY_USERNAME,
                         MY_PASSWORD,
                         ZoneId.systemDefault(),
@@ -189,6 +194,7 @@ public class MySqlTableSourceFactoryTest {
                         MY_LOCALHOST,
                         MY_DATABASE,
                         MY_TABLE,
+                        TABLE_SEPARATOR,
                         MY_USERNAME,
                         MY_PASSWORD,
                         ZoneId.systemDefault(),
@@ -227,6 +233,7 @@ public class MySqlTableSourceFactoryTest {
                         MY_LOCALHOST,
                         MY_DATABASE,
                         MY_TABLE,
+                        TABLE_SEPARATOR,
                         MY_USERNAME,
                         MY_PASSWORD,
                         ZoneId.systemDefault(),
@@ -273,6 +280,7 @@ public class MySqlTableSourceFactoryTest {
                         MY_LOCALHOST,
                         MY_DATABASE,
                         MY_TABLE,
+                        TABLE_SEPARATOR,
                         MY_USERNAME,
                         MY_PASSWORD,
                         ZoneId.of("Asia/Shanghai"),
@@ -333,6 +341,7 @@ public class MySqlTableSourceFactoryTest {
                         MY_LOCALHOST,
                         MY_DATABASE,
                         MY_TABLE,
+                        TABLE_SEPARATOR,
                         MY_USERNAME,
                         MY_PASSWORD,
                         ZoneId.systemDefault(),
@@ -402,6 +411,7 @@ public class MySqlTableSourceFactoryTest {
                         MY_LOCALHOST,
                         MY_DATABASE,
                         MY_TABLE,
+                        TABLE_SEPARATOR,
                         MY_USERNAME,
                         MY_PASSWORD,
                         ZoneId.systemDefault(),
@@ -443,6 +453,7 @@ public class MySqlTableSourceFactoryTest {
                         MY_LOCALHOST,
                         MY_DATABASE,
                         MY_TABLE,
+                        TABLE_SEPARATOR,
                         MY_USERNAME,
                         MY_PASSWORD,
                         ZoneId.systemDefault(),


### PR DESCRIPTION
1、Currently, doesn't support separator to set multi-table-name. Howere, when the tablename is different and can't use a regex to describle, so i think maybe we can support a separator. eg: table-name=t[1-4],xx1,ab2
2、We don't care about regex and normal tablename cause a confict because tableFilter can  help to deal with repeat table
according to tableId.

