### PR TITLE
fix(sec): upgrade protobuf-java to 3.16.1

### DIFF
--- a/flink-connector-tidb-cdc/pom.xml
+++ b/flink-connector-tidb-cdc/pom.xml
@@ -50,7 +50,7 @@ under the License.
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.12.0</version>
+            <version>3.16.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Upgrade protobuf-java 3.12.0 to  for vulnerability fix:
         - [CVE-2021-22569](https://www.oscs1024.com/hd/MPS-2021-19066)