### PR TITLE
[cdc-base] JdbcSourceConfig can be template type of DataSourceDialect

### DIFF
--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/dialect/DataSourceDialect.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/dialect/DataSourceDialect.java
@@ -18,7 +18,6 @@ package com.ververica.cdc.connectors.base.dialect;
 
 import org.apache.flink.annotation.Experimental;
 
-import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
 import com.ververica.cdc.connectors.base.config.SourceConfig;
 import com.ververica.cdc.connectors.base.source.assigner.splitter.ChunkSplitter;
 import com.ververica.cdc.connectors.base.source.meta.offset.Offset;
@@ -70,6 +69,5 @@ public interface DataSourceDialect<ID extends DataCollectionId, S, C extends Sou
     FetchTask<SourceSplitBase> createFetchTask(SourceSplitBase sourceSplitBase);
 
     /** The task context used for fetch task to fetch data from external systems. */
-    FetchTask.Context createFetchTaskContext(
-            SourceSplitBase sourceSplitBase, JdbcSourceConfig taskSourceConfig);
+    FetchTask.Context createFetchTaskContext(SourceSplitBase sourceSplitBase, C sourceConfig);
 }


### PR DESCRIPTION
`JdbcSourceConfig` can be template type of `DataSourceDialect`.