### PR TITLE
[Mysql] Fix duplicate split which cause duplicate data when open scanNewlyAddedTableEnabled

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
@@ -300,6 +300,7 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
                 remainingSplits.addAll(schemaLessSnapshotSplits);
                 if (!chunkSplitter.hasNextChunk()) {
                     remainingTables.remove(nextTable);
+                    addAlreadyProcessedTablesIfNotExists(nextTable);
                 }
                 lock.notify();
             }
@@ -323,7 +324,6 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
                 MySqlSchemalessSnapshotSplit split = iterator.next();
                 remainingSplits.remove(split);
                 assignedSplits.put(split.splitId(), split);
-                addAlreadyProcessedTablesIfNotExists(split.getTableId());
                 return Optional.of(
                         split.toMySqlSnapshotSplit(tableSchemas.get(split.getTableId())));
             } else if (!remainingTables.isEmpty()) {

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
@@ -300,7 +300,6 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
                 remainingSplits.addAll(schemaLessSnapshotSplits);
                 if (!chunkSplitter.hasNextChunk()) {
                     remainingTables.remove(nextTable);
-                    addAlreadyProcessedTablesIfNotExists(nextTable);
                 }
                 lock.notify();
             }
@@ -324,6 +323,7 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
                 MySqlSchemalessSnapshotSplit split = iterator.next();
                 remainingSplits.remove(split);
                 assignedSplits.put(split.splitId(), split);
+                addAlreadyProcessedTablesIfNotExists(split.getTableId());
                 return Optional.of(
                         split.toMySqlSnapshotSplit(tableSchemas.get(split.getTableId())));
             } else if (!remainingTables.isEmpty()) {


### PR DESCRIPTION
Fix #2095 

I carefully debugged the bug and there is the analysis:

1、In MySqlSnapshotSplitAssigner, split table happens asynchronously
2、After the finish of every table split the table will be moved from remaining table 
3、After tm calls getNext() from  MySqlSnapshotSplitAssigner, the table will be added to alreadyProcessedTables
4、However when job restarts and open scanNewlyAddedTableEnabled and discover newly added table, it gets into the following logic

![image](https://user-images.githubusercontent.com/26538404/233299047-b087ddd9-409a-4375-acab-86506b3c4d8a.png)

The alreadyProcessedTables + remainingTables won't always be euqals to the tables splitted in the last run.

This happens when table is so large and tm can't process split on time. 

For example:
1、The task reads from A and B, and each of them split into 1000 chunks 
2、The remaingTable is empty since they are already splitted, but alreadyProcessedTables only contains A since B is not fetch by tm now
3、 job restarts and B will be spliited again.


