### PR TITLE
[e2e] optimization for arm64

### DIFF
--- a/flink-cdc-e2e-tests/pom.xml
+++ b/flink-cdc-e2e-tests/pom.xml
@@ -31,6 +31,7 @@ under the License.
         <flink-1.13>1.13.6</flink-1.13>
         <flink-1.14>1.14.4</flink-1.14>
         <mysql.driver.version>8.0.27</mysql.driver.version>
+        <docker-java>3.2.8</docker-java>
     </properties>
 
     <dependencies>
@@ -119,6 +120,18 @@ under the License.
             <groupId>org.testcontainers</groupId>
             <artifactId>mssqlserver</artifactId>
             <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-api</artifactId>
+            <version>${docker-java}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-transport-zerodep</artifactId>
+            <version>${docker-java}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/flink-cdc-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/utils/FlinkContainerTestEnvironment.java
+++ b/flink-cdc-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/utils/FlinkContainerTestEnvironment.java
@@ -26,6 +26,9 @@ import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.util.TestLogger;
 
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
 import com.ververica.cdc.connectors.mysql.testutils.MySqlContainer;
 import com.ververica.cdc.connectors.mysql.testutils.UniqueDatabase;
 import org.junit.After;
@@ -136,6 +139,10 @@ public abstract class FlinkContainerTestEnvironment extends TestLogger {
                         .withNetwork(NETWORK)
                         .withNetworkAliases(INTER_CONTAINER_JM_ALIAS)
                         .withExposedPorts(JOB_MANAGER_REST_PORT)
+                        .withCreateContainerCmdModifier(
+                                cmd -> cmd.getHostConfig().withPortBindings(
+                                        (new PortBinding(Ports.Binding.bindPort(8081), new ExposedPort(8081))))
+                        )
                         .withEnv("FLINK_PROPERTIES", FLINK_PROPERTIES)
                         .withLogConsumer(new Slf4jLogConsumer(LOG));
         taskManager =

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/testutils/MySqlVersion.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/testutils/MySqlVersion.java
@@ -21,6 +21,7 @@ public enum MySqlVersion {
     V5_5("5.5"),
     V5_6("5.6"),
     V5_7("5.7"),
+    // chip of arm64 is available
     V8_0("8.0");
 
     private String version;


### PR DESCRIPTION
linked #1558
1  make sure mac with apple silicon chip can run the test case.
2  define the expose port 8081:8081 in JobManager's container.So when container is running, Flink web is avaliable in http://localhost:8081
