### PR TITLE
Optimized slow oracle real-time synchronization

### DIFF
--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OracleDialect.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OracleDialect.java
@@ -105,8 +105,7 @@ public class OracleDialect implements JdbcDataSourceDialect {
     public List<TableId> discoverDataCollections(JdbcSourceConfig sourceConfig) {
         OracleSourceConfig oracleSourceConfig = (OracleSourceConfig) sourceConfig;
         try (JdbcConnection jdbcConnection = openJdbcConnection(sourceConfig)) {
-            return OracleConnectionUtils.listTables(
-                    jdbcConnection, oracleSourceConfig.getTableFilters());
+            return OracleConnectionUtils.listTables(jdbcConnection, oracleSourceConfig);
         } catch (SQLException e) {
             throw new FlinkRuntimeException("Error to discover tables: " + e.getMessage(), e);
         }


### PR DESCRIPTION
#https://github.com/ververica/flink-cdc-connectors/issues/1999
To solve the problem of slow real-time oracle synchronization, add a table name as a query condition, improving query efficiency and reducing memory usage