### PR TITLE
[docs] add 'server-time-zone' config to mysql-cdc table

### DIFF
--- a/docs/content/快速上手/mysql-postgres-tutorial-zh.md
+++ b/docs/content/快速上手/mysql-postgres-tutorial-zh.md
@@ -188,7 +188,8 @@ Flink SQL> CREATE TABLE products (
     'username' = 'root',
     'password' = '123456',
     'database-name' = 'mydb',
-    'table-name' = 'products'
+    'table-name' = 'products',
+    'server-time-zone' = 'UTC'
   );
 
 Flink SQL> CREATE TABLE orders (
@@ -206,7 +207,8 @@ Flink SQL> CREATE TABLE orders (
    'username' = 'root',
    'password' = '123456',
    'database-name' = 'mydb',
-   'table-name' = 'orders'
+   'table-name' = 'orders',
+   'server-time-zone' = 'UTC'
  );
 
 Flink SQL> CREATE TABLE shipments (


### PR DESCRIPTION
specify 'server-time-zone' config to mysql-cdc table in tutorial doc.
'server-time-zone' uses ZoneId.systemDefault() as value if not set, but the session time zone of Mysql in docker is  fixed.
```

mysql> show global variables like '%time_zone%'; 
+------------------+--------+
| Variable_name    | Value  |
+------------------+--------+
| system_time_zone | UTC    |
| time_zone        | SYSTEM |
+------------------+--------+
2 rows in set (0.00 sec)

```
thus, we may meet this error in Flink if this parameter is not specified.
```

org.apache.flink.table.api.ValidationException: 
The MySQL server has a timezone offset (0 seconds ahead of UTC) which does not match the configured timezone Asia/Shanghai. Specify the right server-time-zone to avoid inconsistencies for time-related fields.

```
