### PR TITLE
[mysql-cdc] Fix newly-added-table failed if job failover before a success checkpoint

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/AssignerStatus.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/AssignerStatus.java
@@ -41,7 +41,7 @@ import static java.lang.String.format;
  *     NEWLY_ADDED_ASSIGNING ---onFinish()--→ NEWLY_ADDED_ASSIGNING_SNAPSHOT_FINISHED---onBinlogSplitUpdated()---> NEWLY_ADDED_ASSIGNING_FINISHED(end)
  *              ↑                                                                                                               |
  *              |                                                                                                               |
- *              |--------------- startAssignNewlyTables() //found newly added tables,, assign newly added tables ---------------|
+ *              |--------------- startAssignNewlyTables() //found newly added tables, assign newly added tables ----------------|
  * </pre>
  */
 public enum AssignerStatus {
@@ -178,6 +178,15 @@ public enum AssignerStatus {
     public static boolean isSnapshotAssigningFinished(AssignerStatus assignerStatus) {
         return assignerStatus == INITIAL_ASSIGNING_FINISHED
                 || assignerStatus == NEWLY_ADDED_ASSIGNING_SNAPSHOT_FINISHED;
+    }
+
+    /**
+     * Returns whether the split assigner has assigned all splits, which indicates it can assign
+     * splits for newly added tables or not.
+     */
+    public static boolean isAssigningFinished(AssignerStatus assignerStatus) {
+        return assignerStatus == INITIAL_ASSIGNING_FINISHED
+                || assignerStatus == NEWLY_ADDED_ASSIGNING_FINISHED;
     }
 
     /** Returns whether the split assigner is assigning snapshot splits. */

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
@@ -56,6 +56,7 @@ import java.util.stream.Collectors;
 
 import static com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils.discoverCapturedTables;
 import static com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils.openJdbcConnection;
+import static com.ververica.cdc.connectors.mysql.source.assigners.AssignerStatus.isAssigningFinished;
 import static com.ververica.cdc.connectors.mysql.source.assigners.AssignerStatus.isAssigningSnapshotSplits;
 import static com.ververica.cdc.connectors.mysql.source.assigners.AssignerStatus.isNewlyAddedAssigningSnapshotFinished;
 import static com.ververica.cdc.connectors.mysql.source.assigners.AssignerStatus.isSnapshotAssigningFinished;
@@ -207,7 +208,7 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
                     // tables
                     LOG.info("Found newly added tables, start capture newly added tables process");
                     remainingTables.addAll(newlyAddedTables);
-                    if (isSnapshotAssigningFinished(assignerStatus)) {
+                    if (isAssigningFinished(assignerStatus)) {
                         // start the newly added tables process under binlog reading phase
                         LOG.info(
                                 "Found newly added tables, start capture newly added tables process under binlog reading phase");
@@ -410,9 +411,7 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
     @Override
     public void startAssignNewlyAddedTables() {
         Preconditions.checkState(
-                isSnapshotAssigningFinished(assignerStatus),
-                "Invalid assigner status {}",
-                assignerStatus);
+                isAssigningFinished(assignerStatus), "Invalid assigner status {}", assignerStatus);
         assignerStatus = assignerStatus.startAssignNewlyTables();
     }
 

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
@@ -106,7 +106,7 @@ public class MySqlSourceEnumerator implements SplitEnumerator<MySqlSplit, Pendin
 
     @Override
     public void addSplitsBack(List<MySqlSplit> splits, int subtaskId) {
-        LOG.debug("MySQL Source Enumerator adds splits back: {}", splits);
+        LOG.debug("The enumerator adds splits back: {}", splits);
         splitAssigner.addSplits(splits);
     }
 
@@ -123,7 +123,8 @@ public class MySqlSourceEnumerator implements SplitEnumerator<MySqlSplit, Pendin
     public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
         if (sourceEvent instanceof FinishedSnapshotSplitsReportEvent) {
             LOG.info(
-                    "The enumerator receives finished split offsets {} from subtask {}.",
+                    "The enumerator under {} receives finished split offsets {} from subtask {}.",
+                    splitAssigner.getAssignerStatus(),
                     sourceEvent,
                     subtaskId);
             FinishedSnapshotSplitsReportEvent reportEvent =
@@ -192,7 +193,7 @@ public class MySqlSourceEnumerator implements SplitEnumerator<MySqlSplit, Pendin
                 final MySqlSplit mySqlSplit = split.get();
                 context.assignSplit(mySqlSplit, nextAwaiting);
                 awaitingReader.remove();
-                LOG.info("Assign split {} to subtask {}", mySqlSplit, nextAwaiting);
+                LOG.info("The enumerator assigns split {} to subtask {}", mySqlSplit, nextAwaiting);
             } else {
                 // there is no available splits by now, skip assigning
                 requestBinlogSplitUpdateIfNeed();
@@ -227,6 +228,9 @@ public class MySqlSourceEnumerator implements SplitEnumerator<MySqlSplit, Pendin
     private void requestBinlogSplitUpdateIfNeed() {
         if (isNewlyAddedAssigningSnapshotFinished(splitAssigner.getAssignerStatus())) {
             for (int subtaskId : getRegisteredReader()) {
+                LOG.info(
+                        "The enumerator requests subtask {} to update the binlog split after newly added table.",
+                        subtaskId);
                 context.sendEventToSourceReader(subtaskId, new BinlogSplitUpdateRequestEvent());
             }
         }
@@ -239,9 +243,9 @@ public class MySqlSourceEnumerator implements SplitEnumerator<MySqlSplit, Pendin
                     splitAssigner.getFinishedSplitInfos();
             if (finishedSnapshotSplitInfos.isEmpty()) {
                 LOG.error(
-                        "The assigner offer empty finished split information, this should not happen");
+                        "The assigner offers empty finished split information, this should not happen");
                 throw new FlinkRuntimeException(
-                        "The assigner offer empty finished split information, this should not happen");
+                        "The assigner offers empty finished split information, this should not happen");
             }
             binlogSplitMeta =
                     Lists.partition(
@@ -261,7 +265,7 @@ public class MySqlSourceEnumerator implements SplitEnumerator<MySqlSplit, Pendin
             context.sendEventToSourceReader(subTask, metadataEvent);
         } else {
             LOG.error(
-                    "Received invalid request meta group id {}, the valid meta group id range is [0, {}]",
+                    "The enumerator received invalid request meta group id {}, the valid meta group id range is [0, {}]",
                     requestMetaGroupId,
                     binlogSplitMeta.size() - 1);
         }

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/NewlyAddedTableITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/NewlyAddedTableITCase.java
@@ -152,6 +152,32 @@ public class NewlyAddedTableITCase extends MySqlSourceTestBase {
     }
 
     @Test
+    public void testNewlyAddedTableForExistsPipelineThrice() throws Exception {
+        testNewlyAddedTableOneByOne(
+                DEFAULT_PARALLELISM,
+                FailoverType.NONE,
+                FailoverPhase.NEVER,
+                false,
+                "address_hangzhou",
+                "address_beijing",
+                "address_shanghai",
+                "address_shenzhen");
+    }
+
+    @Test
+    public void testNewlyAddedTableForExistsPipelineThriceWithAheadBinlog() throws Exception {
+        testNewlyAddedTableOneByOne(
+                DEFAULT_PARALLELISM,
+                FailoverType.NONE,
+                FailoverPhase.NEVER,
+                true,
+                "address_hangzhou",
+                "address_beijing",
+                "address_shanghai",
+                "address_shenzhen");
+    }
+
+    @Test
     public void testNewlyAddedTableForExistsPipelineSingleParallelism() throws Exception {
         testNewlyAddedTableOneByOne(
                 1,
@@ -494,7 +520,6 @@ public class NewlyAddedTableITCase extends MySqlSourceTestBase {
             connection.setAutoCommit(false);
             // make binlog events for the first split
             String tableId = customDatabase.getDatabaseName() + "." + tableName;
-            String cityName = tableName.split("_")[1];
             connection.execute(
                     format(
                             "UPDATE %s SET COUNTRY = 'CHINA' where id = 416874195632735147",

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -66,14 +66,12 @@ jobs:
     dependsOn: compile_${{parameters.stage_name}}
     condition: and(succeeded(), not(eq(variables['MODE'], 'e2e')))
     pool: ${{parameters.test_pool_definition}}
-    timeoutInMinutes: 70
+    timeoutInMinutes: 60
     cancelTimeoutInMinutes: 1
     workspace:
       clean: all
     strategy:
       matrix:
-        mysql:
-          module: mysql
         postgres:
           module: postgres
         oracle:
@@ -86,10 +84,66 @@ jobs:
           module: tidb
         db2:
           module: db2
-        e2e:
-          module: e2e
         misc:
           module: misc
+    steps:
+      # download artifact from compile stage
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          path: $(FLINK_ARTIFACT_DIR)
+          artifact: FlinkCompileArtifact-${{parameters.stage_name}}
+
+      - script: ./tools/azure-pipelines/unpack_build_artifact.sh
+        displayName: "Unpack Build artifact"
+
+      - task: Cache@2
+        inputs:
+          key: $(CACHE_KEY)
+          restoreKeys: $(CACHE_FALLBACK_KEY)
+          path: $(MAVEN_CACHE_FOLDER)
+        continueOnError: true # continue the build even if the cache fails.
+        condition: not(eq('${{parameters.test_pool_definition.name}}', 'Default'))
+        displayName: Cache Maven local repo
+
+      - script: |
+          echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_${{parameters.jdk}}_X64"
+          echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_${{parameters.jdk}}_X64/bin:$PATH"
+        displayName: "Set JDK"
+
+      - script: sudo sysctl -w kernel.core_pattern=core.%p
+        displayName: Set coredump pattern
+
+      # Test
+      - script: ./tools/azure-pipelines/uploading_watchdog.sh ./tools/ci/test_controller.sh $(module)
+        displayName: Test - $(module)
+
+      - task: PublishTestResults@2
+        condition: succeededOrFailed()
+        inputs:
+          testResultsFormat: 'JUnit'
+
+      # upload debug artifacts
+      - task: PublishPipelineArtifact@1
+        condition: not(eq('$(DEBUG_FILES_OUTPUT_DIR)', ''))
+        displayName: Upload Logs
+        inputs:
+          targetPath: $(DEBUG_FILES_OUTPUT_DIR)
+          artifact: logs-${{parameters.stage_name}}-$(DEBUG_FILES_NAME)
+
+  - job: test_${{parameters.stage_name}}
+    dependsOn: compile_${{parameters.stage_name}}
+    condition: and(succeeded(), not(eq(variables['MODE'], 'e2e')))
+    pool: ${{parameters.test_pool_definition}}
+    timeoutInMinutes: 90
+    cancelTimeoutInMinutes: 1
+    workspace:
+      clean: all
+    strategy:
+      matrix:
+        mysql:
+          module: mysql
+        e2e:
+          module: e2e
     steps:
       # download artifact from compile stage
       - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
   When the newly added table finishes (Assigner status is NEWLY_ADDED_ASSIGNING_FINISHED) and then job failsover before a success checkpoint, the snapshotSplits of newly added table will be added back, and are assigned to taskmanager later. However, taskmanager will first start MySqlBinlogSplit read task after failover, the the later assigned snapshotSplits will never be processed if the job parallelism is 1.  Also the binlog of newly added table will never be processed, as shown in the log below。

```
2023-01-31 23:40:45.283 [blc-9.134.34.15:3306] MySqlStreamingChangeEventSource.java:1222 ERROR io.debezium.connector.mysql.MySqlStreamingChangeEventSource - Error during binlog processing. Last offset stored = null, binlog reader near position = mysql-bin.000101/143162238
2023-01-31 23:40:45.283 [blc-9.134.34.15:3306] MySqlErrorHandler.java:67 WARN  com.ververica.cdc.connectors.mysql.debezium.task.context.MySqlErrorHandler - Schema for table cdc_basic_source.10_random_source_4 is null
2023-01-31 23:40:45.283 [blc-9.134.34.15:3306] MySqlStreamingChangeEventSource.java:429 INFO  io.debezium.connector.mysql.MySqlStreamingChangeEventSource - Error processing binlog event, and propagating to Kafka Connect so it stops this connector. Future binlog events read before connector is shutdown will be ignored.
```

So we should suspend binlogReader and read the snapshotSplits first.