### PR TITLE
[mysql] Fix issue #1944: Initialize complete GTIDs to ensure subsequent recovery from checkpoint

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/GtidSet.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/GtidSet.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright 2015 Stanley Shyiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.shyiko.mysql.binlog;
+
+import java.util.*;
+
+/**
+ * Copied from https://github.com/osheroff/mysql-binlog-connector-java project to fix
+ * https://github.com/ververica/flink-cdc-connectors/issues/1944
+ *
+ * <p>Line 106 ~ 120: A new method called "overwriteThenAdd" has been added to address the incomplete Gtid storage
+ * issue in MySQL-CDC when storing checkpoints. In the MySQL-CDC scenario, consuming from a certain GTID should be
+ * ordered, and GTIDs before this should not be consumed again. Therefore, it is assumed that when recording a
+ * checkpoint, the historical offset should also be recorded as processed.
+ */
+public class GtidSet {
+
+    private final Map<String, UUIDSet> map = new LinkedHashMap<String, UUIDSet>();
+
+    /**
+     * @param gtidSet gtid set comprised of closed intervals (like MySQL's executed_gtid_set).
+     */
+    public GtidSet(String gtidSet) {
+        String[] uuidSets = (gtidSet == null || gtidSet.isEmpty()) ? new String[0] :
+                gtidSet.replace("\n", "").split(",");
+        for (String uuidSet : uuidSets) {
+            int uuidSeparatorIndex = uuidSet.indexOf(":");
+            String sourceId = uuidSet.substring(0, uuidSeparatorIndex);
+            List<Interval> intervals = new ArrayList<Interval>();
+            String[] rawIntervals = uuidSet.substring(uuidSeparatorIndex + 1).split(":");
+            for (String interval : rawIntervals) {
+                String[] is = interval.split("-");
+                long[] split = new long[is.length];
+                for (int i = 0, e = is.length; i < e; i++) {
+                    split[i] = Long.parseLong(is[i]);
+                }
+                if (split.length == 1) {
+                    split = new long[] {split[0], split[0]};
+                }
+                intervals.add(new Interval(split[0], split[1]));
+            }
+            map.put(sourceId, new UUIDSet(sourceId, intervals));
+        }
+    }
+
+    /**
+     * Get an immutable collection of the {@link UUIDSet range of GTIDs for a single server}.
+     * @return the {@link UUIDSet GTID ranges for each server}; never null
+     */
+    public Collection<UUIDSet> getUUIDSets() {
+        return Collections.unmodifiableCollection(map.values());
+    }
+
+    /**
+     * Find the {@link UUIDSet} for the server with the specified UUID.
+     * @param uuid the UUID of the server
+     * @return the {@link UUIDSet} for the identified server, or {@code null} if there are no GTIDs from that server.
+     */
+    public UUIDSet getUUIDSet(String uuid) {
+        return map.get(uuid);
+    }
+
+    /**
+     * Add or replace the UUIDSet
+     * @param uuidSet UUIDSet to be added
+     * @return the old {@link UUIDSet} for the server given in uuidSet param,
+     *         or {@code null} if there are no UUIDSet for the given server.
+     */
+    public UUIDSet putUUIDSet(UUIDSet uuidSet) {
+        return map.put(uuidSet.getUUID(), uuidSet);
+    }
+
+    /**
+     * @param gtid GTID ("source_id:transaction_id")
+     * @return whether or not gtid was added to the set (false if it was already there)
+     */
+    public boolean add(String gtid) {
+        String[] split = gtid.split(":");
+        String sourceId = split[0];
+        long transactionId = Long.parseLong(split[1]);
+        UUIDSet uuidSet = map.get(sourceId);
+        if (uuidSet == null) {
+            map.put(sourceId, uuidSet = new UUIDSet(sourceId, new ArrayList<Interval>()));
+        }
+        return uuidSet.add(transactionId);
+    }
+
+    /**
+     * Add a Gtid string to the current GtidSet. If the corresponding sourceId is being added for the first time,
+     * overwrite it; otherwise, add it.
+     * Overwrite: For example, if the current GtidSet is A:1-100, and a Gtid A:150 is added with overwrite, then the
+     * current GtidSet will become A:1-150.
+     * @param gtid GTID ("source_id:transaction_id")
+     * @return whether or not gtid was added to the set (false if it was already there)
+     */
+    public boolean overwriteThenAdd(String gtid) {
+        String[] split = gtid.split(":");
+        String sourceId = split[0];
+        long transactionId = Long.parseLong(split[1]);
+        UUIDSet uuidSet = map.get(sourceId);
+        if (uuidSet == null) {
+            map.put(sourceId, uuidSet = new UUIDSet(sourceId, new ArrayList<>()));
+        }
+        if (!uuidSet.isOverwrited) {
+            uuidSet.overwrite(transactionId);
+            return true;
+        } else {
+            return uuidSet.add(transactionId);
+        }
+    }
+
+    /**
+     * Determine if the GTIDs represented by this object are contained completely within the supplied set of GTIDs.
+     * Note that if two {@link GtidSet}s are equal, then they both are subsets of the other.
+     * @param other the other set of GTIDs; may be null
+     * @return {@code true} if all of the GTIDs in this set are equal to or completely contained within the supplied
+     * set of GTIDs, or {@code false} otherwise
+     */
+    public boolean isContainedWithin(GtidSet other) {
+        if (other == null) {
+            return false;
+        }
+        if (this == other) {
+            return true;
+        }
+        if (this.equals(other)) {
+            return true;
+        }
+        for (UUIDSet uuidSet : map.values()) {
+            UUIDSet thatSet = other.getUUIDSet(uuidSet.getUUID());
+            if (!uuidSet.isContainedWithin(thatSet)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return map.keySet().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof GtidSet) {
+            GtidSet that = (GtidSet) obj;
+            return this.map.equals(that.map);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        List<String> gtids = new ArrayList<String>();
+        for (UUIDSet uuidSet : map.values()) {
+            gtids.add(uuidSet.getUUID() + ":" + join(uuidSet.intervals, ":"));
+        }
+        return join(gtids, ",");
+    }
+
+    private static String join(Collection<?> o, String delimiter) {
+        if (o.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (Object o1 : o) {
+            sb.append(o1).append(delimiter);
+        }
+        return sb.substring(0, sb.length() - delimiter.length());
+    }
+
+    /**
+     * A range of GTIDs for a single server with a specific UUID.
+     * @see GtidSet
+     */
+    public static final class UUIDSet {
+
+        private String uuid;
+        private List<Interval> intervals;
+        private boolean isOverwrited = false;
+
+        public UUIDSet(String uuid, List<Interval> intervals) {
+            this.uuid = uuid;
+            this.intervals = intervals;
+            if (intervals.size() > 1) {
+                joinAdjacentIntervals(0);
+            }
+        }
+
+        private void overwrite(long transactionId) {
+            intervals = new ArrayList<>(Collections.singletonList(new Interval(1, transactionId)));
+            isOverwrited = true;
+        }
+
+        private boolean add(long transactionId) {
+            int index = findInterval(transactionId);
+            boolean addedToExisting = false;
+            if (index < intervals.size()) {
+                Interval interval = intervals.get(index);
+                if (interval.start == transactionId + 1) {
+                    interval.start = transactionId;
+                    addedToExisting = true;
+                } else
+                if (interval.end + 1 == transactionId) {
+                    interval.end = transactionId;
+                    addedToExisting = true;
+                } else
+                if (interval.start <= transactionId && transactionId <= interval.end) {
+                    return false;
+                }
+            }
+            if (!addedToExisting) {
+                intervals.add(index, new Interval(transactionId, transactionId));
+            }
+            if (intervals.size() > 1) {
+                joinAdjacentIntervals(index);
+            }
+            return true;
+        }
+
+        /**
+         * Collapses intervals like a-(b-1):b-c into a-c (only in index+-1 range).
+         */
+        private void joinAdjacentIntervals(int index) {
+            for (int i = Math.min(index + 1, intervals.size() - 1), e = Math.max(index - 1, 0); i > e; i--) {
+                Interval a = intervals.get(i - 1), b = intervals.get(i);
+                if (a.end + 1 == b.start) {
+                    a.end = b.end;
+                    intervals.remove(i);
+                }
+            }
+        }
+
+        /**
+         * @return index which is either a pointer to the interval containing v or a position at which v can be added
+         */
+        private int findInterval(long v) {
+            int l = 0, p = 0, r = intervals.size();
+            while (l < r) {
+                p = (l + r) / 2;
+                Interval i = intervals.get(p);
+                if (i.end < v) {
+                    l = p + 1;
+                } else
+                if (v < i.start) {
+                    r = p;
+                } else {
+                    return p;
+                }
+            }
+            if (!intervals.isEmpty() && intervals.get(p).end < v) {
+                p++;
+            }
+            return p;
+        }
+
+        /**
+         * Get the UUID for the server that generated the GTIDs.
+         * @return the server's UUID; never null
+         */
+        public String getUUID() {
+            return uuid;
+        }
+
+        /**
+         * Get the intervals of transaction numbers.
+         * @return the immutable transaction intervals; never null
+         */
+        public List<Interval> getIntervals() {
+            return Collections.unmodifiableList(intervals);
+        }
+
+        /**
+         * Determine if the set of transaction numbers from this server is completely within the set of transaction
+         * numbers from the set of transaction numbers in the supplied set.
+         * @param other the set to compare with this set
+         * @return {@code true} if this server's transaction numbers are equal to or a subset of the transaction
+         * numbers of the supplied set, or false otherwise
+         */
+        public boolean isContainedWithin(UUIDSet other) {
+            if (other == null) {
+                return false;
+            }
+            if (!this.getUUID().equalsIgnoreCase(other.getUUID())) {
+                // not even the same server ...
+                return false;
+            }
+            if (this.intervals.isEmpty()) {
+                return true;
+            }
+            if (other.intervals.isEmpty()) {
+                return false;
+            }
+            // every interval in this must be within an interval of the other ...
+            for (Interval thisInterval : this.intervals) {
+                boolean found = false;
+                for (Interval otherInterval : other.intervals) {
+                    if (thisInterval.isContainedWithin(otherInterval)) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    return false; // didn't find a match
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return uuid.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj instanceof UUIDSet) {
+                UUIDSet that = (UUIDSet) obj;
+                return this.getUUID().equalsIgnoreCase(that.getUUID()) &&
+                        this.getIntervals().equals(that.getIntervals());
+            }
+            return super.equals(obj);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            if (sb.length() != 0) {
+                sb.append(',');
+            }
+            sb.append(uuid).append(':');
+            Iterator<Interval> iter = intervals.iterator();
+            if (iter.hasNext()) {
+                sb.append(iter.next());
+            }
+            while (iter.hasNext()) {
+                sb.append(':');
+                sb.append(iter.next());
+            }
+            return sb.toString();
+        }
+    }
+
+    /**
+     * An interval of contiguous transaction identifiers.
+     * @see GtidSet
+     */
+    public static final class Interval implements Comparable<Interval> {
+
+        private long start;
+        private long end;
+
+        public Interval(long start, long end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        /**
+         * Get the starting transaction number in this interval.
+         * @return this interval's first transaction number
+         */
+        public long getStart() {
+            return start;
+        }
+
+        /**
+         * Get the ending transaction number in this interval.
+         * @return this interval's last transaction number
+         */
+        public long getEnd() {
+            return end;
+        }
+
+        /**
+         * Determine if this interval is completely within the supplied interval.
+         * @param other the interval to compare with
+         * @return {@code true} if the {@link #getStart() start} is greater than or equal to the supplied interval's
+         * {@link #getStart() start} and the {@link #getEnd() end} is less than or equal to the supplied
+         * interval's {@link #getEnd() end}, or {@code false} otherwise
+         */
+        public boolean isContainedWithin(Interval other) {
+            if (other == this) {
+                return true;
+            }
+            if (other == null) {
+                return false;
+            }
+            return this.getStart() >= other.getStart() && this.getEnd() <= other.getEnd();
+        }
+
+        @Override
+        public int hashCode() {
+            return (int) getStart();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj instanceof Interval) {
+                Interval that = (Interval) obj;
+                return this.getStart() == that.getStart() && this.getEnd() == that.getEnd();
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return start + "-" + end;
+        }
+
+        @Override
+        public int compareTo(Interval o) {
+            return saturatedCast(this.start - o.start);
+        }
+
+        private static int saturatedCast(long value) {
+            if (value > Integer.MAX_VALUE) {
+                return Integer.MAX_VALUE;
+            }
+            if (value < Integer.MIN_VALUE) {
+                return Integer.MIN_VALUE;
+            }
+            return (int) value;
+        }
+    }
+
+}

--- a/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/GtidSet.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/GtidSet.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Stanley Shyiko
+ * Copyright 2022 Ververica Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.github.shyiko.mysql.binlog;
 
 import java.util.*;

--- a/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -89,8 +89,9 @@ import static io.debezium.util.Strings.isNullOrEmpty;
  * remove this class after we bumped a higher debezium version where the
  * https://issues.redhat.com/browse/DBZ-5126 has been fixed.
  *
- * <p> Line 555, 1071 ~ 1090: To fix https://github.com/ververica/flink-cdc-connectors/issues/1944, attempt to obtain
- * the complete GTID when initializing the GtidSet (MySQL may have multiple sources).
+ * <p>Line 555, 1071 ~ 1090: To fix https://github.com/ververica/flink-cdc-connectors/issues/1944,
+ * attempt to obtain the complete GTID when initializing the GtidSet (MySQL may have multiple
+ * sources).
  */
 public class MySqlStreamingChangeEventSource
         implements StreamingChangeEventSource<MySqlOffsetContext> {
@@ -1071,19 +1072,28 @@ public class MySqlStreamingChangeEventSource
                 String purgedServerGtidSetStr = purgedServerGtidSet.toString();
                 if ("".equals(effectiveOffsetContext.getSource().binlogFilename())
                         && effectiveOffsetContext.getSource().binlogPosition() == 0) {
-                    // When starting with the "earliest", "offset-binlogfile", or "timestamp" mode, GTIDs will be null,
-                    // binlogfile will be '', and binlogpos will be 0. In this case, it is expected to consume from the
-                    // beginning. However, in reality, some binlogs may be cleaned up, so consumption should start from
+                    // When starting with the "earliest", "offset-binlogfile", or "timestamp" mode,
+                    // GTIDs will be null,
+                    // binlogfile will be '', and binlogpos will be 0. In this case, it is expected
+                    // to consume from the
+                    // beginning. However, in reality, some binlogs may be cleaned up, so
+                    // consumption should start from
                     // the position of the purged GTIDs.
                     client.setGtidSet(purgedServerGtidSetStr);
                     gtidSet = new com.github.shyiko.mysql.binlog.GtidSet(purgedServerGtidSetStr);
                 } else {
-                    // When GTID is enabled and starting from the offset-binlogfile, the client will start from the
-                    // binlogFile + binlogPos. However, at this point, it is difficult to obtain the precise GTIDs at
-                    // a low cost, so the availableServerGtid can only be used as the initial value. Then,
-                    // the overwriteThenAppend method is used for correction. This approach is effective when MySQL is
-                    // in both single-master and multi-master configurations, as it ensures that the client starts
-                    // reading the binlog from the correct position and properly handles new GTIDs afterward.
+                    // When GTID is enabled and starting from the offset-binlogfile, the client will
+                    // start from the
+                    // binlogFile + binlogPos. However, at this point, it is difficult to obtain the
+                    // precise GTIDs at
+                    // a low cost, so the availableServerGtid can only be used as the initial value.
+                    // Then,
+                    // the overwriteThenAppend method is used for correction. This approach is
+                    // effective when MySQL is
+                    // in both single-master and multi-master configurations, as it ensures that the
+                    // client starts
+                    // reading the binlog from the correct position and properly handles new GTIDs
+                    // afterward.
                     client.setBinlogFilename(effectiveOffsetContext.getSource().binlogFilename());
                     client.setBinlogPosition(effectiveOffsetContext.getSource().binlogPosition());
                     gtidSet = new com.github.shyiko.mysql.binlog.GtidSet(availableServerGtidStr);
@@ -1217,10 +1227,10 @@ public class MySqlStreamingChangeEventSource
 
                     keyManagers = kmf.getKeyManagers();
                 } catch (KeyStoreException
-                         | IOException
-                         | CertificateException
-                         | NoSuchAlgorithmException
-                         | UnrecoverableKeyException e) {
+                        | IOException
+                        | CertificateException
+                        | NoSuchAlgorithmException
+                        | UnrecoverableKeyException e) {
                     throw new DebeziumException("Could not load keystore", e);
                 }
             }
@@ -1236,23 +1246,23 @@ public class MySqlStreamingChangeEventSource
                         sc.init(
                                 finalKMS,
                                 new TrustManager[] {
-                                        new X509TrustManager() {
+                                    new X509TrustManager() {
 
-                                            @Override
-                                            public void checkClientTrusted(
-                                                    X509Certificate[] x509Certificates, String s)
-                                                    throws CertificateException {}
+                                        @Override
+                                        public void checkClientTrusted(
+                                                X509Certificate[] x509Certificates, String s)
+                                                throws CertificateException {}
 
-                                            @Override
-                                            public void checkServerTrusted(
-                                                    X509Certificate[] x509Certificates, String s)
-                                                    throws CertificateException {}
+                                        @Override
+                                        public void checkServerTrusted(
+                                                X509Certificate[] x509Certificates, String s)
+                                                throws CertificateException {}
 
-                                            @Override
-                                            public X509Certificate[] getAcceptedIssuers() {
-                                                return new X509Certificate[0];
-                                            }
+                                        @Override
+                                        public X509Certificate[] getAcceptedIssuers() {
+                                            return new X509Certificate[0];
                                         }
+                                    }
                                 },
                                 null);
                     }

--- a/flink-connector-mysql-cdc/src/test/java/com/github/shyiko/mysql/binlog/GtidSetTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/github/shyiko/mysql/binlog/GtidSetTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 public class GtidSetTest {
 
     @Test
-    public void overwriteThenAddTest() {
+    public void testOverwriteThenAdd() {
         GtidSet gtidSet =
                 new GtidSet(
                         "6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-88");
@@ -51,7 +51,7 @@ public class GtidSetTest {
     }
 
     @Test
-    public void overwriteThenAddInEmptyGtidSetTest() {
+    public void testOverwriteThenAddInEmptyGtidSet() {
         GtidSet gtidSet = new GtidSet("");
 
         gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:100");
@@ -59,7 +59,7 @@ public class GtidSetTest {
     }
 
     @Test
-    public void overwriteThenAddInBiggerInitGtidSetTest() {
+    public void testOverwriteThenAddInBiggerInitGtidSet() {
         GtidSet gtidSet =
                 new GtidSet(
                         "6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-2147483647");

--- a/flink-connector-mysql-cdc/src/test/java/com/github/shyiko/mysql/binlog/GtidSetTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/github/shyiko/mysql/binlog/GtidSetTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.github.shyiko.mysql.binlog;
 
 import org.junit.Test;

--- a/flink-connector-mysql-cdc/src/test/java/com/github/shyiko/mysql/binlog/GtidSetTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/github/shyiko/mysql/binlog/GtidSetTest.java
@@ -1,0 +1,51 @@
+package com.github.shyiko.mysql.binlog;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit test for {@link GtidSet}.
+ */
+public class GtidSetTest {
+
+    @Test
+    public void overwriteThenAddTest() {
+        GtidSet gtidSet = new GtidSet("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-88");
+
+        gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:100");
+        assertEquals("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-100", gtidSet.toString());
+
+        gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:101");
+        assertEquals("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-101", gtidSet.toString());
+
+        gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:103");
+        assertEquals("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-101:103-103", gtidSet.toString());
+
+        gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:104");
+        assertEquals("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-101:103-104", gtidSet.toString());
+    }
+
+    @Test
+    public void overwriteThenAddInEmptyGtidSetTest() {
+        GtidSet gtidSet = new GtidSet("");
+
+        gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:100");
+        assertEquals("85ebef13-1e2d-11e7-a18e-080027d89544:1-100", gtidSet.toString());
+    }
+
+    @Test
+    public void overwriteThenAddInBiggerInitGtidSetTest() {
+        GtidSet gtidSet = new GtidSet("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-2147483647");
+
+        gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:100");
+        assertEquals("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-100", gtidSet.toString());
+
+        gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:101");
+        assertEquals("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-101", gtidSet.toString());
+
+        gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:1000");
+        assertEquals("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-101:1000-1000", gtidSet.toString());
+    }
+
+}

--- a/flink-connector-mysql-cdc/src/test/java/com/github/shyiko/mysql/binlog/GtidSetTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/github/shyiko/mysql/binlog/GtidSetTest.java
@@ -20,26 +20,34 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-/**
- * Unit test for {@link GtidSet}.
- */
+/** Unit test for {@link GtidSet}. */
 public class GtidSetTest {
 
     @Test
     public void overwriteThenAddTest() {
-        GtidSet gtidSet = new GtidSet("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-88");
+        GtidSet gtidSet =
+                new GtidSet(
+                        "6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-88");
 
         gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:100");
-        assertEquals("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-100", gtidSet.toString());
+        assertEquals(
+                "6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-100",
+                gtidSet.toString());
 
         gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:101");
-        assertEquals("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-101", gtidSet.toString());
+        assertEquals(
+                "6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-101",
+                gtidSet.toString());
 
         gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:103");
-        assertEquals("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-101:103-103", gtidSet.toString());
+        assertEquals(
+                "6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-101:103-103",
+                gtidSet.toString());
 
         gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:104");
-        assertEquals("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-101:103-104", gtidSet.toString());
+        assertEquals(
+                "6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-101:103-104",
+                gtidSet.toString());
     }
 
     @Test
@@ -52,16 +60,23 @@ public class GtidSetTest {
 
     @Test
     public void overwriteThenAddInBiggerInitGtidSetTest() {
-        GtidSet gtidSet = new GtidSet("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-2147483647");
+        GtidSet gtidSet =
+                new GtidSet(
+                        "6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-2147483647");
 
         gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:100");
-        assertEquals("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-100", gtidSet.toString());
+        assertEquals(
+                "6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-100",
+                gtidSet.toString());
 
         gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:101");
-        assertEquals("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-101", gtidSet.toString());
+        assertEquals(
+                "6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-101",
+                gtidSet.toString());
 
         gtidSet.overwriteThenAdd("85ebef13-1e2d-11e7-a18e-080027d89544:1000");
-        assertEquals("6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-101:1000-1000", gtidSet.toString());
+        assertEquals(
+                "6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,85ebef13-1e2d-11e7-a18e-080027d89544:1-101:1000-1000",
+                gtidSet.toString());
     }
-
 }

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlGtidsOffsetITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlGtidsOffsetITCase.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ververica.cdc.connectors.mysql.source;
 
 import com.github.shyiko.mysql.binlog.GtidSet;

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlGtidsOffsetITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlGtidsOffsetITCase.java
@@ -88,7 +88,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doSingleGtidsInitialTest() throws Exception {
+    public void testSingleGtidsInitial() throws Exception {
         // Set parameters and expected data for test cases
         StartupOptions startupOptions = StartupOptions.initial();
         int actuallyAddDataCount = 5;
@@ -114,7 +114,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doMultipleGtidsInitialTest() throws Exception {
+    public void testMultipleGtidsInitial() throws Exception {
         // Set parameters and expected data for test cases.
         StartupOptions startupOptions = StartupOptions.initial();
         int actuallyAddDataCount = 5;
@@ -141,7 +141,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doSingleGtidsLatestTest() throws Exception {
+    public void testSingleGtidsLatest() throws Exception {
         // Set parameters and expected data for test cases
         StartupOptions startupOptions = StartupOptions.latest();
         int actuallyAddDataCount = 5;
@@ -167,7 +167,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doMultipleGtidsLatestTest() throws Exception {
+    public void testMultipleGtidsLatest() throws Exception {
         // Set parameters and expected data for test cases.
         StartupOptions startupOptions = StartupOptions.latest();
         int actuallyAddDataCount = 5;
@@ -194,7 +194,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doSingleGtidsEarliestTest() throws Exception {
+    public void testSingleGtidsEarliest() throws Exception {
         // Set parameters and expected data for test cases.
         StartupOptions startupOptions = StartupOptions.earliest();
         int actuallyAddDataCount = 5;
@@ -220,7 +220,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doMultipleGtidsEarliestTest() throws Exception {
+    public void testMultipleGtidsEarliest() throws Exception {
         // Set parameters and expected data for test cases.
         StartupOptions startupOptions = StartupOptions.earliest();
         int actuallyAddDataCount = 5;
@@ -247,7 +247,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doSingleGtidsOffsetGtidByBeginningTest() throws Exception {
+    public void testSingleGtidsOffsetGtidByBeginning() throws Exception {
         // Set parameters and expected data for test cases.
         Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
         String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
@@ -273,7 +273,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doSingleGtidsOffsetGtidByMiddleTest() throws Exception {
+    public void testSingleGtidsOffsetGtidByMiddle() throws Exception {
         // Set parameters and expected data for test cases.
         Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
         String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
@@ -299,7 +299,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doMultipleGtidsOffsetGtidByBeginningIncorrectSettingTest() throws Exception {
+    public void testMultipleGtidsOffsetGtidByBeginningIncorrectSetting() throws Exception {
         try {
             // Set parameters and expected data for test cases.
             Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
@@ -330,7 +330,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doMultipleGtidsOffsetGtidByBeginningCorrectSettingTest() throws Exception {
+    public void testMultipleGtidsOffsetGtidByBeginningCorrectSetting() throws Exception {
         // Set parameters and expected data for test cases.
         Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
         String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
@@ -358,7 +358,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doMultipleGtidsOffsetGtidByMiddleIncorrectSettingTest() {
+    public void testMultipleGtidsOffsetGtidByMiddleIncorrectSetting() {
         try {
             // Set parameters and expected data for test cases.
             Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
@@ -390,7 +390,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doMultipleGtidsOffsetGtidByMiddleCorrectSettingTest() throws Exception {
+    public void testMultipleGtidsOffsetGtidByMiddleCorrectSetting() throws Exception {
         // Set parameters and expected data for test cases.
         Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
         String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
@@ -418,7 +418,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doSingleGtidsOffsetBinlogFileByBeginningTest() throws Exception {
+    public void testSingleGtidsOffsetBinlogFileByBeginning() throws Exception {
         // Set parameters and expected data for test cases.
         Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
         String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
@@ -446,7 +446,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doSingleGtidsOffsetBinlogFileByMiddleTest() throws Exception {
+    public void testSingleGtidsOffsetBinlogFileByMiddle() throws Exception {
         // Set parameters and expected data for test cases.
         Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
         String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
@@ -475,7 +475,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doMultipleGtidsOffsetBinlogFileByBeginningTest() throws Exception {
+    public void testMultipleGtidsOffsetBinlogFileByBeginning() throws Exception {
         // Set parameters and expected data for test cases.
         Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
         String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
@@ -504,7 +504,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doMultipleGtidsOffsetBinlogFileByMiddleTest() throws Exception {
+    public void testMultipleGtidsOffsetBinlogFileByMiddle() throws Exception {
         // Set parameters and expected data for test cases.
         Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
         String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
@@ -534,7 +534,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doSingleGtidsTimestampTest() throws Exception {
+    public void testSingleGtidsTimestamp() throws Exception {
         // Set parameters and expected data for test cases.
         Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
         String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
@@ -562,7 +562,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     @Test
-    public void doMultipleGtidsTimestampTest() throws Exception {
+    public void testMultipleGtidsTimestamp() throws Exception {
         // Set parameters and expected data for test cases.
         Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
         String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlGtidsOffsetITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlGtidsOffsetITCase.java
@@ -1,0 +1,731 @@
+package com.ververica.cdc.connectors.mysql.source;
+
+import com.github.shyiko.mysql.binlog.GtidSet;
+import com.ververica.cdc.connectors.mysql.table.StartupOptions;
+import com.ververica.cdc.connectors.mysql.testutils.UniqueDatabase;
+import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import com.ververica.cdc.debezium.table.RowDataDebeziumDeserializeSchema;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.flink.util.Collector;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * IT cases for {@link MySqlSource} to test the gtids offset is correctly stored and restored.
+ */
+public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(MySqlGtidsOffsetITCase.class);
+
+    private final UniqueDatabase gtidsDatabase =
+            new UniqueDatabase(MYSQL_CONTAINER, "gtids_test", "mysqluser", "mysqlpw");
+
+    private final String tableId = gtidsDatabase.getDatabaseName() + ".products";
+
+    private final String historyPurgedGtids = "6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543," +
+            "85ebef13-1e2d-11e7-a18e-080027d89544:1-27336452";
+
+    private static boolean isDatabaseInitialized = false;
+    
+    private static final long waitFlinkBootTime = 5000;
+
+    @Before
+    public void initDatabase() throws Exception {
+        if (!isDatabaseInitialized) {
+            // Initialize the database for the first time
+            gtidsDatabase.createAndInitialize();
+            isDatabaseInitialized = true;
+        } else {
+            // For non-initial database initialization, it is necessary to reset the GTID to avoid interference from
+            // previous tests and create some events to generate new GTIDs for obtaining source IDs.
+            gtidsDatabase.createAndInitialize();
+            Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+            resetMaster(jdbcConnection);
+            addData(jdbcConnection, 1);
+            truncate(jdbcConnection);
+        }
+    }
+
+    @Test
+    public void doSingleGtidsInitialTest() throws Exception {
+        // Set parameters and expected data for test cases
+        StartupOptions startupOptions = StartupOptions.initial();
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 10;
+        String expectedTransactionId = "1-9"; //
+
+        // Predefined Gtids for the database
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        addData(jdbcConnection, 5); //
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                null,
+                expectedTransactionId
+        );
+    }
+
+    @Test
+    public void doMultipleGtidsInitialTest() throws Exception {
+        // Set parameters and expected data for test cases.
+        StartupOptions startupOptions = StartupOptions.initial();
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 10;
+        String expectedTransactionId = "1-9";
+
+        // Predefined Gtids for the database
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        setPurgedGitds(jdbcConnection, historyPurgedGtids);
+        addData(jdbcConnection, 5);
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                historyPurgedGtids,
+                expectedTransactionId
+        );
+    }
+
+    @Test
+    public void doSingleGtidsLatestTest() throws Exception {
+        // Set parameters and expected data for test cases
+        StartupOptions startupOptions = StartupOptions.latest();
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 5;
+        String expectedTransactionId = "1-9";
+
+        // Predefined Gtids for the database
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        addData(jdbcConnection, 5);
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                null,
+                expectedTransactionId
+        );
+    }
+
+    @Test
+    public void doMultipleGtidsLatestTest() throws Exception {
+        // Set parameters and expected data for test cases.
+        StartupOptions startupOptions = StartupOptions.latest();
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 5;
+        String expectedTransactionId = "1-9";
+
+        // Predefined Gtids for the database
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        setPurgedGitds(jdbcConnection, historyPurgedGtids);
+        addData(jdbcConnection, 5);
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                historyPurgedGtids,
+                expectedTransactionId
+        );
+    }
+
+    @Test
+    public void doSingleGtidsEarliestTest() throws Exception {
+        // Set parameters and expected data for test cases.
+        StartupOptions startupOptions = StartupOptions.earliest();
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 10;
+        String expectedTransactionId = "1-9";
+
+        // Predefined Gtids for the database
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        addData(jdbcConnection, 5);
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                null,
+                expectedTransactionId
+        );
+    }
+
+    @Test
+    public void doMultipleGtidsEarliestTest() throws Exception {
+        // Set parameters and expected data for test cases.
+        StartupOptions startupOptions = StartupOptions.earliest();
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 10;
+        String expectedTransactionId = "1-9";
+
+        // Predefined Gtids for the database
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        setPurgedGitds(jdbcConnection, historyPurgedGtids);
+        addData(jdbcConnection, 5);
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                historyPurgedGtids,
+                expectedTransactionId
+        );
+    }
+
+    @Test
+    public void doSingleGtidsOffsetGtidByBeginningTest() throws Exception {
+        // Set parameters and expected data for test cases.
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        StartupOptions startupOptions = StartupOptions.specificOffset(initSourceId + ":1-3");
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 7;
+        String expectedTransactionId = "1-9";
+
+        // Predefined Gtids for the database
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        addData(jdbcConnection, 5);
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                null,
+                expectedTransactionId
+        );
+    }
+
+    @Test
+    public void doSingleGtidsOffsetGtidByMiddleTest() throws Exception {
+        // Set parameters and expected data for test cases.
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        StartupOptions startupOptions = StartupOptions.specificOffset(initSourceId + ":3-4");
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 8;
+        String expectedTransactionId = "1-2:5-9";
+
+        // Predefined Gtids for the database
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        addData(jdbcConnection, 5);
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                null,
+                expectedTransactionId
+        );
+    }
+
+    @Test
+    public void doMultipleGtidsOffsetGtidByBeginningIncorrectSettingTest() throws Exception {
+        try {
+            // Set parameters and expected data for test cases.
+            Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+            String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+            StartupOptions startupOptions = StartupOptions.specificOffset(initSourceId + ":1-3");
+            int actuallyAddDataCount = 5;
+            int actuallyFetchDataCount = 7;
+            String expectedTransactionId = "1-9";
+
+            // Predefined Gtids for the database
+            resetMaster(gtidsDatabase.getJdbcConnection());
+            setPurgedGitds(jdbcConnection, historyPurgedGtids);
+            addData(jdbcConnection, 5);
+            MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+            // Run Flink CDC, insert data, and finally validate assertions
+            executeCdcAndAssert(
+                    jdbcConnection,
+                    mySqlSource,
+                    actuallyAddDataCount,
+                    actuallyFetchDataCount,
+                    initSourceId,
+                    historyPurgedGtids,
+                    expectedTransactionId
+            );
+        } catch (Exception e) {
+            assertEquals("Failed to fetch next result", e.getMessage());
+        }
+    }
+
+    @Test
+    public void doMultipleGtidsOffsetGtidByBeginningCorrectSettingTest() throws Exception {
+        // Set parameters and expected data for test cases.
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        StartupOptions startupOptions = StartupOptions.specificOffset(historyPurgedGtids + "," + initSourceId + ":1-3");
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 7;
+        String expectedTransactionId = "1-9";
+
+        // Predefined Gtids for the database
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        setPurgedGitds(jdbcConnection, historyPurgedGtids);
+        addData(jdbcConnection, 5);
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                historyPurgedGtids,
+                expectedTransactionId
+        );
+    }
+
+    @Test
+    public void doMultipleGtidsOffsetGtidByMiddleIncorrectSettingTest() {
+        try {
+            // Set parameters and expected data for test cases.
+            Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+            String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+            StartupOptions startupOptions = StartupOptions.specificOffset(initSourceId + ":3-4");
+            int actuallyAddDataCount = 5;
+            int actuallyFetchDataCount = 8;
+            String expectedTransactionId = "1-9";
+
+            // Predefined Gtids for the database
+            resetMaster(gtidsDatabase.getJdbcConnection());
+            setPurgedGitds(jdbcConnection, historyPurgedGtids);
+            addData(jdbcConnection, 5);
+            MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+            // Run Flink CDC, insert data, and finally validate assertions
+            executeCdcAndAssert(
+                    jdbcConnection,
+                    mySqlSource,
+                    actuallyAddDataCount,
+                    actuallyFetchDataCount,
+                    initSourceId,
+                    historyPurgedGtids,
+                    expectedTransactionId
+            );
+        } catch (Exception e) {
+            // The exception is expected, because the offset is not in the history gtid set
+            assertEquals("Failed to fetch next result", e.getMessage());
+        }
+    }
+
+    @Test
+    public void doMultipleGtidsOffsetGtidByMiddleCorrectSettingTest() throws Exception {
+        // Set parameters and expected data for test cases.
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        StartupOptions startupOptions = StartupOptions.specificOffset(historyPurgedGtids + "," + initSourceId + ":3-4");
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 8;
+        String expectedTransactionId = "1-2:5-9";
+
+        // Predefined Gtids for the database
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        setPurgedGitds(jdbcConnection, historyPurgedGtids);
+        addData(jdbcConnection, 5);
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                historyPurgedGtids,
+                expectedTransactionId
+        );
+    }
+
+    @Test
+    public void doSingleGtidsOffsetBinlogFileByBeginningTest() throws Exception {
+        // Set parameters and expected data for test cases.
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 10;
+        String expectedTransactionId = "1-9";
+
+        // Predefined Gtids for the database
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        Tuple2<String, Long> binlogFileAndPos = getBinlogFileAndPos(jdbcConnection);
+        StartupOptions startupOptions = StartupOptions.specificOffset(binlogFileAndPos.f0, binlogFileAndPos.f1);
+        addData(jdbcConnection, 5);
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                null,
+                expectedTransactionId
+        );
+    }
+
+    @Test
+    public void doSingleGtidsOffsetBinlogFileByMiddleTest() throws Exception {
+        // Set parameters and expected data for test cases.
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 7;
+        String expectedTransactionId = "1-9";
+
+        // Predefined Gtids for the database
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        addData(jdbcConnection, 3);
+        Tuple2<String, Long> binlogFileAndPos = getBinlogFileAndPos(jdbcConnection);
+        StartupOptions startupOptions = StartupOptions.specificOffset(binlogFileAndPos.f0, binlogFileAndPos.f1);
+        addData(jdbcConnection, 2);
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                null,
+                expectedTransactionId
+        );
+    }
+
+    @Test
+    public void doMultipleGtidsOffsetBinlogFileByBeginningTest() throws Exception {
+        // Set parameters and expected data for test cases.
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 10;
+        String expectedTransactionId = "1-9";
+
+        // Predefined Gtids for the database
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        setPurgedGitds(jdbcConnection, historyPurgedGtids);
+        Tuple2<String, Long> binlogFileAndPos = getBinlogFileAndPos(jdbcConnection);
+        StartupOptions startupOptions = StartupOptions.specificOffset(binlogFileAndPos.f0, binlogFileAndPos.f1);
+        addData(jdbcConnection, 5);
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                historyPurgedGtids,
+                expectedTransactionId
+        );
+    }
+
+    @Test
+    public void doMultipleGtidsOffsetBinlogFileByMiddleTest() throws Exception {
+        // Set parameters and expected data for test cases.
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 7;
+        String expectedTransactionId = "1-9";
+
+        // Predefined Gtids for the database
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        setPurgedGitds(jdbcConnection, historyPurgedGtids);
+        addData(jdbcConnection, 3);
+        Tuple2<String, Long> binlogFileAndPos = getBinlogFileAndPos(jdbcConnection);
+        StartupOptions startupOptions = StartupOptions.specificOffset(binlogFileAndPos.f0, binlogFileAndPos.f1);
+        addData(jdbcConnection, 2);
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                historyPurgedGtids,
+                expectedTransactionId
+        );
+    }
+
+    @Test
+    public void doSingleGtidsTimestampTest() throws Exception {
+        // Set parameters and expected data for test cases.
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 10;
+        String expectedTransactionId = "1-14";
+
+        // Predefined Gtids for the database
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        addData(jdbcConnection, 5);
+        Thread.sleep(1000);
+        StartupOptions startupOptions = StartupOptions.timestamp(System.currentTimeMillis());
+        addData(jdbcConnection, 5);
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                null,
+                expectedTransactionId
+        );
+    }
+
+    @Test
+    public void doMultipleGtidsTimestampTest() throws Exception {
+        // Set parameters and expected data for test cases.
+        Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
+        String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
+        int actuallyAddDataCount = 5;
+        int actuallyFetchDataCount = 10;
+        String expectedTransactionId = "1-14";
+
+        // Predefined Gtids for the database
+        resetMaster(gtidsDatabase.getJdbcConnection());
+        setPurgedGitds(jdbcConnection, historyPurgedGtids);
+        addData(jdbcConnection, 5);
+        Thread.sleep(1000);
+        StartupOptions startupOptions = StartupOptions.timestamp(System.currentTimeMillis());
+        addData(jdbcConnection, 5);
+        MySqlSource<String> mySqlSource = getSource(startupOptions);
+
+        // Run Flink CDC, insert data, and finally validate assertions
+        executeCdcAndAssert(
+                jdbcConnection,
+                mySqlSource,
+                actuallyAddDataCount,
+                actuallyFetchDataCount,
+                initSourceId,
+                historyPurgedGtids,
+                expectedTransactionId
+        );
+    }
+
+    private String getSourceId(String gtids) {
+        String[] split = gtids.split(":");
+        return split[0];
+    }
+
+    private void resetMaster(Connection jdbcConnection) throws Exception {
+        jdbcConnection.createStatement().execute("RESET MASTER");
+    }
+
+    private void setPurgedGitds(Connection jdbcConnection, String gtids) throws Exception {
+        jdbcConnection.createStatement().execute(String.format("SET @@GLOBAL.gtid_purged='%s'", gtids));
+    }
+
+    private String getExecutedGtids(Connection jdbcConnection) throws Exception {
+        ResultSet resultSet = jdbcConnection.createStatement().executeQuery("SHOW MASTER STATUS");
+        if (resultSet.next()) {
+            return resultSet.getString("Executed_Gtid_Set");
+        }
+        throw new Exception("Can not got ExecutedGtids");
+    }
+
+    private Tuple2<String, Long> getBinlogFileAndPos(Connection jdbcConnection) throws Exception {
+        ResultSet resultSet = jdbcConnection.createStatement().executeQuery("SHOW MASTER STATUS");
+        if (resultSet.next()) {
+            Tuple2<String, Long> BinlogFilePos = new Tuple2<>();
+            BinlogFilePos.f0 = (resultSet.getString("File"));
+            BinlogFilePos.f1 = (resultSet.getLong("Position"));
+            return BinlogFilePos;
+        }
+        throw new Exception("Can not got ExecutedGtids");
+    }
+
+    private String getPurgedGtids(Connection jdbcConnection) throws Exception {
+        ResultSet resultSet = jdbcConnection.createStatement().executeQuery("SELECT @@global.gtid_purged");
+        if (resultSet.next()) {
+            return resultSet.getString("@@global.gtid_purged");
+        }
+        throw new Exception("Can not got PurgedGtids");
+    }
+
+    private void addData(Connection jdbcConnection, int dataCnt) throws Exception {
+        for (int i = 0; i < dataCnt; i++) {
+            jdbcConnection.createStatement().execute("INSERT INTO products VALUES (default,\"scooter\",\"Small 2-wheel scooter\", 3.14);");
+        }
+    }
+
+    private void truncate(Connection jdbcConnection) throws Exception {
+        jdbcConnection.createStatement().execute("TRUNCATE TABLE products;");
+    }
+
+    private StreamExecutionEnvironment getEnv() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(DEFAULT_PARALLELISM);
+        env.enableCheckpointing(5000L);
+        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
+        return env;
+    }
+
+    private RowDataDebeziumDeserializeSchema getProductsTableDeserializer() {
+        DataType dataType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("id", DataTypes.INT()),
+                        DataTypes.FIELD("name", DataTypes.STRING()),
+                        DataTypes.FIELD("description", DataTypes.STRING()),
+                        DataTypes.FIELD("weight", DataTypes.FLOAT()));
+        InternalTypeInfo<RowData> typeInfo = InternalTypeInfo.of(TypeConversions.fromDataToLogicalType(dataType));
+        return RowDataDebeziumDeserializeSchema.newBuilder()
+                        .setPhysicalRowType((RowType) dataType.getLogicalType())
+                        .setResultTypeInfo(typeInfo)
+                        .build();
+    }
+
+    private MySqlSource<String> getSource(StartupOptions startupOptions) {
+        return MySqlSource.<String>builder()
+                        .hostname(MYSQL_CONTAINER.getHost())
+                        .port(MYSQL_CONTAINER.getDatabasePort())
+                        .databaseList(gtidsDatabase.getDatabaseName())
+                        .serverTimeZone("UTC")
+                        .tableList(tableId)
+                        .username(gtidsDatabase.getUsername())
+                        .password(gtidsDatabase.getPassword())
+                        .serverId("5401-5404")
+                        .deserializer(new GtidsDebeziumDeserializationSchema())
+                        .startupOptions(startupOptions)
+                        .build();
+    }
+
+    private static List<String> fetchRowData(Iterator<String> iter, int size) {
+        List<String> rows = new ArrayList<>(size);
+        while (size > 0 && iter.hasNext()) {
+            String row = iter.next();
+            rows.add(row);
+            size--;
+        }
+        return (rows);
+    }
+
+    private void executeCdcAndAssert(Connection jdbcConnection, MySqlSource<String> mySqlSource, int addSize, int fetchSize, String initSourceId, String historyGtids, String expectedTransactionId) throws Exception {
+        StreamExecutionEnvironment env = getEnv();
+        DataStreamSource<String> sourceStream =
+                env.fromSource(mySqlSource, WatermarkStrategy.noWatermarks(), "selfSource");
+        try (CloseableIterator<String> iterator = sourceStream.executeAndCollect()) {
+            Thread.sleep(waitFlinkBootTime);
+            addData(jdbcConnection, addSize);
+            List<String> rows = fetchRowData(iterator, fetchSize);
+            LOG.info("expectedFetchSize is {}, actualFetchSize is {}", fetchSize, rows.size());
+            assertEquals(fetchSize, rows.size());
+
+            String lastGtids = (rows.size() > 0) ? rows.get(rows.size()-1) : "";
+            GtidSet lastGtidSet = new GtidSet(lastGtids);
+            GtidSet expectedGtidSet = getExpectedGtidSet(initSourceId, historyGtids, expectedTransactionId);
+            LOG.info("expectedGtidSet is {}, lastGtidSet is {}", expectedGtidSet, lastGtidSet);
+            assertEquals(expectedGtidSet, lastGtidSet);
+        }
+    }
+
+    private GtidSet getExpectedGtidSet(String initSourceId, String historyGtids, String expectedTransactionId) {
+        String expectedGtids = "";
+        if (historyGtids != null) {
+            expectedGtids = expectedGtids + historyGtids + ",";
+        }
+        expectedGtids = expectedGtids + initSourceId + ":" + expectedTransactionId;
+        return new GtidSet(expectedGtids);
+    }
+
+    static class GtidsDebeziumDeserializationSchema implements DebeziumDeserializationSchema<String> {
+
+        private static final long serialVersionUID = 1L;
+
+        public void deserialize(SourceRecord record, Collector<String> out) {
+            String sourceGtids = (String) record.sourceOffset().get("gtids");
+            if (sourceGtids == null) {
+                sourceGtids = "";
+            }
+            LOG.info("deserialize sourceGtids is {}", sourceGtids);
+            out.collect(sourceGtids);
+        }
+
+        public TypeInformation<String> getProducedType() {
+            return BasicTypeInfo.of(String.class);
+        }
+
+    }
+}

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlGtidsOffsetITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlGtidsOffsetITCase.java
@@ -16,11 +16,6 @@
 
 package com.ververica.cdc.connectors.mysql.source;
 
-import com.github.shyiko.mysql.binlog.GtidSet;
-import com.ververica.cdc.connectors.mysql.table.StartupOptions;
-import com.ververica.cdc.connectors.mysql.testutils.UniqueDatabase;
-import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
-import com.ververica.cdc.debezium.table.RowDataDebeziumDeserializeSchema;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
@@ -36,6 +31,12 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Collector;
+
+import com.github.shyiko.mysql.binlog.GtidSet;
+import com.ververica.cdc.connectors.mysql.table.StartupOptions;
+import com.ververica.cdc.connectors.mysql.testutils.UniqueDatabase;
+import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import com.ververica.cdc.debezium.table.RowDataDebeziumDeserializeSchema;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,9 +51,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-/**
- * IT cases for {@link MySqlSource} to test the gtids offset is correctly stored and restored.
- */
+/** IT cases for {@link MySqlSource} to test the gtids offset is correctly stored and restored. */
 public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
 
     protected static final Logger LOG = LoggerFactory.getLogger(MySqlGtidsOffsetITCase.class);
@@ -62,11 +61,12 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
 
     private final String tableId = gtidsDatabase.getDatabaseName() + ".products";
 
-    private final String historyPurgedGtids = "6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543," +
-            "85ebef13-1e2d-11e7-a18e-080027d89544:1-27336452";
+    private final String historyPurgedGtids =
+            "6f7b6d88-6a12-11e9-bd82-0242ac110002:1-39816543,"
+                    + "85ebef13-1e2d-11e7-a18e-080027d89544:1-27336452";
 
     private static boolean isDatabaseInitialized = false;
-    
+
     private static final long waitFlinkBootTime = 5000;
 
     @Before
@@ -76,7 +76,8 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
             gtidsDatabase.createAndInitialize();
             isDatabaseInitialized = true;
         } else {
-            // For non-initial database initialization, it is necessary to reset the GTID to avoid interference from
+            // For non-initial database initialization, it is necessary to reset the GTID to avoid
+            // interference from
             // previous tests and create some events to generate new GTIDs for obtaining source IDs.
             gtidsDatabase.createAndInitialize();
             Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
@@ -109,8 +110,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 null,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     @Test
@@ -137,8 +137,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 historyPurgedGtids,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     @Test
@@ -164,8 +163,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 null,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     @Test
@@ -192,8 +190,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 historyPurgedGtids,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     @Test
@@ -219,8 +216,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 null,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     @Test
@@ -247,8 +243,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 historyPurgedGtids,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     @Test
@@ -274,8 +269,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 null,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     @Test
@@ -301,8 +295,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 null,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     @Test
@@ -330,8 +323,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                     actuallyFetchDataCount,
                     initSourceId,
                     historyPurgedGtids,
-                    expectedTransactionId
-            );
+                    expectedTransactionId);
         } catch (Exception e) {
             assertEquals("Failed to fetch next result", e.getMessage());
         }
@@ -342,7 +334,8 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
         // Set parameters and expected data for test cases.
         Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
         String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
-        StartupOptions startupOptions = StartupOptions.specificOffset(historyPurgedGtids + "," + initSourceId + ":1-3");
+        StartupOptions startupOptions =
+                StartupOptions.specificOffset(historyPurgedGtids + "," + initSourceId + ":1-3");
         int actuallyAddDataCount = 5;
         int actuallyFetchDataCount = 7;
         String expectedTransactionId = "1-9";
@@ -361,8 +354,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 historyPurgedGtids,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     @Test
@@ -390,8 +382,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                     actuallyFetchDataCount,
                     initSourceId,
                     historyPurgedGtids,
-                    expectedTransactionId
-            );
+                    expectedTransactionId);
         } catch (Exception e) {
             // The exception is expected, because the offset is not in the history gtid set
             assertEquals("Failed to fetch next result", e.getMessage());
@@ -403,7 +394,8 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
         // Set parameters and expected data for test cases.
         Connection jdbcConnection = gtidsDatabase.getJdbcConnection();
         String initSourceId = getSourceId(getExecutedGtids(jdbcConnection));
-        StartupOptions startupOptions = StartupOptions.specificOffset(historyPurgedGtids + "," + initSourceId + ":3-4");
+        StartupOptions startupOptions =
+                StartupOptions.specificOffset(historyPurgedGtids + "," + initSourceId + ":3-4");
         int actuallyAddDataCount = 5;
         int actuallyFetchDataCount = 8;
         String expectedTransactionId = "1-2:5-9";
@@ -422,8 +414,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 historyPurgedGtids,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     @Test
@@ -438,7 +429,8 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
         // Predefined Gtids for the database
         resetMaster(gtidsDatabase.getJdbcConnection());
         Tuple2<String, Long> binlogFileAndPos = getBinlogFileAndPos(jdbcConnection);
-        StartupOptions startupOptions = StartupOptions.specificOffset(binlogFileAndPos.f0, binlogFileAndPos.f1);
+        StartupOptions startupOptions =
+                StartupOptions.specificOffset(binlogFileAndPos.f0, binlogFileAndPos.f1);
         addData(jdbcConnection, 5);
         MySqlSource<String> mySqlSource = getSource(startupOptions);
 
@@ -450,8 +442,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 null,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     @Test
@@ -467,7 +458,8 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
         resetMaster(gtidsDatabase.getJdbcConnection());
         addData(jdbcConnection, 3);
         Tuple2<String, Long> binlogFileAndPos = getBinlogFileAndPos(jdbcConnection);
-        StartupOptions startupOptions = StartupOptions.specificOffset(binlogFileAndPos.f0, binlogFileAndPos.f1);
+        StartupOptions startupOptions =
+                StartupOptions.specificOffset(binlogFileAndPos.f0, binlogFileAndPos.f1);
         addData(jdbcConnection, 2);
         MySqlSource<String> mySqlSource = getSource(startupOptions);
 
@@ -479,8 +471,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 null,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     @Test
@@ -496,7 +487,8 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
         resetMaster(gtidsDatabase.getJdbcConnection());
         setPurgedGitds(jdbcConnection, historyPurgedGtids);
         Tuple2<String, Long> binlogFileAndPos = getBinlogFileAndPos(jdbcConnection);
-        StartupOptions startupOptions = StartupOptions.specificOffset(binlogFileAndPos.f0, binlogFileAndPos.f1);
+        StartupOptions startupOptions =
+                StartupOptions.specificOffset(binlogFileAndPos.f0, binlogFileAndPos.f1);
         addData(jdbcConnection, 5);
         MySqlSource<String> mySqlSource = getSource(startupOptions);
 
@@ -508,8 +500,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 historyPurgedGtids,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     @Test
@@ -526,7 +517,8 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
         setPurgedGitds(jdbcConnection, historyPurgedGtids);
         addData(jdbcConnection, 3);
         Tuple2<String, Long> binlogFileAndPos = getBinlogFileAndPos(jdbcConnection);
-        StartupOptions startupOptions = StartupOptions.specificOffset(binlogFileAndPos.f0, binlogFileAndPos.f1);
+        StartupOptions startupOptions =
+                StartupOptions.specificOffset(binlogFileAndPos.f0, binlogFileAndPos.f1);
         addData(jdbcConnection, 2);
         MySqlSource<String> mySqlSource = getSource(startupOptions);
 
@@ -538,8 +530,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 historyPurgedGtids,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     @Test
@@ -567,8 +558,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 null,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     @Test
@@ -597,8 +587,7 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                 actuallyFetchDataCount,
                 initSourceId,
                 historyPurgedGtids,
-                expectedTransactionId
-        );
+                expectedTransactionId);
     }
 
     private String getSourceId(String gtids) {
@@ -611,7 +600,9 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     }
 
     private void setPurgedGitds(Connection jdbcConnection, String gtids) throws Exception {
-        jdbcConnection.createStatement().execute(String.format("SET @@GLOBAL.gtid_purged='%s'", gtids));
+        jdbcConnection
+                .createStatement()
+                .execute(String.format("SET @@GLOBAL.gtid_purged='%s'", gtids));
     }
 
     private String getExecutedGtids(Connection jdbcConnection) throws Exception {
@@ -625,16 +616,17 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
     private Tuple2<String, Long> getBinlogFileAndPos(Connection jdbcConnection) throws Exception {
         ResultSet resultSet = jdbcConnection.createStatement().executeQuery("SHOW MASTER STATUS");
         if (resultSet.next()) {
-            Tuple2<String, Long> BinlogFilePos = new Tuple2<>();
-            BinlogFilePos.f0 = (resultSet.getString("File"));
-            BinlogFilePos.f1 = (resultSet.getLong("Position"));
-            return BinlogFilePos;
+            Tuple2<String, Long> binlogFilePos = new Tuple2<>();
+            binlogFilePos.f0 = (resultSet.getString("File"));
+            binlogFilePos.f1 = (resultSet.getLong("Position"));
+            return binlogFilePos;
         }
         throw new Exception("Can not got ExecutedGtids");
     }
 
     private String getPurgedGtids(Connection jdbcConnection) throws Exception {
-        ResultSet resultSet = jdbcConnection.createStatement().executeQuery("SELECT @@global.gtid_purged");
+        ResultSet resultSet =
+                jdbcConnection.createStatement().executeQuery("SELECT @@global.gtid_purged");
         if (resultSet.next()) {
             return resultSet.getString("@@global.gtid_purged");
         }
@@ -643,7 +635,10 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
 
     private void addData(Connection jdbcConnection, int dataCnt) throws Exception {
         for (int i = 0; i < dataCnt; i++) {
-            jdbcConnection.createStatement().execute("INSERT INTO products VALUES (default,\"scooter\",\"Small 2-wheel scooter\", 3.14);");
+            jdbcConnection
+                    .createStatement()
+                    .execute(
+                            "INSERT INTO products VALUES (default,\"scooter\",\"Small 2-wheel scooter\", 3.14);");
         }
     }
 
@@ -666,26 +661,27 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
                         DataTypes.FIELD("name", DataTypes.STRING()),
                         DataTypes.FIELD("description", DataTypes.STRING()),
                         DataTypes.FIELD("weight", DataTypes.FLOAT()));
-        InternalTypeInfo<RowData> typeInfo = InternalTypeInfo.of(TypeConversions.fromDataToLogicalType(dataType));
+        InternalTypeInfo<RowData> typeInfo =
+                InternalTypeInfo.of(TypeConversions.fromDataToLogicalType(dataType));
         return RowDataDebeziumDeserializeSchema.newBuilder()
-                        .setPhysicalRowType((RowType) dataType.getLogicalType())
-                        .setResultTypeInfo(typeInfo)
-                        .build();
+                .setPhysicalRowType((RowType) dataType.getLogicalType())
+                .setResultTypeInfo(typeInfo)
+                .build();
     }
 
     private MySqlSource<String> getSource(StartupOptions startupOptions) {
         return MySqlSource.<String>builder()
-                        .hostname(MYSQL_CONTAINER.getHost())
-                        .port(MYSQL_CONTAINER.getDatabasePort())
-                        .databaseList(gtidsDatabase.getDatabaseName())
-                        .serverTimeZone("UTC")
-                        .tableList(tableId)
-                        .username(gtidsDatabase.getUsername())
-                        .password(gtidsDatabase.getPassword())
-                        .serverId("5401-5404")
-                        .deserializer(new GtidsDebeziumDeserializationSchema())
-                        .startupOptions(startupOptions)
-                        .build();
+                .hostname(MYSQL_CONTAINER.getHost())
+                .port(MYSQL_CONTAINER.getDatabasePort())
+                .databaseList(gtidsDatabase.getDatabaseName())
+                .serverTimeZone("UTC")
+                .tableList(tableId)
+                .username(gtidsDatabase.getUsername())
+                .password(gtidsDatabase.getPassword())
+                .serverId("5401-5404")
+                .deserializer(new GtidsDebeziumDeserializationSchema())
+                .startupOptions(startupOptions)
+                .build();
     }
 
     private static List<String> fetchRowData(Iterator<String> iter, int size) {
@@ -698,7 +694,15 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
         return (rows);
     }
 
-    private void executeCdcAndAssert(Connection jdbcConnection, MySqlSource<String> mySqlSource, int addSize, int fetchSize, String initSourceId, String historyGtids, String expectedTransactionId) throws Exception {
+    private void executeCdcAndAssert(
+            Connection jdbcConnection,
+            MySqlSource<String> mySqlSource,
+            int addSize,
+            int fetchSize,
+            String initSourceId,
+            String historyGtids,
+            String expectedTransactionId)
+            throws Exception {
         StreamExecutionEnvironment env = getEnv();
         DataStreamSource<String> sourceStream =
                 env.fromSource(mySqlSource, WatermarkStrategy.noWatermarks(), "selfSource");
@@ -709,15 +713,17 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
             LOG.info("expectedFetchSize is {}, actualFetchSize is {}", fetchSize, rows.size());
             assertEquals(fetchSize, rows.size());
 
-            String lastGtids = (rows.size() > 0) ? rows.get(rows.size()-1) : "";
+            String lastGtids = (rows.size() > 0) ? rows.get(rows.size() - 1) : "";
             GtidSet lastGtidSet = new GtidSet(lastGtids);
-            GtidSet expectedGtidSet = getExpectedGtidSet(initSourceId, historyGtids, expectedTransactionId);
+            GtidSet expectedGtidSet =
+                    getExpectedGtidSet(initSourceId, historyGtids, expectedTransactionId);
             LOG.info("expectedGtidSet is {}, lastGtidSet is {}", expectedGtidSet, lastGtidSet);
             assertEquals(expectedGtidSet, lastGtidSet);
         }
     }
 
-    private GtidSet getExpectedGtidSet(String initSourceId, String historyGtids, String expectedTransactionId) {
+    private GtidSet getExpectedGtidSet(
+            String initSourceId, String historyGtids, String expectedTransactionId) {
         String expectedGtids = "";
         if (historyGtids != null) {
             expectedGtids = expectedGtids + historyGtids + ",";
@@ -726,7 +732,8 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
         return new GtidSet(expectedGtids);
     }
 
-    static class GtidsDebeziumDeserializationSchema implements DebeziumDeserializationSchema<String> {
+    static class GtidsDebeziumDeserializationSchema
+            implements DebeziumDeserializationSchema<String> {
 
         private static final long serialVersionUID = 1L;
 
@@ -742,6 +749,5 @@ public class MySqlGtidsOffsetITCase extends MySqlSourceTestBase {
         public TypeInformation<String> getProducedType() {
             return BasicTypeInfo.of(String.class);
         }
-
     }
 }

--- a/flink-connector-mysql-cdc/src/test/resources/ddl/gtids_test.sql
+++ b/flink-connector-mysql-cdc/src/test/resources/ddl/gtids_test.sql
@@ -1,0 +1,24 @@
+-- Copyright 2022 Ververica Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--   http://www.apache.org/licenses/LICENSE-2.0
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- ----------------------------------------------------------------------------------------------------------------
+-- DATABASE:  gtids_test
+-- ----------------------------------------------------------------------------------------------------------------
+
+CREATE TABLE products (
+      id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,
+      name VARCHAR(255) NOT NULL DEFAULT 'flink',
+      description VARCHAR(512),
+      weight FLOAT
+);
+


### PR DESCRIPTION
Resolve #1944

> <b>Problem analysis</b>

Issue #1944 reports a bug where recovery from checkpoint fails when starting from offset-binlogfile&pos. After conducting further tests, I found that this bug can occur in Earliest, Timestamp, BinlogFile&Pos startup modes, as well as when incomplete Gtids are incorrectly set. The root cause of this bug is that when MySQL has GTID enabled and the aforementioned startup modes are used, the complete GTIDs cannot be recorded in the offsetContext. Instead, an empty GtidSet is initialized and subsequently appended by received Gtid Events. This leads to recovery failure when restoring from checkpoint due to incomplete GTIDs being recorded.

_Test premise: MySQL needs to have GTID enabled, and due to settings such as master-slave switching and multiple masters, there are multiple sourceIDs for GTIDs_
|startupMode|How to initialize GTID|Restore from a checkpoint|
|-|-|-|
| initial | Obtain the GTID value through SHOW MASTER STATUS before starting the snapshot | √ |
| latest | Obtain the GTID value through SHOW MASTER STATUS before starting to consume | √ |
| offset-gtid | Use the user-set GTID before starting to consume.<b>Note: The user needs to set the complete GTID, otherwise it will not pass the startup verification</b> | √ |
| offset-binlogfile&pos | Set the consumption anchor of the binlog through binlog_file='xxx', offset=yyy before starting to consume, but the GTID is null after initialization | X |
| earliest | Set the consumption anchor of the binlog through binlog_file='', offset=0 before starting to consume, but the GTID is null after initialization | X |
| timestamp | Set the consumption anchor of the binlog through binlog_file='', offset=0 before starting to consume, but the GTID is null after initialization. After starting the consumption, all binlog events with timestamps less than the specified timestamp will be skipped until an event with a timestamp greater than or equal to timestamp is found, and the GTID will be recorded at that point | X |


> <b>Solution approach</b>

There are two solutions to fix this bug:

* <b>Solution A</b>: When recovering from checkpoint, check whether the startup is based on GTID or binlogFile&Pos settings. If it is based on latest/initial/offset-gitds startup, recover from GTID. If it is based on earliest/timestamp/binlogFile&Pos startup, recover from binlogFile&Pos.

* <b>Solution B</b>: Attempt to initialize the complete GTIDs when starting from earliest/timestamp/binlogFile&Pos, and subsequently recover from GTID in all checkpoints.

Personally, I am more inclined towards Solution B because in complex production environments of MySQL, there are situations such as master-slave architecture, multi-master architecture, failover, etc. Using GTID may avoid more unpredictable problems than using binlogFile&Pos. Therefore, this PR is also implemented based on Solution B.

> <b>Implementation logic</b>

Copied the GtidSet class from com.github.shyiko.mysql.binlog and added the overwriteThenAdd method:
In the CDC scenario, if starting from a certain offset, it can be assumed that the data before that offset will not be consumed again. Therefore, when initializing the GtidSet, if the first GTID event is received, the overwrite method can be used to correct the GtidSet to be complete and continuous. For example, if the initial gtidSet is `A:1-100,B:1-20`, but due to filtering, the first received GTID event is `B:50`, the overwrite method will correct the gtidSet to `A:1-100,B:1-50` to ensure the completeness and continuity of the GtidSet. In the GtidSet, each sourceID has an independent trigger switch to ensure that each SourceID triggers an overwrite when first written, and then uses the add method for updates.

Made some changes in the MySqlStreamingChangeEventSource class and adjusted the logic for initializing the GtidSet:
Starting from earliest/timestamp: The client startup anchor/offsetContext's gtidSet is set to purgedGtids, so CDC will consume from the valid GTID and record the correct and complete GtidSet. For timestamp, because a batch of data (<timestamp) will be skipped after startup, the overwriteThenAppend method will be used to correct it when the first GTID event is received.

Starting from offset-binlogFile&Pos: The client startup anchor is set to binlogFile&Pos. Since it is not cost-effective to obtain accurate corresponding Gtids, the initial value of the gtidSet is set to executedGTIDs (obtained from show master status). At this time, the gtidSet is incorrect, but it will not record the checkpoint. The overwriteThenAppend method will be used to correct it when the first GTID event is received. For example, if the initialized gtidSet is `A:1-100,B:1-100`, and the first received GTID event is `B:50`, the overwrite method will correct it to `A:1-100,B:1-50`.

Starting from offset-gtids: No modifications. As MySQL-CDC will verify the user-set offset-gtids, the task cannot be started if it is not set correctly.

Starting from latest/initial: No modifications. This is because when starting through these two modes, the gtidSet will be initialized through show master status to obtain the complete GTIDs.

> <b>Test cases</b>

Three unit tests have been added for the newly added "overwriteThenAdd" method in the "GtidSet" class to ensure that it works correctly.

Due to the complexity of the modifications made to the "MySqlStreamingChangeEventSource" class, a set of integration tests based on docker-mysql have been written. Eighteen test cases have been written for the initial/latest/earliest/timestamp/offset-gtids/offset-binlogfile&pos startup modes to ensure that the code works correctly.