### PR TITLE
[hotfix] Forward root cause in DebeziumSourceFunction

### DIFF
--- a/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
+++ b/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
@@ -305,7 +305,8 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
         if (handover.hasError()) {
             LOG.debug("snapshotState() called on closed source");
             throw new FlinkRuntimeException(
-                    "Call snapshotState() on closed source, checkpoint failed.", handover.getError());
+                    "Call snapshotState() on closed source, checkpoint failed.",
+                    handover.getError());
         } else {
             snapshotOffsetState(functionSnapshotContext.getCheckpointId());
             snapshotHistoryRecordsState();

--- a/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
+++ b/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
@@ -305,7 +305,7 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
         if (handover.hasError()) {
             LOG.debug("snapshotState() called on closed source");
             throw new FlinkRuntimeException(
-                    "Call snapshotState() on closed source, checkpoint failed.");
+                    "Call snapshotState() on closed source, checkpoint failed.", handover.getError());
         } else {
             snapshotOffsetState(functionSnapshotContext.getCheckpointId());
             snapshotHistoryRecordsState();

--- a/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/internal/Handover.java
+++ b/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/internal/Handover.java
@@ -24,6 +24,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -56,6 +57,7 @@ public class Handover implements Closeable {
     private List<ChangeEvent<SourceRecord, SourceRecord>> next;
 
     @GuardedBy("lock")
+    @Nullable
     private Throwable error;
 
     private boolean wakeupProducer;
@@ -159,6 +161,18 @@ public class Handover implements Closeable {
      */
     public boolean hasError() {
         return error != null;
+    }
+
+    /**
+     * Return the error, if its set.
+     *
+     * @return the error, if its set
+     */
+    @Nullable
+    public Throwable getError() {
+        synchronized (lock) {
+            return this.error;
+        }
     }
 
     /**


### PR DESCRIPTION
In our production system, I've seen exceptions about rejected snapshots, but I was not able to find the root cause (e.g. the exception in the handover). 
This change is adding the exception as the cause to the `FlinkRuntimeException` we throw in the `snapshotState` method.