### PR TITLE
[Flink][Improvement]Throw an exception when the table has no primary key set instead of catching it

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
@@ -275,9 +275,9 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
 
     @Override
     public Optional<MySqlSplit> getNext() {
-        checkSplitterErrors();
         waitTableDiscoveryReady();
         synchronized (lock) {
+            checkSplitterErrors();
             if (!remainingSplits.isEmpty()) {
                 // return remaining splits firstly
                 Iterator<MySqlSchemalessSnapshotSplit> iterator = remainingSplits.iterator();


### PR DESCRIPTION
Throw an exception when the table has no primary key set instead of catching it,In this way, the flink job will failover, and users can find the problem faster.