### PR TITLE
[oracle-cdc]Optimized slow oracle real-time synchronization

### DIFF
--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OracleDialect.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OracleDialect.java
@@ -105,8 +105,7 @@ public class OracleDialect implements JdbcDataSourceDialect {
     public List<TableId> discoverDataCollections(JdbcSourceConfig sourceConfig) {
         OracleSourceConfig oracleSourceConfig = (OracleSourceConfig) sourceConfig;
         try (JdbcConnection jdbcConnection = openJdbcConnection(sourceConfig)) {
-            return OracleConnectionUtils.listTables(
-                    jdbcConnection, oracleSourceConfig.getTableFilters());
+            return OracleConnectionUtils.listTables(jdbcConnection, oracleSourceConfig);
         } catch (SQLException e) {
             throw new FlinkRuntimeException("Error to discover tables: " + e.getMessage(), e);
         }

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
@@ -95,7 +95,8 @@ public class OracleConnectionUtils {
         if (tableList != null && !tableList.isEmpty()) {
             StringJoiner stringJoiner = new StringJoiner(",");
             for (String tableId : tableList) {
-                stringJoiner.add("'" + tableId + "'");
+
+                stringJoiner.add("'" + tableId.split("\\.")[1] + "'");
             }
             queryTablesSql
                     .append(" AND TABLE_NAME IN (")

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
@@ -92,8 +92,8 @@ public class OracleConnectionUtils {
                 new StringBuilder(
                         "SELECT OWNER ,TABLE_NAME,TABLESPACE_NAME FROM ALL_TABLES \n"
                                 + "WHERE TABLESPACE_NAME IS NOT NULL AND TABLESPACE_NAME NOT IN ('SYSTEM','SYSAUX')");
-        String schema = jdbcConnection.connection().getSchema();
         if (tableList != null && !tableList.isEmpty()) {
+            String schema = jdbcConnection.connection().getSchema();
             StringJoiner stringJoiner = new StringJoiner(",");
             for (String tableId : tableList) {
                 String tableName = tableId.replaceFirst(schema + "\\.", "");

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
@@ -92,11 +92,12 @@ public class OracleConnectionUtils {
                 new StringBuilder(
                         "SELECT OWNER ,TABLE_NAME,TABLESPACE_NAME FROM ALL_TABLES \n"
                                 + "WHERE TABLESPACE_NAME IS NOT NULL AND TABLESPACE_NAME NOT IN ('SYSTEM','SYSAUX')");
+        String schema = jdbcConnection.connection().getSchema();
         if (tableList != null && !tableList.isEmpty()) {
             StringJoiner stringJoiner = new StringJoiner(",");
             for (String tableId : tableList) {
-
-                stringJoiner.add("'" + tableId.split("\\.")[1] + "'");
+                String tableName = tableId.replaceFirst(schema + "\\.", "");
+                stringJoiner.add("'" + tableName + "'");
             }
             queryTablesSql
                     .append(" AND TABLE_NAME IN (")


### PR DESCRIPTION
#https://github.com/ververica/flink-cdc-connectors/issues/1999
To solve the problem of slow real-time oracle synchronization, add a table name as a query condition, improving query efficiency and reducing memory usage