### PR TITLE
[hotfix] Exclude auto-generated files in docs from apache-rat-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,7 @@ under the License.
                         <exclude>docs/make.bat</exclude>
                         <exclude>docs/_templates/version.html</exclude>
                         <exclude>docs/_static/button.js</exclude>
+                        <exclude>docs/_build/**</exclude>
                         <!-- Site -->
                         <exclude>docs/site/**</exclude>
                         <!-- Tests -->


### PR DESCRIPTION
This PR excludes automatically generated folder `docs/_build` from apache-rat-plugin. If a developer builds the docs then build the project, the rat plugin will scan the folder and show error