### PR TITLE
[bug][tidb-connector]checkpoint is not updated long after a task has been running 

### DIFF
--- a/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/TiKVRichParallelSourceFunction.java
+++ b/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/TiKVRichParallelSourceFunction.java
@@ -206,7 +206,7 @@ public class TiKVRichParallelSourceFunction<T> extends RichParallelSourceFunctio
                 }
                 handleRow(row);
             }
-            resolvedTs = cdcClient.getMinResolvedTs();
+            resolvedTs = cdcClient.getMaxResolvedTs();
             if (commits.size() > 0) {
                 flushRows(resolvedTs);
             }


### PR DESCRIPTION
Describe the bug(Please use English)

Environment :

Flink version : 1.14
Flink CDC version: 2.3
Database and version: 5.1
To Reproduce
Steps to reproduce the behavior:

The error :
``2022-10-27 12:48:34,981 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436953707961122840, regionId: 1721083
2022-10-27 12:48:35,469 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436953708092194817, regionId: 10236245
2022-10-27 12:48:35,469 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436953708092194817, regionId: 10237829
2022-10-27 12:48:35,469 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436953708092194817, regionId: 8419115
2022-10-27 12:48:35,477 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436953708092194820, regionId: 7318373
2022-10-27 12:48:35,477 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436953708092194820, regionId: 11085331
2022-10-27 12:48:35,631 INFO com.ververica.cdc.connectors.tidb.TiKVRichParallelSourceFunction [] - snapshotState checkpoint: 9 at resolvedTs: 436952756312866827`
2022-10-27 12:58:35,594 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436953865404809241, regionId: 8684959 2022-10-27 12:58:35,594 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436953865404809241, regionId: 8309437 2022-10-27 12:58:35,594 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436953865404809241, regionId: 1721083 2022-10-27 12:58:35,594 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436953865404809241, regionId: 11090547 2022-10-27 12:58:35,635 INFO com.ververica.cdc.connectors.tidb.TiKVRichParallelSourceFunction [] - snapshotState checkpoint: 10 at resolvedTs: 436952756312866827
`

2022-10-27 13:08:35,197 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436954022586351623, regionId: 8424191 2022-10-27 13:08:35,197 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436954022586351623, regionId: 8343109 2022-10-27 13:08:35,197 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436954022586351623, regionId: 3287795 2022-10-27 13:08:35,197 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436954022586351623, regionId: 8221803 2022-10-27 13:08:35,197 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436954022586351623, regionId: 11120919 2022-10-27 13:08:35,197 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436954022586351623, regionId: 10296761 2022-10-2 7 13:08:35,197 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436954022586351623, regionId: 8309437 2022-10-27 13:08:35,197 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436954022586351623, regionId: 8684959 2022-10-27 13:08:35,197 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436954022586351623, regionId: 11090547 2022-10-27 13:08:35,197 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 436954022586351623, regionId: 1721083 2022-10-27 13:08:35,632 INFO com.ververica.cdc.connectors.tidb.TiKVRichParallelSourceFunction [] - snapshotState checkpoint: 11 at resolvedTs: 436952756312866827

Additional Description
update the resolvedTs from the max ResolvedTs