### PR TITLE
[cdc-base] Fix StreamSplit's endingOffset of StreamSplitAssigner

### DIFF
--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/assigner/StreamSplitAssigner.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/assigner/StreamSplitAssigner.java
@@ -127,7 +127,7 @@ public class StreamSplitAssigner implements SplitAssigner {
         return new StreamSplit(
                 BINLOG_SPLIT_ID,
                 dialect.displayCurrentOffset(sourceConfig),
-                offsetFactory.createInitialOffset(),
+                offsetFactory.createNoStoppingOffset(),
                 new ArrayList<>(),
                 new HashMap<>(),
                 0);


### PR DESCRIPTION
`StreamSplit`'s endingOffset should be no-stopping offset of `StreamSplitAssigner`.