### PR TITLE
change test case expect

### DIFF
--- a/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/table/OracleConnectorITCase.java
+++ b/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/table/OracleConnectorITCase.java
@@ -286,7 +286,7 @@ public class OracleConnectorITCase extends AbstractTestBase {
                     "+I[12-pack drill bits, 0.800]",
                     "+I[hammer, 2.625]",
                     "+I[rocks, 5.100]",
-                    "+I[jacket, 0.600]",
+                    "+I[jacket, 1.100]",
                     "+I[spare tire, 22.200]"
                 };
 


### PR DESCRIPTION
`Dec 21 04:49:39 	at com.ververica.cdc.connectors.oracle.table.OracleConnectorITCase.testConsumingAllEventsByChunkKeyColumn(OracleConnectorITCase.java:295)
Dec 21 04:49:39 Caused by: org.junit.ComparisonFailure: expected:<+I[jacket, [0.6]00]> but was:<+I[jacket, [1.1]00]>
Dec 21 04:49:39 	at com.ververica.cdc.connectors.oracle.table.OracleConnectorITCase.testConsumingAllEventsByChunkKeyColumn(OracleConnectorITCase.java:295)
Dec 21 04:49:39 
`
Beacauese  class OracleConnectorITCase
The table products:
select * from products:
* | 108 | jacket             | water resistent black wind breaker                      |    0.1 |
* | 109 | spare tire         | 24 inch spare tire                                      |   22.2 |
* | 111 | jacket             | new water resistent white wind breaker                  |    0.5 |

and the code 447 -454 line:
`
 statement.execute(
                    "INSERT INTO debezium.products VALUES (110,'jacket','water resistent white wind breaker',0.2)"); // 110
            statement.execute(
                    "INSERT INTO debezium.products VALUES (111,'scooter','Big 2-wheel scooter ',5.18)");
            statement.execute(
                    "UPDATE debezium.products SET description='new water resistent white wind breaker', weight=0.5 WHERE id=110");
            statement.execute("UPDATE debezium.products SET weight=5.17 WHERE id=111");
            statement.execute("DELETE FROM debezium.products WHERE id=111");
`
* 110,'jacket','water resistent white wind breaker',0.5

so the SUM(WEIGHT)  with 'jacket' is 0.1 +0.5 +0.5 =1.1

