### PR TITLE
[hotfix] Add method getMaxResolvedTs back to class CDCClient.

### DIFF
--- a/flink-connector-tidb-cdc/src/main/java/org/tikv/cdc/CDCClient.java
+++ b/flink-connector-tidb-cdc/src/main/java/org/tikv/cdc/CDCClient.java
@@ -120,6 +120,10 @@ public class CDCClient implements AutoCloseable {
         return resolvedTsSet.firstEntry().getElement();
     }
 
+    public synchronized long getMaxResolvedTs() {
+        return resolvedTsSet.lastEntry().getElement();
+    }
+
     public synchronized void close() {
         removeRegions(regionClients.keySet());
     }


### PR DESCRIPTION
For this pr https://github.com/ververica/flink-cdc-connectors/pull/1686.