### PR TITLE
[mongodb][hotfix] Fix authentication error when using a non admin auth source and duplicated usernames

### DIFF
--- a/flink-connector-mongodb-cdc/pom.xml
+++ b/flink-connector-mongodb-cdc/pom.xml
@@ -67,7 +67,7 @@ under the License.
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
-            <version>4.3.1</version>
+            <version>4.3.4</version>
         </dependency>
 
         <!-- test dependencies on Flink -->


### PR DESCRIPTION
Fix authentication error when using a non admin auth source and duplicated usernames.
#1934 