### PR TITLE
[Doc][MongoDB CDC] Add 'chunk-meta.group.size' option in the documentation for MongoDB CDC

### DIFF
--- a/docs/content/connectors/mongodb-cdc.md
+++ b/docs/content/connectors/mongodb-cdc.md
@@ -254,6 +254,13 @@ Connector Options
       <td>Integer</td>
       <td>The chunk size mb of incremental snapshot.</td>
     </tr>
+    <tr>
+      <td>chunk-meta.group.size</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">100</td>
+      <td>Integer</td>
+      <td>The group size of chunk meta, if the meta size exceeds the group size, the meta will be divided into multiple groups.</td>
+    </tr>
     </tbody>
 </table>
 </div>


### PR DESCRIPTION
[MongoDB CDC][Doc] Add chunk-meta.group.size option in the documentation for MongoDB CDC

Fix #1986 

`chunk-meta.group.size` option exists in the source code of branch 2.3 and master, but it is not documented. Therefore, this PR adds the description of this option.

Source code：

```java
    @Override
    public Set<ConfigOption<?>> optionalOptions() {
        Set<ConfigOption<?>> options = new HashSet<>();
        options.add(USERNAME);
        options.add(PASSWORD);
        options.add(CONNECTION_OPTIONS);
        options.add(DATABASE);
        options.add(COLLECTION);
        options.add(COPY_EXISTING);
        options.add(COPY_EXISTING_QUEUE_SIZE);
        options.add(BATCH_SIZE);
        options.add(POLL_MAX_BATCH_SIZE);
        options.add(POLL_AWAIT_TIME_MILLIS);
        options.add(HEARTBEAT_INTERVAL_MILLIS);
        options.add(SCAN_INCREMENTAL_SNAPSHOT_ENABLED);
        options.add(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB);
       // This option is not documented.
        options.add(CHUNK_META_GROUP_SIZE);
        return options;
    }

    public static final ConfigOption<Integer> CHUNK_META_GROUP_SIZE =
            ConfigOptions.key("chunk-meta.group.size")
                    .intType()
                    .defaultValue(1000)
                    .withDescription(
                            "The group size of chunk meta, if the meta size exceeds the group size, the meta will be divided into multiple groups.");
```