### PR TITLE
[ci] Fix for dubious repo ownership issue

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -21,6 +21,7 @@ jobs:
         apt-get update
         apt-get install -y git
         git clone "https://token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" .
+        git config --global --add safe.directory /__w/${GITHUB_REPOSITORY}/${GITHUB_REPOSITORY}
       shell: bash
  
     - name: Execute script to build our documentation and update pages


### PR DESCRIPTION
https://github.com/ververica/flink-cdc-connectors/actions/runs/3785546870/jobs/6435677503

```
+ make -C docs clean
make: Entering directory '/__w/flink-cdc-connectors/flink-cdc-connectors/docs'
make: Leaving directory '/__w/flink-cdc-connectors/flink-cdc-connectors/docs'
++ git for-each-ref '--format=%(refname:lstrip=-1)' refs/remotes/origin/
++ grep -iE '^(release-|master)'
fatal: detected dubious ownership in repository at '/__w/flink-cdc-connectors/flink-cdc-connectors'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/flink-cdc-connectors/flink-cdc-connectors
```