### PR TITLE
[mongodb][hotfix] Fix resume token not found problem #1879

### DIFF
--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/dialect/MongoDBDialect.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/dialect/MongoDBDialect.java
@@ -120,8 +120,13 @@ public class MongoDBDialect implements DataSourceDialect<MongoDBSourceConfig> {
     @Override
     public ChangeStreamOffset displayCurrentOffset(MongoDBSourceConfig sourceConfig) {
         MongoClient mongoClient = clientFor(sourceConfig);
-        BsonDocument startupResumeToken =
-                getLatestResumeToken(mongoClient, ChangeStreamDescriptor.deployment());
+        CollectionDiscoveryInfo discoveryInfo = discoverAndCacheDataCollections(sourceConfig);
+        ChangeStreamDescriptor changeStreamDescriptor =
+                getChangeStreamDescriptor(
+                        sourceConfig,
+                        discoveryInfo.getDiscoveredDatabases(),
+                        discoveryInfo.getDiscoveredCollections());
+        BsonDocument startupResumeToken = getLatestResumeToken(mongoClient, changeStreamDescriptor);
 
         ChangeStreamOffset changeStreamOffset;
         if (startupResumeToken != null) {


### PR DESCRIPTION
Use unmatch resume token may cause resume token not found problem under MongoDB 4.4.x.
May fix #1879.