### PR TITLE
fix(db2-doc): for db2 , char should be CHARACTER

### DIFF
--- a/docs/content/connectors/db2-cdc.md
+++ b/docs/content/connectors/db2-cdc.md
@@ -314,7 +314,7 @@ Data Type Mapping
     </tr>
     <tr>
       <td>
-        CHAR(n)
+        CHARACTER(n)
       </td>
       <td>CHAR(n)</td>
       <td></td>


### PR DESCRIPTION
db2 cdc doc modify , char type should be character type . linked below

https://www.ibm.com/docs/en/db2-for-zos/12?topic=columns-string-data-types