### PR TITLE
feat: Add support for srv protocol

### DIFF
--- a/docs/content/connectors/mongodb-cdc.md
+++ b/docs/content/connectors/mongodb-cdc.md
@@ -147,6 +147,14 @@ Connector Options
       <td>Specify what connector to use, here should be <code>mongodb-cdc</code>.</td>
     </tr>
     <tr>
+      <td>is-srv-protocol</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Whether to use the srv protocol. Enable the srv protocol, the schema connected to the mongo server is <code>mongodb+srv://</code>, otherwise it is <code>mongodb://</code>.
+      </td>
+    </tr>
+    <tr>
       <td>hosts</td>
       <td>required</td>
       <td style="word-wrap: break-word;">(none)</td>

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/MongoDBSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/MongoDBSource.java
@@ -64,6 +64,7 @@ public class MongoDBSource {
     /** Builder class of {@link MongoDBSource}. */
     public static class Builder<T> {
 
+        private boolean isSrvProtocol;
         private String hosts;
         private String username;
         private String password;
@@ -80,6 +81,11 @@ public class MongoDBSource {
         private String copyExistingPipeline;
         private Integer heartbeatIntervalMillis = HEARTBEAT_INTERVAL_MILLIS.defaultValue();
         private DebeziumDeserializationSchema<T> deserializer;
+
+        public Builder<T> isSrvProtocol(boolean isSrvProtocol) {
+            this.isSrvProtocol = isSrvProtocol;
+            return this;
+        }
 
         /** The comma-separated list of hostname and port pairs of mongodb servers. */
         public Builder<T> hosts(String hosts) {
@@ -261,7 +267,8 @@ public class MongoDBSource {
             props.setProperty(
                     MongoSourceConfig.CONNECTION_URI_CONFIG,
                     String.valueOf(
-                            buildConnectionString(username, password, hosts, connectionOptions)));
+                            buildConnectionString(
+                                    username, password, isSrvProtocol, hosts, connectionOptions)));
 
             if (databaseList != null) {
                 props.setProperty(DATABASE_INCLUDE_LIST, String.join(",", databaseList));

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/internal/MongoDBEnvelope.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/internal/MongoDBEnvelope.java
@@ -40,6 +40,7 @@ import static com.mongodb.kafka.connect.source.schema.AvroSchemaDefaults.DEFAULT
 public class MongoDBEnvelope {
 
     public static final String MONGODB_SCHEME = "mongodb";
+    public static final String MONGODB_SRV_SCHEME = "mongodb+srv";
 
     public static final String ID_FIELD = "_id";
 

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/MongoDBSourceBuilder.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/MongoDBSourceBuilder.java
@@ -52,6 +52,12 @@ public class MongoDBSourceBuilder<T> {
     private final MongoDBSourceConfigFactory configFactory = new MongoDBSourceConfigFactory();
     private DebeziumDeserializationSchema<T> deserializer;
 
+    /** Is srv Protocol. Defaults to false. */
+    public MongoDBSourceBuilder<T> isSrvProtocol(boolean isSrvProtocol) {
+        this.configFactory.isSrvProtocol(isSrvProtocol);
+        return this;
+    }
+
     /** The comma-separated list of hostname and port pairs of mongodb servers. */
     public MongoDBSourceBuilder<T> hosts(String hosts) {
         this.configFactory.hosts(hosts);

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfig.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfig.java
@@ -33,6 +33,7 @@ public class MongoDBSourceConfig implements SourceConfig {
 
     private static final long serialVersionUID = 1L;
 
+    private final boolean isSrvProtocol;
     private final String hosts;
     @Nullable private final String username;
     @Nullable private final String password;
@@ -49,6 +50,7 @@ public class MongoDBSourceConfig implements SourceConfig {
     private final int splitSizeMB;
 
     MongoDBSourceConfig(
+            boolean isSrvProtocol,
             String hosts,
             @Nullable String username,
             @Nullable String password,
@@ -63,13 +65,14 @@ public class MongoDBSourceConfig implements SourceConfig {
             int heartbeatIntervalMillis,
             int splitMetaGroupSize,
             int splitSizeMB) {
+        this.isSrvProtocol = isSrvProtocol;
         this.hosts = checkNotNull(hosts);
         this.username = username;
         this.password = password;
         this.databaseList = databaseList;
         this.collectionList = collectionList;
         this.connectionString =
-                buildConnectionString(username, password, hosts, connectionOptions)
+                buildConnectionString(username, password, isSrvProtocol, hosts, connectionOptions)
                         .getConnectionString();
         this.batchSize = batchSize;
         this.pollAwaitTimeMillis = pollAwaitTimeMillis;
@@ -166,6 +169,7 @@ public class MongoDBSourceConfig implements SourceConfig {
                 && heartbeatIntervalMillis == that.heartbeatIntervalMillis
                 && splitMetaGroupSize == that.splitMetaGroupSize
                 && splitSizeMB == that.splitSizeMB
+                && isSrvProtocol == that.isSrvProtocol
                 && Objects.equals(hosts, that.hosts)
                 && Objects.equals(username, that.username)
                 && Objects.equals(password, that.password)
@@ -177,6 +181,7 @@ public class MongoDBSourceConfig implements SourceConfig {
     @Override
     public int hashCode() {
         return Objects.hash(
+                isSrvProtocol,
                 hosts,
                 username,
                 password,

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfigFactory.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfigFactory.java
@@ -39,6 +39,7 @@ public class MongoDBSourceConfigFactory implements Factory<MongoDBSourceConfig> 
 
     private static final long serialVersionUID = 1L;
 
+    private boolean isSrvProtocol;
     private String hosts;
     private String username;
     private String password;
@@ -53,6 +54,12 @@ public class MongoDBSourceConfigFactory implements Factory<MongoDBSourceConfig> 
     private Integer heartbeatIntervalMillis = HEARTBEAT_INTERVAL_MILLIS.defaultValue();
     private Integer splitMetaGroupSize = CHUNK_META_GROUP_SIZE.defaultValue();
     private Integer splitSizeMB = SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB.defaultValue();
+
+    /** Is srv Protocol. Defaults to false. */
+    public MongoDBSourceConfigFactory isSrvProtocol(boolean isSrvProtocol) {
+        this.isSrvProtocol = isSrvProtocol;
+        return this;
+    }
 
     /** The comma-separated list of hostname and port pairs of mongodb servers. */
     public MongoDBSourceConfigFactory hosts(String hosts) {
@@ -196,6 +203,7 @@ public class MongoDBSourceConfigFactory implements Factory<MongoDBSourceConfig> 
     @Override
     public MongoDBSourceConfig create(int subtaskId) {
         return new MongoDBSourceConfig(
+                isSrvProtocol,
                 hosts,
                 username,
                 password,

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceOptions.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceOptions.java
@@ -23,6 +23,12 @@ import org.apache.flink.configuration.ConfigOptions;
 /** Configurations for {@link com.ververica.cdc.connectors.mongodb.source.MongoDBSource}. */
 public class MongoDBSourceOptions {
 
+    public static final ConfigOption<Boolean> IS_SRV_PROTOCOL =
+            ConfigOptions.key("is-srv-protocol")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Is srv Protocol. Defaults to false.");
+
     public static final ConfigOption<String> HOSTS =
             ConfigOptions.key("hosts")
                     .stringType()

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/utils/MongoUtils.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/utils/MongoUtils.java
@@ -57,6 +57,7 @@ import static com.ververica.cdc.connectors.mongodb.internal.MongoDBEnvelope.DROP
 import static com.ververica.cdc.connectors.mongodb.internal.MongoDBEnvelope.ID_FIELD;
 import static com.ververica.cdc.connectors.mongodb.internal.MongoDBEnvelope.KEY_FIELD;
 import static com.ververica.cdc.connectors.mongodb.internal.MongoDBEnvelope.MONGODB_SCHEME;
+import static com.ververica.cdc.connectors.mongodb.internal.MongoDBEnvelope.MONGODB_SRV_SCHEME;
 import static com.ververica.cdc.connectors.mongodb.internal.MongoDBEnvelope.NAMESPACE_FIELD;
 import static com.ververica.cdc.connectors.mongodb.internal.MongoDBEnvelope.UUID_FIELD;
 import static com.ververica.cdc.connectors.mongodb.internal.MongoDBEnvelope.encodeValue;
@@ -348,9 +349,11 @@ public class MongoUtils {
     public static ConnectionString buildConnectionString(
             @Nullable String username,
             @Nullable String password,
+            boolean isSrvProtocol,
             String hosts,
             @Nullable String connectionOptions) {
-        StringBuilder sb = new StringBuilder(MONGODB_SCHEME).append("://");
+        String schema = isSrvProtocol ? MONGODB_SRV_SCHEME : MONGODB_SCHEME;
+        StringBuilder sb = new StringBuilder(schema).append("://");
 
         if (StringUtils.isNotEmpty(username) && StringUtils.isNotEmpty(password)) {
             sb.append(encodeValue(username)).append(":").append(encodeValue(password)).append("@");

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
@@ -62,6 +62,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
     private static final Logger LOG = LoggerFactory.getLogger(MongoDBTableSource.class);
 
     private final ResolvedSchema physicalSchema;
+    private final Boolean isSrvProtocol;
     private final String hosts;
     private final String connectionOptions;
     private final String username;
@@ -91,6 +92,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
 
     public MongoDBTableSource(
             ResolvedSchema physicalSchema,
+            Boolean isSrvProtocol,
             String hosts,
             @Nullable String username,
             @Nullable String password,
@@ -108,6 +110,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
             @Nullable Integer splitMetaGroupSize,
             @Nullable Integer splitSizeMB) {
         this.physicalSchema = physicalSchema;
+        this.isSrvProtocol = isSrvProtocol;
         this.hosts = checkNotNull(hosts);
         this.username = username;
         this.password = password;
@@ -172,7 +175,10 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
 
         if (enableParallelRead) {
             MongoDBSourceBuilder<RowData> builder =
-                    MongoDBSource.<RowData>builder().hosts(hosts).deserializer(deserializer);
+                    MongoDBSource.<RowData>builder()
+                            .isSrvProtocol(isSrvProtocol)
+                            .hosts(hosts)
+                            .deserializer(deserializer);
 
             Optional.ofNullable(databaseList).ifPresent(builder::databaseList);
             Optional.ofNullable(collectionList).ifPresent(builder::collectionList);
@@ -192,6 +198,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
         } else {
             com.ververica.cdc.connectors.mongodb.MongoDBSource.Builder<RowData> builder =
                     com.ververica.cdc.connectors.mongodb.MongoDBSource.<RowData>builder()
+                            .isSrvProtocol(isSrvProtocol)
                             .hosts(hosts)
                             .deserializer(deserializer);
 
@@ -248,6 +255,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
         MongoDBTableSource source =
                 new MongoDBTableSource(
                         physicalSchema,
+                        isSrvProtocol,
                         hosts,
                         username,
                         password,

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
@@ -38,6 +38,7 @@ import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOp
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.DATABASE;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.HEARTBEAT_INTERVAL_MILLIS;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.HOSTS;
+import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.IS_SRV_PROTOCOL;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.PASSWORD;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_AWAIT_TIME_MILLIS;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_MAX_BATCH_SIZE;
@@ -62,6 +63,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
 
         final ReadableConfig config = helper.getOptions();
 
+        Boolean isSrvProtocol = config.get(IS_SRV_PROTOCOL);
         String hosts = config.get(HOSTS);
         String connectionOptions = config.getOptional(CONNECTION_OPTIONS).orElse(null);
 
@@ -98,6 +100,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
 
         return new MongoDBTableSource(
                 physicalSchema,
+                isSrvProtocol,
                 hosts,
                 username,
                 password,
@@ -137,6 +140,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(IS_SRV_PROTOCOL);
         options.add(USERNAME);
         options.add(PASSWORD);
         options.add(CONNECTION_OPTIONS);

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBSourceTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBSourceTest.java
@@ -352,28 +352,30 @@ public class LegacyMongoDBSourceTest extends LegacyMongoDBTestBase {
 
     @Test
     public void testConnectionUri() {
-        String hosts = MONGODB_CONTAINER.getHostAndPort();
+        String hostAndPort = MONGODB_CONTAINER.getHostAndPort();
 
-        ConnectionString case0 = buildConnectionString(null, null, false, hosts, null);
-        assertEquals(String.format("mongodb://%s", hosts), case0.toString());
+        ConnectionString case0 = buildConnectionString(null, null, false, hostAndPort, null);
+        assertEquals(String.format("mongodb://%s", hostAndPort), case0.toString());
 
-        ConnectionString case1 = buildConnectionString("", null, false, hosts, null);
-        assertEquals(String.format("mongodb://%s", hosts), case1.toString());
+        ConnectionString case1 = buildConnectionString("", null, false, hostAndPort, null);
+        assertEquals(String.format("mongodb://%s", hostAndPort), case1.toString());
 
-        ConnectionString case2 = buildConnectionString(null, "", false, hosts, null);
-        assertEquals(String.format("mongodb://%s", hosts), case2.toString());
+        ConnectionString case2 = buildConnectionString(null, "", false, hostAndPort, null);
+        assertEquals(String.format("mongodb://%s", hostAndPort), case2.toString());
 
-        ConnectionString case3 = buildConnectionString(null, null, true, hosts, null);
-        assertEquals(String.format("mongodb+srv://%s", hosts), case3.toString());
+        String host = MONGODB_CONTAINER.getHost();
 
-        ConnectionString case4 = buildConnectionString("", null, true, hosts, null);
-        assertEquals(String.format("mongodb+srv://%s", hosts), case4.toString());
+        ConnectionString case3 = buildConnectionString(null, null, true, host, null);
+        assertEquals(String.format("mongodb+srv://%s", host), case3.toString());
 
-        ConnectionString case5 = buildConnectionString(null, "", true, hosts, null);
-        assertEquals(String.format("mongodb+srv://%s", hosts), case5.toString());
+        ConnectionString case4 = buildConnectionString("", null, true, host, null);
+        assertEquals(String.format("mongodb+srv://%s", host), case4.toString());
+
+        ConnectionString case5 = buildConnectionString(null, "", true, host, null);
+        assertEquals(String.format("mongodb+srv://%s", host), case5.toString());
 
         ConnectionString case6 =
-                buildConnectionString(FLINK_USER, FLINK_USER_PASSWORD, false, hosts, null);
+                buildConnectionString(FLINK_USER, FLINK_USER_PASSWORD, false, hostAndPort, null);
         assertEquals(FLINK_USER, case6.getUsername());
         assertEquals(FLINK_USER_PASSWORD, new String(case6.getPassword()));
     }

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBSourceTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBSourceTest.java
@@ -354,19 +354,28 @@ public class LegacyMongoDBSourceTest extends LegacyMongoDBTestBase {
     public void testConnectionUri() {
         String hosts = MONGODB_CONTAINER.getHostAndPort();
 
-        ConnectionString case0 = buildConnectionString(null, null, hosts, null);
+        ConnectionString case0 = buildConnectionString(null, null, false, hosts, null);
         assertEquals(String.format("mongodb://%s", hosts), case0.toString());
 
-        ConnectionString case1 = buildConnectionString("", null, hosts, null);
+        ConnectionString case1 = buildConnectionString("", null, false, hosts, null);
         assertEquals(String.format("mongodb://%s", hosts), case1.toString());
 
-        ConnectionString case2 = buildConnectionString(null, "", hosts, null);
+        ConnectionString case2 = buildConnectionString(null, "", false, hosts, null);
         assertEquals(String.format("mongodb://%s", hosts), case2.toString());
 
-        ConnectionString case3 =
-                buildConnectionString(FLINK_USER, FLINK_USER_PASSWORD, hosts, null);
-        assertEquals(FLINK_USER, case3.getUsername());
-        assertEquals(FLINK_USER_PASSWORD, new String(case3.getPassword()));
+        ConnectionString case3 = buildConnectionString(null, null, true, hosts, null);
+        assertEquals(String.format("mongodb+srv://%s", hosts), case3.toString());
+
+        ConnectionString case4 = buildConnectionString("", null, true, hosts, null);
+        assertEquals(String.format("mongodb+srv://%s", hosts), case4.toString());
+
+        ConnectionString case5 = buildConnectionString(null, "", true, hosts, null);
+        assertEquals(String.format("mongodb+srv://%s", hosts), case5.toString());
+
+        ConnectionString case6 =
+                buildConnectionString(FLINK_USER, FLINK_USER_PASSWORD, false, hosts, null);
+        assertEquals(FLINK_USER, case6.getUsername());
+        assertEquals(FLINK_USER_PASSWORD, new String(case6.getPassword()));
     }
 
     // ------------------------------------------------------------------------------------------

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
@@ -83,7 +83,7 @@ public class MongoDBTableFactoryTest {
                                     "_database_name", DataTypes.STRING(), "database_name", true)),
                     Collections.emptyList(),
                     UniqueConstraint.primaryKey("pk", Collections.singletonList("_id")));
-
+    private static final Boolean IS_SRV_PROTOCOL = false;
     private static final String MY_HOSTS = "localhost:27017,localhost:27018";
     private static final String USER = "flinkuser";
     private static final String PASSWORD = "flinkpw";
@@ -111,6 +111,7 @@ public class MongoDBTableFactoryTest {
         MongoDBTableSource expectedSource =
                 new MongoDBTableSource(
                         SCHEMA,
+                        IS_SRV_PROTOCOL,
                         MY_HOSTS,
                         USER,
                         PASSWORD,
@@ -148,6 +149,7 @@ public class MongoDBTableFactoryTest {
         MongoDBTableSource expectedSource =
                 new MongoDBTableSource(
                         SCHEMA,
+                        false,
                         MY_HOSTS,
                         USER,
                         PASSWORD,
@@ -182,6 +184,7 @@ public class MongoDBTableFactoryTest {
         MongoDBTableSource expectedSource =
                 new MongoDBTableSource(
                         ResolvedSchemaUtils.getPhysicalSchema(SCHEMA_WITH_METADATA),
+                        false,
                         MY_HOSTS,
                         USER,
                         PASSWORD,


### PR DESCRIPTION
Add support for the srv protocol. Some cloud vendors only support addresses of the srv protocol, such as the Atlas version of mongo on AWS.