### PR TITLE
[Oracle] Fix Oracle CDC fetch two different db name for the same table

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
@@ -103,7 +103,7 @@ public class OracleConnectionUtils {
                             String schemaName = rs.getString(1);
                             String tableName = rs.getString(2);
                             TableId tableId =
-                                    new TableId(jdbcConnection.database(), schemaName, tableName);
+                                    new TableId(jdbcConnection.database().toUpperCase(), schemaName, tableName);
                             tableIdSet.add(tableId);
                         }
                     });

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
@@ -103,7 +103,7 @@ public class OracleConnectionUtils {
                             String schemaName = rs.getString(1);
                             String tableName = rs.getString(2);
                             TableId tableId =
-                                    new TableId(jdbcConnection.database().toUpperCase(), schemaName, tableName);
+                                    new TableId(jdbcConnection.database(), schemaName, tableName);
                             tableIdSet.add(tableId);
                         }
                     });

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactory.java
@@ -77,6 +77,11 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
         String password = config.get(PASSWORD);
         String databaseName = config.get(DATABASE_NAME);
         checkNotNull(databaseName);
+        // During the incremental phase, Debezium uses the uppercase database name.
+        // However, during the snapshot phase, the database name is user-configurable.
+        // To avoid inconsistencies between the database names in the snapshot and incremental phases,
+        // it is necessary to convert the database name to uppercase when constructing the Oracle Source.
+        // For more details, please refer to: : https://github.com/ververica/flink-cdc-connectors/pull/2088.
         databaseName = databaseName.toUpperCase();
         String tableName = config.get(TABLE_NAME);
         String schemaName = config.get(SCHEMA_NAME);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactory.java
@@ -16,6 +16,7 @@
 
 package com.ververica.cdc.connectors.oracle.table;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
@@ -56,6 +57,7 @@ import static com.ververica.cdc.connectors.oracle.source.config.OracleSourceOpti
 import static com.ververica.cdc.connectors.oracle.source.config.OracleSourceOptions.SCHEMA_NAME;
 import static com.ververica.cdc.connectors.oracle.source.config.OracleSourceOptions.URL;
 import static com.ververica.cdc.debezium.table.DebeziumOptions.getDebeziumProperties;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /** Factory for creating configured instance of {@link OracleTableSource}. */
@@ -75,6 +77,8 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
         String username = config.get(USERNAME);
         String password = config.get(PASSWORD);
         String databaseName = config.get(DATABASE_NAME);
+        checkNotNull(databaseName);
+        databaseName = databaseName.toUpperCase();
         String tableName = config.get(TABLE_NAME);
         String schemaName = config.get(SCHEMA_NAME);
         int port = config.get(PORT);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactory.java
@@ -81,7 +81,7 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
         // However, during the snapshot phase, the database name is user-configurable.
         // To avoid inconsistencies between the database names in the snapshot and incremental phases,
         // it is necessary to convert the database name to uppercase when constructing the Oracle Source.
-        // For more details, please refer to: : https://github.com/ververica/flink-cdc-connectors/pull/2088.
+        // For more details, please refer to: https://github.com/ververica/flink-cdc-connectors/pull/2088.
         databaseName = databaseName.toUpperCase();
         String tableName = config.get(TABLE_NAME);
         String schemaName = config.get(SCHEMA_NAME);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactory.java
@@ -16,7 +16,6 @@
 
 package com.ververica.cdc.connectors.oracle.table;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactory.java
@@ -79,9 +79,12 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
         checkNotNull(databaseName);
         // During the incremental phase, Debezium uses the uppercase database name.
         // However, during the snapshot phase, the database name is user-configurable.
-        // To avoid inconsistencies between the database names in the snapshot and incremental phases,
-        // it is necessary to convert the database name to uppercase when constructing the Oracle Source.
-        // For more details, please refer to: https://github.com/ververica/flink-cdc-connectors/pull/2088.
+        // To avoid inconsistencies between the database names in the snapshot and incremental
+        // phases,
+        // it is necessary to convert the database name to uppercase when constructing the Oracle
+        // Source.
+        // For more details, please refer to:
+        // https://github.com/ververica/flink-cdc-connectors/pull/2088.
         databaseName = databaseName.toUpperCase();
         String tableName = config.get(TABLE_NAME);
         String schemaName = config.get(SCHEMA_NAME);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
@@ -83,7 +83,7 @@ public class OracleTableSourceFactoryTest {
     private static final String MY_LOCALHOST = "localhost";
     private static final String MY_USERNAME = "flinkuser";
     private static final String MY_PASSWORD = "flinkpw";
-    private static final String MY_DATABASE = "myDB";
+    private static final String MY_DATABASE = "MYDB";
     private static final String MY_TABLE = "myTable";
     private static final String MY_SCHEMA = "mySchema";
     private static final Properties PROPERTIES = new Properties();


### PR DESCRIPTION
### Fix Oracle CDC fetch two different db name for the same table

- Fixes #2087  

### Motivation

If the database name configured for Oracle CDC in Flink SQL is lowercase, such as the following example (`'database-name' = 'xe'`), 

```sql
CREATE TABLE products (
     ID INT NOT NULL,
     NAME STRING,
     DESCRIPTION STRING,
     WEIGHT DECIMAL(10, 3),
     PRIMARY KEY(id) NOT ENFORCED
     ) WITH (
     'connector' = 'oracle-cdc',
     'hostname' = 'localhost',
     'port' = '1521',
     'username' = 'flinkuser',
     'password' = 'flinkpw',
     'database-name' = 'xe',
     'schema-name' = 'FLINKUSER',
     'table-name' = 'TEST_03');
```

the following problems will occur:
1. For the same table (`TEST_03`)，the snapshot phase  will use the lowercase database name  (`xe.FLINKUSER.TEST_03 `), and the incremental phase will use the uppercase database name (`XE.FLINKUSER.TEST_03 `).
2. For the same table (`TEST_03 `), after being captured in the snapshot phase, it will be captured again in the incremental phase because their database names are inconsistent.

<img width="1166" alt="image" src="https://user-images.githubusercontent.com/111486498/232319947-bb0b8ae5-be1d-452f-bed9-aa2ea2f140ca.png">


In `OracleConnectorConfig`, the database name in Flink SQL is converted to uppercase, but the database name used in the snapshot phase is directly taken from Flink SQL. Therefore, when constructing the `tableId`, the database name in Flink SQL also needs to be converted to uppercase.

<img width="1467" alt="企业微信截图_92720bc3-5148-463a-9b35-12c3c8f77570" src="https://user-images.githubusercontent.com/111486498/232319384-94ceef68-a5e6-4238-9506-30a7546184e2.png">

### Modifications

When constructing the `tableId`, the database name in Flink SQL needs to be converted to uppercase.


