### PR TITLE
[mongodb] supports pre- & post-image feature in mongo 6.0 (#2062)

### DIFF
--- a/flink-cdc-e2e-tests/pom.xml
+++ b/flink-cdc-e2e-tests/pom.xml
@@ -153,6 +153,12 @@ under the License.
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <version>1.18.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flink-connector-mongodb-cdc/pom.xml
+++ b/flink-connector-mongodb-cdc/pom.xml
@@ -51,7 +51,7 @@ under the License.
         <dependency>
             <groupId>org.mongodb.kafka</groupId>
             <artifactId>mongo-kafka-connect</artifactId>
-            <version>1.6.1</version>
+            <version>1.10.1</version>
             <exclusions>
                 <exclusion>
                     <artifactId>mongodb-driver-sync</artifactId>
@@ -67,7 +67,7 @@ under the License.
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
-            <version>4.3.4</version>
+            <version>4.9.1</version>
         </dependency>
 
         <!-- test dependencies on Flink -->
@@ -150,6 +150,13 @@ under the License.
                     <artifactId>junit</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <version>1.18.3</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/internal/MongoDBEnvelope.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/internal/MongoDBEnvelope.java
@@ -61,6 +61,8 @@ public class MongoDBEnvelope {
 
     public static final String FULL_DOCUMENT_FIELD = "fullDocument";
 
+    public static final String FULL_DOCUMENT_BEFORE_CHANGE_FIELD = "fullDocumentBeforeChange";
+
     public static final String DOCUMENT_KEY_FIELD = "documentKey";
 
     public static final String OPERATION_TYPE_FIELD = "operationType";
@@ -94,6 +96,7 @@ public class MongoDBEnvelope {
                     + "    { \"name\": \"_id\", \"type\": \"string\" },"
                     + "    { \"name\": \"operationType\", \"type\": [\"string\", \"null\"] },"
                     + "    { \"name\": \"fullDocument\", \"type\": [\"string\", \"null\"] },"
+                    + "    { \"name\": \"fullDocumentBeforeChange\", \"type\": [\"string\", \"null\"] },"
                     + "    { \"name\": \"source\","
                     + "      \"type\": [{\"name\": \"source\", \"type\": \"record\", \"fields\": ["
                     + "                {\"name\": \"ts_ms\", \"type\": \"long\"},"

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/MongoDBSourceBuilder.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/MongoDBSourceBuilder.java
@@ -196,6 +196,17 @@ public class MongoDBSourceBuilder<T> {
     }
 
     /**
+     * scan.full-changelog
+     *
+     * <p>Whether to generate full mode row data by looking up full document pre- and post-image
+     * collections. Requires MongoDB >= 6.0.
+     */
+    public MongoDBSourceBuilder<T> scanFullChangelog(boolean enableFullDocPrePostImage) {
+        this.configFactory.scanFullChangelog(enableFullDocPrePostImage);
+        return this;
+    }
+
+    /**
      * The deserializer used to convert from consumed {@link
      * org.apache.kafka.connect.source.SourceRecord}.
      */

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfig.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfig.java
@@ -49,6 +49,7 @@ public class MongoDBSourceConfig implements SourceConfig {
     private final int splitMetaGroupSize;
     private final int splitSizeMB;
     private final boolean closeIdleReaders;
+    private final boolean enableFullDocPrePostImage;
 
     MongoDBSourceConfig(
             String scheme,
@@ -66,7 +67,8 @@ public class MongoDBSourceConfig implements SourceConfig {
             int heartbeatIntervalMillis,
             int splitMetaGroupSize,
             int splitSizeMB,
-            boolean closeIdleReaders) {
+            boolean closeIdleReaders,
+            boolean enableFullDocPrePostImage) {
         this.scheme = checkNotNull(scheme);
         this.hosts = checkNotNull(hosts);
         this.username = username;
@@ -84,6 +86,7 @@ public class MongoDBSourceConfig implements SourceConfig {
         this.splitMetaGroupSize = splitMetaGroupSize;
         this.splitSizeMB = splitSizeMB;
         this.closeIdleReaders = closeIdleReaders;
+        this.enableFullDocPrePostImage = enableFullDocPrePostImage;
     }
 
     public String getScheme() {
@@ -161,6 +164,10 @@ public class MongoDBSourceConfig implements SourceConfig {
     @Override
     public boolean isCloseIdleReaders() {
         return closeIdleReaders;
+    }
+
+    public boolean isFullDocPrePostImageEnabled() {
+        return enableFullDocPrePostImage;
     }
 
     @Override

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfigFactory.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfigFactory.java
@@ -59,6 +59,7 @@ public class MongoDBSourceConfigFactory implements Factory<MongoDBSourceConfig> 
     private Integer splitMetaGroupSize = CHUNK_META_GROUP_SIZE.defaultValue();
     private Integer splitSizeMB = SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB.defaultValue();
     private boolean closeIdleReaders = false;
+    private boolean enableFullDocPrePostImage = false;
 
     /** The protocol connected to MongoDB. For example mongodb or mongodb+srv. */
     public MongoDBSourceConfigFactory scheme(String scheme) {
@@ -219,6 +220,17 @@ public class MongoDBSourceConfigFactory implements Factory<MongoDBSourceConfig> 
         return this;
     }
 
+    /**
+     * scan.full-changelog
+     *
+     * <p>Whether to generate full mode row data by looking up full document pre- and post-image
+     * collections. Requires MongoDB >= 6.0.
+     */
+    public MongoDBSourceConfigFactory scanFullChangelog(boolean enableFullDocPrePostImage) {
+        this.enableFullDocPrePostImage = enableFullDocPrePostImage;
+        return this;
+    }
+
     /** Creates a new {@link MongoDBSourceConfig} for the given subtask {@code subtaskId}. */
     @Override
     public MongoDBSourceConfig create(int subtaskId) {
@@ -239,6 +251,7 @@ public class MongoDBSourceConfigFactory implements Factory<MongoDBSourceConfig> 
                 heartbeatIntervalMillis,
                 splitMetaGroupSize,
                 splitSizeMB,
-                closeIdleReaders);
+                closeIdleReaders,
+                enableFullDocPrePostImage);
     }
 }

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceOptions.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceOptions.java
@@ -78,8 +78,8 @@ public class MongoDBSourceOptions {
                             "The ampersand-separated MongoDB connection options. "
                                     + "eg. replicaSet=test&connectTimeoutMS=300000");
 
-    public static final ConfigOption<Integer> COPY_EXISTING_QUEUE_SIZE =
-            ConfigOptions.key("copy.existing.queue.size")
+    public static final ConfigOption<Integer> INITIAL_SNAPSHOTTING_QUEUE_SIZE =
+            ConfigOptions.key("initial.snapshotting.queue.size")
                     .intType()
                     .defaultValue(10240)
                     .withDescription(
@@ -133,4 +133,12 @@ public class MongoDBSourceOptions {
                     .defaultValue(64)
                     .withDescription(
                             "The chunk size mb of incremental snapshot. Defaults to 64mb.");
+
+    @Experimental
+    public static final ConfigOption<Boolean> FULL_DOCUMENT_PRE_POST_IMAGE =
+            ConfigOptions.key("scan.full-changelog")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Scan full mode changelog. Only available when MongoDB >= 6.0. Defaults to false.");
 }

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/reader/fetch/MongoDBStreamFetchTask.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/reader/fetch/MongoDBStreamFetchTask.java
@@ -334,7 +334,6 @@ public class MongoDBStreamFetchTask implements FetchTask<SourceSplitBase> {
         Instant clusterInstant = Instant.ofEpochSecond(clusterTime.getTime());
         source.put(TIMESTAMP_KEY_FIELD, new BsonInt64(clusterInstant.toEpochMilli()));
         changeStreamDocument.put(SOURCE_FIELD, source);
-
         return changeStreamDocument;
     }
 

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBConnectorDeserializationSchema.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBConnectorDeserializationSchema.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2008-present MongoDB, Inc.
+ * Copyright 2023 Ververica Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -166,12 +166,12 @@ public class MongoDBConnectorDeserializationSchema
         }
     }
 
-    private GenericRowData extractRowData(BsonDocument document) throws Exception {
+    protected GenericRowData extractRowData(BsonDocument document) throws Exception {
         checkNotNull(document);
         return (GenericRowData) physicalConverter.convert(document);
     }
 
-    private BsonDocument extractBsonDocument(Struct value, Schema valueSchema, String fieldName) {
+    protected BsonDocument extractBsonDocument(Struct value, Schema valueSchema, String fieldName) {
         if (valueSchema.field(fieldName) != null) {
             String docString = value.getString(fieldName);
             if (docString != null) {
@@ -186,12 +186,12 @@ public class MongoDBConnectorDeserializationSchema
         return resultTypeInfo;
     }
 
-    private OperationType operationTypeFor(SourceRecord record) {
+    protected OperationType operationTypeFor(SourceRecord record) {
         Struct value = (Struct) record.value();
         return OperationType.fromString(value.getString(MongoDBEnvelope.OPERATION_TYPE_FIELD));
     }
 
-    private void emit(SourceRecord inRecord, RowData physicalRow, Collector<RowData> collector) {
+    protected void emit(SourceRecord inRecord, RowData physicalRow, Collector<RowData> collector) {
         if (!hasMetadata) {
             collector.collect(physicalRow);
             return;

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBConnectorFullChangelogDeserializationSchema.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBConnectorFullChangelogDeserializationSchema.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mongodb.table;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Collector;
+
+import com.mongodb.client.model.changestream.OperationType;
+import com.ververica.cdc.connectors.mongodb.internal.MongoDBEnvelope;
+import com.ververica.cdc.debezium.table.MetadataConverter;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.bson.BsonDocument;
+
+import java.time.ZoneId;
+
+/**
+ * Deserialization schema from Mongodb ChangeStreamDocument to Flink Table/SQL internal data that
+ * produces full changelog mode structure {@link RowData}.
+ */
+public class MongoDBConnectorFullChangelogDeserializationSchema
+        extends MongoDBConnectorDeserializationSchema {
+
+    private static final long serialVersionUID = 1750787080613035184L;
+
+    public MongoDBConnectorFullChangelogDeserializationSchema(
+            RowType physicalDataType,
+            MetadataConverter[] metadataConverters,
+            TypeInformation<RowData> resultTypeInfo,
+            ZoneId localTimeZone) {
+        super(physicalDataType, metadataConverters, resultTypeInfo, localTimeZone);
+    }
+
+    @Override
+    public void deserialize(SourceRecord record, Collector<RowData> out) throws Exception {
+        Struct value = (Struct) record.value();
+        Schema valueSchema = record.valueSchema();
+
+        OperationType op = operationTypeFor(record);
+
+        BsonDocument documentKey =
+                extractBsonDocument(value, valueSchema, MongoDBEnvelope.DOCUMENT_KEY_FIELD);
+        BsonDocument fullDocument =
+                extractBsonDocument(value, valueSchema, MongoDBEnvelope.FULL_DOCUMENT_FIELD);
+
+        BsonDocument fullDocumentBeforeChange =
+                extractBsonDocument(
+                        value, valueSchema, MongoDBEnvelope.FULL_DOCUMENT_BEFORE_CHANGE_FIELD);
+
+        switch (op) {
+            case INSERT:
+                GenericRowData insert = extractRowData(fullDocument);
+                insert.setRowKind(RowKind.INSERT);
+                emit(record, insert, out);
+                break;
+            case DELETE:
+                // there might be FullDocBeforeChange field
+                // if fullDocumentPrePostImage feature is on
+                // convert it to Delete row data with full document
+                if (fullDocumentBeforeChange != null) {
+                    GenericRowData updateBefore = extractRowData(fullDocumentBeforeChange);
+                    updateBefore.setRowKind(RowKind.DELETE);
+                    emit(record, updateBefore, out);
+                } else {
+                    GenericRowData delete = extractRowData(documentKey);
+                    delete.setRowKind(RowKind.DELETE);
+                    emit(record, delete, out);
+                }
+                break;
+            case UPDATE:
+                // It’s null if another operation deletes the document
+                // before the lookup operation happens. Ignored it.
+                if (fullDocument == null) {
+                    break;
+                }
+                // there might be FullDocBeforeChange field
+                // if fullDocumentPrePostImage feature is on
+                // convert it to UB row data
+                if (fullDocumentBeforeChange != null) {
+                    GenericRowData updateBefore = extractRowData(fullDocumentBeforeChange);
+                    updateBefore.setRowKind(RowKind.UPDATE_BEFORE);
+                    emit(record, updateBefore, out);
+                }
+                GenericRowData updateAfter = extractRowData(fullDocument);
+                updateAfter.setRowKind(RowKind.UPDATE_AFTER);
+                emit(record, updateAfter, out);
+                break;
+            case REPLACE:
+                // there might be FullDocBeforeChange field
+                // if fullDocumentPrePostImage feature is on
+                // convert it to UB row data
+                if (fullDocumentBeforeChange != null) {
+                    GenericRowData updateBefore = extractRowData(fullDocumentBeforeChange);
+                    updateBefore.setRowKind(RowKind.UPDATE_BEFORE);
+                    emit(record, updateBefore, out);
+                }
+                GenericRowData replaceAfter = extractRowData(fullDocument);
+                replaceAfter.setRowKind(RowKind.UPDATE_AFTER);
+                emit(record, replaceAfter, out);
+                break;
+            case INVALIDATE:
+            case DROP:
+            case DROP_DATABASE:
+            case RENAME:
+            case OTHER:
+            default:
+                break;
+        }
+    }
+}

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
@@ -41,10 +41,11 @@ import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_START
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.BATCH_SIZE;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.COLLECTION;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.CONNECTION_OPTIONS;
-import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.COPY_EXISTING_QUEUE_SIZE;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.DATABASE;
+import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.FULL_DOCUMENT_PRE_POST_IMAGE;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.HEARTBEAT_INTERVAL_MILLIS;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.HOSTS;
+import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.INITIAL_SNAPSHOTTING_QUEUE_SIZE;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.PASSWORD;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_AWAIT_TIME_MILLIS;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_MAX_BATCH_SIZE;
@@ -88,7 +89,8 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
         Integer heartbeatIntervalMillis = config.get(HEARTBEAT_INTERVAL_MILLIS);
 
         StartupOptions startupOptions = getStartupOptions(config);
-        Integer copyExistingQueueSize = config.getOptional(COPY_EXISTING_QUEUE_SIZE).orElse(null);
+        Integer initialSnapshottingQueueSize =
+                config.getOptional(INITIAL_SNAPSHOTTING_QUEUE_SIZE).orElse(null);
 
         String zoneId = context.getConfiguration().get(TableConfigOptions.LOCAL_TIME_ZONE);
         ZoneId localTimeZone =
@@ -101,6 +103,9 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
 
         int splitSizeMB = config.get(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB);
         int splitMetaGroupSize = config.get(CHUNK_META_GROUP_SIZE);
+
+        boolean enableFullDocumentPrePostImage =
+                config.getOptional(FULL_DOCUMENT_PRE_POST_IMAGE).orElse(false);
 
         ResolvedSchema physicalSchema =
                 getPhysicalSchema(context.getCatalogTable().getResolvedSchema());
@@ -119,7 +124,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
                 collection,
                 connectionOptions,
                 startupOptions,
-                copyExistingQueueSize,
+                initialSnapshottingQueueSize,
                 batchSize,
                 pollMaxBatchSize,
                 pollAwaitTimeMillis,
@@ -128,7 +133,8 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
                 enableParallelRead,
                 splitMetaGroupSize,
                 splitSizeMB,
-                enableCloseIdleReaders);
+                enableCloseIdleReaders,
+                enableFullDocumentPrePostImage);
     }
 
     private void checkPrimaryKey(UniqueConstraint pk, String message) {
@@ -191,7 +197,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
         options.add(COLLECTION);
         options.add(SCAN_STARTUP_MODE);
         options.add(SCAN_STARTUP_TIMESTAMP_MILLIS);
-        options.add(COPY_EXISTING_QUEUE_SIZE);
+        options.add(INITIAL_SNAPSHOTTING_QUEUE_SIZE);
         options.add(BATCH_SIZE);
         options.add(POLL_MAX_BATCH_SIZE);
         options.add(POLL_AWAIT_TIME_MILLIS);
@@ -200,6 +206,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
         options.add(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB);
         options.add(CHUNK_META_GROUP_SIZE);
         options.add(SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED);
+        options.add(FULL_DOCUMENT_PRE_POST_IMAGE);
         return options;
     }
 }

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBContainer.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBContainer.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mongodb;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertNotNull;
+
+/** Mongodb test container. */
+public class LegacyMongoDBContainer extends GenericContainer<LegacyMongoDBContainer> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LegacyMongoDBContainer.class);
+
+    private static final String DOCKER_IMAGE_NAME = "mongo:5.0.2";
+
+    public static final int MONGODB_PORT = 27017;
+
+    public static final String MONGO_SUPER_USER = "superuser";
+
+    public static final String MONGO_SUPER_PASSWORD = "superpw";
+
+    public static final String FLINK_USER = "flinkuser";
+
+    public static final String FLINK_USER_PASSWORD = "a1?~!@#$%^&*(){}[]<>.,+_-=/|:;";
+
+    private static final Pattern COMMENT_PATTERN = Pattern.compile("^(.*)//.*$");
+
+    private final ShardingClusterRole clusterRole;
+
+    public LegacyMongoDBContainer(Network network) {
+        this(network, ShardingClusterRole.NONE);
+    }
+
+    public LegacyMongoDBContainer(Network network, ShardingClusterRole clusterRole) {
+        super(
+                new ImageFromDockerfile()
+                        .withFileFromClasspath("random.key", "docker/mongodb/random.key")
+                        .withFileFromClasspath("setup.js", "docker/mongodb/setup.js")
+                        .withDockerfileFromBuilder(
+                                builder ->
+                                        builder.from(DOCKER_IMAGE_NAME)
+                                                .copy(
+                                                        "setup.js",
+                                                        "/docker-entrypoint-initdb.d/setup.js")
+                                                .copy("random.key", "/data/keyfile/random.key")
+                                                .run("chown mongodb /data/keyfile/random.key")
+                                                .run("chmod 400 /data/keyfile/random.key")
+                                                .env("MONGO_INITDB_ROOT_USERNAME", MONGO_SUPER_USER)
+                                                .env(
+                                                        "MONGO_INITDB_ROOT_PASSWORD",
+                                                        MONGO_SUPER_PASSWORD)
+                                                .env("MONGO_INITDB_DATABASE", "admin")
+                                                .build()));
+        this.clusterRole = clusterRole;
+
+        withNetwork(network);
+        withNetworkAliases(clusterRole.hostname);
+        withExposedPorts(MONGODB_PORT);
+        withCommand(ShardingClusterRole.startupCommand(clusterRole));
+        waitingFor(clusterRole.waitStrategy);
+    }
+
+    public String getConnectionString(String username, String password) {
+        return String.format(
+                "mongodb://%s:%s@%s:%d",
+                username, password, getContainerIpAddress(), getMappedPort(MONGODB_PORT));
+    }
+
+    public String getHostAndPort() {
+        return String.format("%s:%s", getContainerIpAddress(), getMappedPort(MONGODB_PORT));
+    }
+
+    public void executeCommand(String command) {
+        try {
+            LOG.info("Executing mongo command: {}", command);
+            ExecResult execResult =
+                    execInContainer(
+                            "mongo",
+                            "-u",
+                            MONGO_SUPER_USER,
+                            "-p",
+                            MONGO_SUPER_PASSWORD,
+                            "--eval",
+                            command);
+            LOG.info(execResult.getStdout());
+            if (execResult.getExitCode() != 0) {
+                throw new IllegalStateException(
+                        "Execute mongo command failed " + execResult.getStdout());
+            }
+        } catch (InterruptedException | IOException e) {
+            throw new IllegalStateException("Execute mongo command failed", e);
+        }
+    }
+
+    @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        LOG.info("Preparing a MongoDB Container with sharding cluster role {}...", clusterRole);
+        if (clusterRole != ShardingClusterRole.ROUTER) {
+            initReplicaSet();
+        } else {
+            initShard();
+        }
+    }
+
+    protected void initReplicaSet() {
+        LOG.info("Initializing a single node replica set...");
+        executeCommand(
+                String.format(
+                        "rs.initiate({ _id : '%s', configsvr: %s, members: [{ _id: 0, host: '%s:%d'}]})",
+                        clusterRole.replicaSetName,
+                        clusterRole == ShardingClusterRole.CONFIG,
+                        clusterRole.hostname,
+                        MONGODB_PORT));
+
+        LOG.info("Waiting for single node replica set initialized...");
+        executeCommand(
+                String.format(
+                        "var attempt = 0; "
+                                + "while"
+                                + "(%s) "
+                                + "{ "
+                                + "if (attempt > %d) {quit(1);} "
+                                + "print('%s ' + attempt); sleep(100);  attempt++; "
+                                + " }",
+                        "db.runCommand( { isMaster: 1 } ).ismaster==false",
+                        60,
+                        "An attempt to await for a single node replica set initialization:"));
+    }
+
+    protected void initShard() {
+        LOG.info("Initializing a sharded cluster...");
+        // decrease chunk size from default 64mb to 1mb to make splitter test easier.
+        executeCommand(
+                "db.getSiblingDB('config').settings.updateOne(\n"
+                        + "   { _id: \"chunksize\" },\n"
+                        + "   { $set: { _id: \"chunksize\", value: 1 } },\n"
+                        + "   { upsert: true }\n"
+                        + ");");
+        executeCommand(
+                String.format(
+                        "sh.addShard('%s/%s:%d')",
+                        ShardingClusterRole.SHARD.replicaSetName,
+                        ShardingClusterRole.SHARD.hostname,
+                        MONGODB_PORT));
+    }
+
+    /** Executes a mongo command file in separate database. */
+    public String executeCommandFileInSeparateDatabase(String fileNameIgnoreSuffix) {
+        return executeCommandFileInDatabase(
+                fileNameIgnoreSuffix,
+                fileNameIgnoreSuffix + "_" + Integer.toUnsignedString(new Random().nextInt(), 36));
+    }
+
+    /** Executes a mongo command file, specify a database name. */
+    public String executeCommandFileInDatabase(String fileNameIgnoreSuffix, String databaseName) {
+        final String dbName = databaseName != null ? databaseName : fileNameIgnoreSuffix;
+        final String ddlFile = String.format("ddl/%s.js", fileNameIgnoreSuffix);
+        final URL ddlTestFile = LegacyMongoDBContainer.class.getClassLoader().getResource(ddlFile);
+        assertNotNull("Cannot locate " + ddlFile, ddlTestFile);
+
+        try {
+            // use database;
+            String command0 = String.format("db = db.getSiblingDB('%s');\n", dbName);
+            String command1 =
+                    Files.readAllLines(Paths.get(ddlTestFile.toURI())).stream()
+                            .filter(x -> StringUtils.isNotBlank(x) && !x.trim().startsWith("//"))
+                            .map(
+                                    x -> {
+                                        final Matcher m = COMMENT_PATTERN.matcher(x);
+                                        return m.matches() ? m.group(1) : x;
+                                    })
+                            .collect(Collectors.joining("\n"));
+
+            executeCommand(command0 + command1);
+
+            return dbName;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** A MongoDB sharded cluster roles. */
+    public enum ShardingClusterRole {
+        // Config servers store metadata and configuration settings for the cluster.
+        CONFIG("config0", "rs0-config", Wait.forLogMessage(".*[Ww]aiting for connections.*", 2)),
+
+        // Each shard contains a subset of the sharded data. Each shard can be deployed as a replica
+        // set.
+        SHARD("shard0", "rs0-shard", Wait.forLogMessage(".*[Ww]aiting for connections.*", 2)),
+
+        // The mongos acts as a query router, providing an interface between client applications and
+        // the sharded cluster.
+        ROUTER("router0", null, Wait.forLogMessage(".*[Ww]aiting for connections.*", 1)),
+
+        // None sharded cluster.
+        NONE("mongo0", "rs0", Wait.forLogMessage(".*Replication has not yet been configured.*", 1));
+
+        private final String hostname;
+        private final String replicaSetName;
+        private final WaitStrategy waitStrategy;
+
+        ShardingClusterRole(String hostname, String replicaSetName, WaitStrategy waitStrategy) {
+            this.hostname = hostname;
+            this.replicaSetName = replicaSetName;
+            this.waitStrategy = waitStrategy;
+        }
+
+        public static String startupCommand(ShardingClusterRole clusterRole) {
+            switch (clusterRole) {
+                case CONFIG:
+                    return String.format(
+                            "mongod --configsvr --port %d --replSet %s --keyFile /data/keyfile/random.key",
+                            MONGODB_PORT, clusterRole.replicaSetName);
+                case SHARD:
+                    return String.format(
+                            "mongod --shardsvr --port %d --replSet %s --keyFile /data/keyfile/random.key",
+                            MONGODB_PORT, clusterRole.replicaSetName);
+                case ROUTER:
+                    return String.format(
+                            "mongos --configdb %s/%s:%d --bind_ip_all --keyFile /data/keyfile/random.key",
+                            CONFIG.replicaSetName, CONFIG.hostname, MONGODB_PORT);
+                case NONE:
+                default:
+                    return String.format(
+                            "mongod --port %d --replSet %s --keyFile /data/keyfile/random.key",
+                            MONGODB_PORT, NONE.replicaSetName);
+            }
+        }
+    }
+}

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBSourceExampleTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBSourceExampleTest.java
@@ -19,17 +19,16 @@ package com.ververica.cdc.connectors.mongodb;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 
-import com.ververica.cdc.connectors.mongodb.source.MongoDBSourceTestBase;
 import com.ververica.cdc.debezium.JsonDebeziumDeserializationSchema;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static com.ververica.cdc.connectors.mongodb.LegacyMongoDBContainer.FLINK_USER;
+import static com.ververica.cdc.connectors.mongodb.LegacyMongoDBContainer.FLINK_USER_PASSWORD;
 import static com.ververica.cdc.connectors.mongodb.LegacyMongoDBTestBase.MONGODB_CONTAINER;
-import static com.ververica.cdc.connectors.mongodb.utils.MongoDBContainer.FLINK_USER;
-import static com.ververica.cdc.connectors.mongodb.utils.MongoDBContainer.FLINK_USER_PASSWORD;
 
 /** Example Tests for {@link MongoDBSource}. */
-public class LegacyMongoDBSourceExampleTest extends MongoDBSourceTestBase {
+public class LegacyMongoDBSourceExampleTest extends LegacyMongoDBSourceTestBase {
 
     @Test
     @Ignore("Test ignored because it won't stop and is used for manual test")

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBSourceTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBSourceTest.java
@@ -57,14 +57,14 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
+import static com.ververica.cdc.connectors.mongodb.LegacyMongoDBContainer.FLINK_USER;
+import static com.ververica.cdc.connectors.mongodb.LegacyMongoDBContainer.FLINK_USER_PASSWORD;
 import static com.ververica.cdc.connectors.mongodb.source.utils.MongoUtils.buildConnectionString;
 import static com.ververica.cdc.connectors.mongodb.utils.MongoDBAssertUtils.assertDelete;
 import static com.ververica.cdc.connectors.mongodb.utils.MongoDBAssertUtils.assertInsert;
 import static com.ververica.cdc.connectors.mongodb.utils.MongoDBAssertUtils.assertObjectIdEquals;
 import static com.ververica.cdc.connectors.mongodb.utils.MongoDBAssertUtils.assertReplace;
 import static com.ververica.cdc.connectors.mongodb.utils.MongoDBAssertUtils.assertUpdate;
-import static com.ververica.cdc.connectors.mongodb.utils.MongoDBContainer.FLINK_USER;
-import static com.ververica.cdc.connectors.mongodb.utils.MongoDBContainer.FLINK_USER_PASSWORD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBSourceTestBase.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBSourceTestBase.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mongodb;
+
+import org.apache.flink.runtime.minicluster.RpcServiceSharing;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.TestLogger;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.lifecycle.Startables;
+
+import java.util.stream.Stream;
+
+import static com.ververica.cdc.connectors.mongodb.LegacyMongoDBContainer.MONGO_SUPER_PASSWORD;
+import static com.ververica.cdc.connectors.mongodb.LegacyMongoDBContainer.MONGO_SUPER_USER;
+
+/** Basic class for testing {@link MongoDBSource}. */
+public abstract class LegacyMongoDBSourceTestBase extends TestLogger {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(LegacyMongoDBSourceTestBase.class);
+    protected static final int DEFAULT_PARALLELISM = 4;
+
+    @Rule
+    public final MiniClusterWithClientResource miniClusterResource =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(DEFAULT_PARALLELISM)
+                            .setRpcServiceSharing(RpcServiceSharing.DEDICATED)
+                            .withHaLeadershipControl()
+                            .build());
+
+    @ClassRule public static final Network NETWORK = Network.newNetwork();
+
+    @ClassRule
+    public static final LegacyMongoDBContainer CONFIG =
+            new LegacyMongoDBContainer(NETWORK, LegacyMongoDBContainer.ShardingClusterRole.CONFIG)
+                    .withLogConsumer(new Slf4jLogConsumer(LOG));
+
+    @ClassRule
+    public static final LegacyMongoDBContainer SHARD =
+            new LegacyMongoDBContainer(NETWORK, LegacyMongoDBContainer.ShardingClusterRole.SHARD)
+                    .dependsOn(CONFIG)
+                    .withLogConsumer(new Slf4jLogConsumer(LOG));
+
+    @ClassRule
+    public static final LegacyMongoDBContainer ROUTER =
+            new LegacyMongoDBContainer(NETWORK, LegacyMongoDBContainer.ShardingClusterRole.ROUTER)
+                    .dependsOn(SHARD)
+                    .withLogConsumer(new Slf4jLogConsumer(LOG));
+
+    protected static MongoClient mongodbClient;
+
+    @BeforeClass
+    public static void startContainers() {
+        LOG.info("Starting containers...");
+        Startables.deepStart(Stream.of(CONFIG)).join();
+        Startables.deepStart(Stream.of(SHARD)).join();
+        Startables.deepStart(Stream.of(ROUTER)).join();
+        initialClient();
+        LOG.info("Containers are started.");
+    }
+
+    @AfterClass
+    public static void closeContainers() {
+        if (mongodbClient != null) {
+            mongodbClient.close();
+        }
+        if (ROUTER != null) {
+            ROUTER.close();
+        }
+        if (SHARD != null) {
+            SHARD.close();
+        }
+        if (CONFIG != null) {
+            CONFIG.close();
+        }
+    }
+
+    private static void initialClient() {
+        MongoClientSettings settings =
+                MongoClientSettings.builder()
+                        .applyConnectionString(
+                                new ConnectionString(
+                                        ROUTER.getConnectionString(
+                                                MONGO_SUPER_USER, MONGO_SUPER_PASSWORD)))
+                        .build();
+        mongodbClient = MongoClients.create(settings);
+    }
+}

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBTestBase.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBTestBase.java
@@ -23,7 +23,6 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
-import com.ververica.cdc.connectors.mongodb.utils.MongoDBContainer;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.slf4j.Logger;
@@ -34,8 +33,8 @@ import org.testcontainers.lifecycle.Startables;
 
 import java.util.stream.Stream;
 
-import static com.ververica.cdc.connectors.mongodb.utils.MongoDBContainer.MONGO_SUPER_PASSWORD;
-import static com.ververica.cdc.connectors.mongodb.utils.MongoDBContainer.MONGO_SUPER_USER;
+import static com.ververica.cdc.connectors.mongodb.LegacyMongoDBContainer.MONGO_SUPER_PASSWORD;
+import static com.ververica.cdc.connectors.mongodb.LegacyMongoDBContainer.MONGO_SUPER_USER;
 
 /**
  * Basic class for testing MongoDB source, this contains a MongoDB container which enables change
@@ -47,8 +46,8 @@ public class LegacyMongoDBTestBase extends AbstractTestBase {
 
     @ClassRule public static final Network NETWORK = Network.newNetwork();
 
-    protected static final MongoDBContainer MONGODB_CONTAINER =
-            new MongoDBContainer(NETWORK).withLogConsumer(new Slf4jLogConsumer(LOG));
+    protected static final LegacyMongoDBContainer MONGODB_CONTAINER =
+            new LegacyMongoDBContainer(NETWORK).withLogConsumer(new Slf4jLogConsumer(LOG));
 
     protected static MongoClient mongodbClient;
 

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/MongoDBParallelSourceExampleTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/MongoDBParallelSourceExampleTest.java
@@ -34,11 +34,11 @@ public class MongoDBParallelSourceExampleTest extends MongoDBSourceTestBase {
     @Test
     @Ignore("Test ignored because it won't stop and is used for manual test")
     public void testMongoDBExampleSource() throws Exception {
-        String database = ROUTER.executeCommandFileInSeparateDatabase("inventory");
+        String database = CONTAINER.executeCommandFileInSeparateDatabase("inventory");
 
         MongoDBSource<String> mongoSource =
                 MongoDBSource.<String>builder()
-                        .hosts(ROUTER.getHostAndPort())
+                        .hosts(CONTAINER.getHostAndPort())
                         .databaseList(database)
                         .collectionList(database + ".products")
                         .username(FLINK_USER)

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBSnapshotSplitReaderTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBSnapshotSplitReaderTest.java
@@ -69,11 +69,11 @@ public class MongoDBSnapshotSplitReaderTest extends MongoDBSourceTestBase {
 
     @Before
     public void before() {
-        database = ROUTER.executeCommandFileInSeparateDatabase("chunk_test");
+        database = CONTAINER.executeCommandFileInSeparateDatabase("chunk_test");
 
         MongoDBSourceConfigFactory configFactory =
                 new MongoDBSourceConfigFactory()
-                        .hosts(ROUTER.getHostAndPort())
+                        .hosts(CONTAINER.getHostAndPort())
                         .databaseList(database)
                         .collectionList(database + ".shopping_cart")
                         .username(FLINK_USER)

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBStreamSplitReaderTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBStreamSplitReaderTest.java
@@ -83,11 +83,11 @@ public class MongoDBStreamSplitReaderTest extends MongoDBSourceTestBase {
 
     @Before
     public void before() {
-        database = ROUTER.executeCommandFileInSeparateDatabase("chunk_test");
+        database = CONTAINER.executeCommandFileInSeparateDatabase("chunk_test");
 
         MongoDBSourceConfigFactory configFactory =
                 new MongoDBSourceConfigFactory()
-                        .hosts(ROUTER.getHostAndPort())
+                        .hosts(CONTAINER.getHostAndPort())
                         .databaseList(database)
                         .collectionList(database + ".shopping_cart")
                         .username(FLINK_USER)

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBRegexFilterITCase.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBRegexFilterITCase.java
@@ -76,9 +76,9 @@ public class MongoDBRegexFilterITCase extends MongoDBSourceTestBase {
     public void testMatchMultipleDatabasesAndCollections() throws Exception {
         // 1. Given collections:
         // db0: [coll_a1, coll_a2, coll_b1, coll_b2]
-        String db0 = ROUTER.executeCommandFileInSeparateDatabase("ns_regex");
+        String db0 = CONTAINER.executeCommandFileInSeparateDatabase("ns_regex");
         // db1: [coll_a1, coll_a2, coll_b1, coll_b2]
-        String db1 = ROUTER.executeCommandFileInSeparateDatabase("ns_regex");
+        String db1 = CONTAINER.executeCommandFileInSeparateDatabase("ns_regex");
 
         // 2. Test match: collection = ^(db0|db1)\.coll_a\d?$
         String collectionRegex = String.format("^(%s|%s)\\.coll_a\\d?$", db0, db1);
@@ -119,11 +119,11 @@ public class MongoDBRegexFilterITCase extends MongoDBSourceTestBase {
     public void testMatchMultipleDatabases() throws Exception {
         // 1. Given collections:
         // db0: [coll_a1, coll_a2, coll_b1, coll_b2]
-        String db0 = ROUTER.executeCommandFileInSeparateDatabase("ns_regex");
+        String db0 = CONTAINER.executeCommandFileInSeparateDatabase("ns_regex");
         // db1: [coll_a1, coll_a2, coll_b1, coll_b2]
-        String db1 = ROUTER.executeCommandFileInSeparateDatabase("ns_regex");
+        String db1 = CONTAINER.executeCommandFileInSeparateDatabase("ns_regex");
         // db2: [coll_a1, coll_a2, coll_b1, coll_b2]
-        String db2 = ROUTER.executeCommandFileInSeparateDatabase("ns_regex");
+        String db2 = CONTAINER.executeCommandFileInSeparateDatabase("ns_regex");
 
         // 2. Test match database: ^(db0|db1)$
         String databaseRegex = String.format("%s|%s", db0, db1);
@@ -173,9 +173,9 @@ public class MongoDBRegexFilterITCase extends MongoDBSourceTestBase {
     public void testMatchSingleQualifiedCollectionPattern() throws Exception {
         // 1. Given collections:
         // db0: [coll_a1, coll_a2, coll_b1, coll_b2]
-        String db0 = ROUTER.executeCommandFileInSeparateDatabase("ns_regex");
+        String db0 = CONTAINER.executeCommandFileInSeparateDatabase("ns_regex");
         // db1: [coll_a1, coll_a2, coll_b1, coll_b2]
-        String db1 = ROUTER.executeCommandFileInSeparateDatabase("ns_regex");
+        String db1 = CONTAINER.executeCommandFileInSeparateDatabase("ns_regex");
 
         // 2. Test match: collection ^(db0|db1)\.coll_a\d?$
         String collectionRegex = String.format("^%s\\.coll_b\\d?$", db0);
@@ -212,9 +212,9 @@ public class MongoDBRegexFilterITCase extends MongoDBSourceTestBase {
     public void testMatchSingleDatabaseWithCollectionPattern() throws Exception {
         // 1. Given collections:
         // db0: [coll_a1, coll_a2, coll_b1, coll_b2]
-        String db0 = ROUTER.executeCommandFileInSeparateDatabase("ns_regex");
+        String db0 = CONTAINER.executeCommandFileInSeparateDatabase("ns_regex");
         // db1: [coll_a1, coll_a2, coll_b1, coll_b2]
-        String db1 = ROUTER.executeCommandFileInSeparateDatabase("ns_regex");
+        String db1 = CONTAINER.executeCommandFileInSeparateDatabase("ns_regex");
 
         // 2. Test match: collection .*coll_b\d?
         String collectionRegex = ".*coll_b\\d?";
@@ -250,7 +250,7 @@ public class MongoDBRegexFilterITCase extends MongoDBSourceTestBase {
     public void testMatchDatabaseAndCollectionContainsDash() throws Exception {
         // 1. Given collections:
         // db0: [coll-a1, coll-a2, coll-b1, coll-b2]
-        String db0 = ROUTER.executeCommandFileInSeparateDatabase("ns-regex");
+        String db0 = CONTAINER.executeCommandFileInSeparateDatabase("ns-regex");
 
         TableResult result = submitTestCase(db0, "coll-a1");
 
@@ -275,7 +275,7 @@ public class MongoDBRegexFilterITCase extends MongoDBSourceTestBase {
                         + " coll_name STRING METADATA FROM 'collection_name' VIRTUAL,"
                         + " PRIMARY KEY (_id) NOT ENFORCED"
                         + ") WITH ("
-                        + ignoreIfNull("hosts", ROUTER.getHostAndPort())
+                        + ignoreIfNull("hosts", CONTAINER.getHostAndPort())
                         + ignoreIfNull("username", FLINK_USER)
                         + ignoreIfNull("password", FLINK_USER_PASSWORD)
                         + ignoreIfNull("database", database)

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
@@ -49,6 +49,7 @@ import static com.ververica.cdc.connectors.base.options.SourceOptions.CHUNK_META
 import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED;
 import static com.ververica.cdc.connectors.mongodb.internal.MongoDBEnvelope.MONGODB_SRV_SCHEME;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.BATCH_SIZE;
+import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.FULL_DOCUMENT_PRE_POST_IMAGE;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.HEARTBEAT_INTERVAL_MILLIS;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_AWAIT_TIME_MILLIS;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_MAX_BATCH_SIZE;
@@ -106,6 +107,9 @@ public class MongoDBTableFactoryTest {
     private static final boolean SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT =
             SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue();
 
+    private static final boolean FULL_DOCUMENT_PRE_POST_IMAGE_ENABLED_DEFAULT =
+            FULL_DOCUMENT_PRE_POST_IMAGE.defaultValue();
+
     @Test
     public void testCommonProperties() {
         Map<String, String> properties = getAllOptions();
@@ -132,7 +136,8 @@ public class MongoDBTableFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_ENABLED_DEFAULT,
                         CHUNK_META_GROUP_SIZE_DEFAULT,
                         SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB_DEFAULT,
-                        SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT);
+                        SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT,
+                        FULL_DOCUMENT_PRE_POST_IMAGE_ENABLED_DEFAULT);
         assertEquals(expectedSource, actualSource);
     }
 
@@ -143,7 +148,7 @@ public class MongoDBTableFactoryTest {
         options.put("connection.options", "replicaSet=test&connectTimeoutMS=300000");
         options.put("scan.startup.mode", "timestamp");
         options.put("scan.startup.timestamp-millis", "1667232000000");
-        options.put("copy.existing.queue.size", "100");
+        options.put("initial.snapshotting.queue.size", "100");
         options.put("batch.size", "101");
         options.put("poll.max.batch.size", "102");
         options.put("poll.await.time.ms", "103");
@@ -152,6 +157,7 @@ public class MongoDBTableFactoryTest {
         options.put("chunk-meta.group.size", "1001");
         options.put("scan.incremental.snapshot.chunk.size.mb", "10");
         options.put("scan.incremental.close-idle-reader.enabled", "true");
+        options.put("scan.full-changelog", "true");
         DynamicTableSource actualSource = createTableSource(SCHEMA, options);
 
         MongoDBTableSource expectedSource =
@@ -174,6 +180,7 @@ public class MongoDBTableFactoryTest {
                         true,
                         1001,
                         10,
+                        true,
                         true);
         assertEquals(expectedSource, actualSource);
     }
@@ -210,7 +217,8 @@ public class MongoDBTableFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_ENABLED_DEFAULT,
                         CHUNK_META_GROUP_SIZE_DEFAULT,
                         SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB_DEFAULT,
-                        SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT);
+                        SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT,
+                        FULL_DOCUMENT_PRE_POST_IMAGE_ENABLED_DEFAULT);
 
         expectedSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
         expectedSource.metadataKeys = Arrays.asList("op_ts", "database_name");

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTimeZoneITCase.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTimeZoneITCase.java
@@ -86,7 +86,7 @@ public class MongoDBTimeZoneITCase extends MongoDBSourceTestBase {
     public void testTemporalTypesWithTimeZone() throws Exception {
         tEnv.getConfig().setLocalTimeZone(ZoneId.of(localTimeZone));
 
-        String database = ROUTER.executeCommandFileInSeparateDatabase("column_type_test");
+        String database = CONTAINER.executeCommandFileInSeparateDatabase("column_type_test");
 
         String sourceDDL =
                 String.format(
@@ -107,7 +107,7 @@ public class MongoDBTimeZoneITCase extends MongoDBSourceTestBase {
                                 + " 'database' = '%s',"
                                 + " 'collection' = '%s'"
                                 + ")",
-                        ROUTER.getHostAndPort(),
+                        CONTAINER.getHostAndPort(),
                         FLINK_USER,
                         FLINK_USER_PASSWORD,
                         database,
@@ -159,7 +159,7 @@ public class MongoDBTimeZoneITCase extends MongoDBSourceTestBase {
     public void testDateAndTimestampToStringWithTimeZone() throws Exception {
         tEnv.getConfig().setLocalTimeZone(ZoneId.of(localTimeZone));
 
-        String database = ROUTER.executeCommandFileInSeparateDatabase("column_type_test");
+        String database = CONTAINER.executeCommandFileInSeparateDatabase("column_type_test");
 
         String sourceDDL =
                 String.format(
@@ -176,7 +176,7 @@ public class MongoDBTimeZoneITCase extends MongoDBSourceTestBase {
                                 + " 'database' = '%s',"
                                 + " 'collection' = '%s'"
                                 + ")",
-                        ROUTER.getHostAndPort(),
+                        CONTAINER.getHostAndPort(),
                         FLINK_USER,
                         FLINK_USER_PASSWORD,
                         database,

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/utils/MongoDBContainer.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/utils/MongoDBContainer.java
@@ -20,164 +20,124 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.containers.wait.strategy.WaitStrategy;
-import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Random;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertNotNull;
 
-/** Mongodb test container. */
-public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
+/** Container for testing MongoDB >= 5.0.3. */
+public class MongoDBContainer extends org.testcontainers.containers.MongoDBContainer {
 
     private static final Logger LOG = LoggerFactory.getLogger(MongoDBContainer.class);
 
-    private static final String DOCKER_IMAGE_NAME = "mongo:5.0.2";
+    private static final Pattern COMMENT_PATTERN = Pattern.compile("^(.*)//.*$");
 
     public static final int MONGODB_PORT = 27017;
-
-    public static final String MONGO_SUPER_USER = "superuser";
-
-    public static final String MONGO_SUPER_PASSWORD = "superpw";
 
     public static final String FLINK_USER = "flinkuser";
 
     public static final String FLINK_USER_PASSWORD = "a1?~!@#$%^&*(){}[]<>.,+_-=/|:;";
 
-    private static final Pattern COMMENT_PATTERN = Pattern.compile("^(.*)//.*$");
-
-    private final ShardingClusterRole clusterRole;
-
-    public MongoDBContainer(Network network) {
-        this(network, ShardingClusterRole.NONE);
+    public MongoDBContainer(String imageName) {
+        super(imageName);
     }
 
-    public MongoDBContainer(Network network, ShardingClusterRole clusterRole) {
-        super(
-                new ImageFromDockerfile()
-                        .withFileFromClasspath("random.key", "docker/mongodb/random.key")
-                        .withFileFromClasspath("setup.js", "docker/mongodb/setup.js")
-                        .withDockerfileFromBuilder(
-                                builder ->
-                                        builder.from(DOCKER_IMAGE_NAME)
-                                                .copy(
-                                                        "setup.js",
-                                                        "/docker-entrypoint-initdb.d/setup.js")
-                                                .copy("random.key", "/data/keyfile/random.key")
-                                                .run("chown mongodb /data/keyfile/random.key")
-                                                .run("chmod 400 /data/keyfile/random.key")
-                                                .env("MONGO_INITDB_ROOT_USERNAME", MONGO_SUPER_USER)
-                                                .env(
-                                                        "MONGO_INITDB_ROOT_PASSWORD",
-                                                        MONGO_SUPER_PASSWORD)
-                                                .env("MONGO_INITDB_DATABASE", "admin")
-                                                .build()));
-        this.clusterRole = clusterRole;
+    @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo, boolean reused) {
+        super.containerIsStarted(containerInfo, reused);
 
-        withNetwork(network);
-        withNetworkAliases(clusterRole.hostname);
-        withExposedPorts(MONGODB_PORT);
-        withCommand(ShardingClusterRole.startupCommand(clusterRole));
-        waitingFor(clusterRole.waitStrategy);
+        final String setupFilePath = "docker/mongodb/setup.js";
+        final URL setupFile = MongoDBContainer.class.getClassLoader().getResource(setupFilePath);
+
+        assertNotNull("Cannot locate " + setupFilePath, setupFile);
+        try {
+            String createUserCommand =
+                    Files.readAllLines(Paths.get(setupFile.toURI())).stream()
+                            .filter(x -> StringUtils.isNotBlank(x) && !x.trim().startsWith("//"))
+                            .map(
+                                    x -> {
+                                        final Matcher m = COMMENT_PATTERN.matcher(x);
+                                        return m.matches() ? m.group(1) : x;
+                                    })
+                            .collect(Collectors.joining(" "));
+            ExecResult execResult =
+                    execInContainer(
+                            "mongosh",
+                            "--eval",
+                            "use admin",
+                            "--eval",
+                            createUserCommand,
+                            "--eval",
+                            "console.log('Flink test user created.\\n');");
+            LOG.info(execResult.getStdout());
+            if (execResult.getExitCode() != 0) {
+                throw new IllegalStateException(
+                        "Execute mongo command failed " + execResult.getStderr());
+            }
+            this.waitingFor(Wait.forLogMessage("Flink test user created.\\s", 1));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    public String getConnectionString(String username, String password) {
-        return String.format(
-                "mongodb://%s:%s@%s:%d",
-                username, password, getContainerIpAddress(), getMappedPort(MONGODB_PORT));
+    @Override
+    public MongoDBContainer withSharding() {
+        return (MongoDBContainer) super.withSharding();
     }
 
-    public String getHostAndPort() {
-        return String.format("%s:%s", getContainerIpAddress(), getMappedPort(MONGODB_PORT));
+    @Override
+    public MongoDBContainer withLogConsumer(Consumer<OutputFrame> consumer) {
+        return (MongoDBContainer) super.withLogConsumer(consumer);
+    }
+
+    @Override
+    public MongoDBContainer withNetwork(Network network) {
+        return (MongoDBContainer) super.withNetwork(network);
+    }
+
+    @Override
+    public MongoDBContainer withNetworkAliases(String... aliases) {
+        return (MongoDBContainer) super.withNetworkAliases(aliases);
     }
 
     public void executeCommand(String command) {
         try {
             LOG.info("Executing mongo command: {}", command);
-            ExecResult execResult =
-                    execInContainer(
-                            "mongo",
-                            "-u",
-                            MONGO_SUPER_USER,
-                            "-p",
-                            MONGO_SUPER_PASSWORD,
-                            "--eval",
-                            command);
+            ExecResult execResult = execInContainer("mongosh", "--eval", command);
             LOG.info(execResult.getStdout());
             if (execResult.getExitCode() != 0) {
                 throw new IllegalStateException(
-                        "Execute mongo command failed " + execResult.getStdout());
+                        "Execute mongo command failed " + execResult.getStderr());
             }
         } catch (InterruptedException | IOException e) {
             throw new IllegalStateException("Execute mongo command failed", e);
         }
     }
 
-    @Override
-    protected void containerIsStarted(InspectContainerResponse containerInfo) {
-        LOG.info("Preparing a MongoDB Container with sharding cluster role {}...", clusterRole);
-        if (clusterRole != ShardingClusterRole.ROUTER) {
-            initReplicaSet();
-        } else {
-            initShard();
+    public String executeCommandInDatabase(String command, String databaseName) {
+        try {
+            executeCommand(String.format("db = db.getSiblingDB('%s');\n", databaseName) + command);
+            return databaseName;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 
-    protected void initReplicaSet() {
-        LOG.info("Initializing a single node replica set...");
-        executeCommand(
-                String.format(
-                        "rs.initiate({ _id : '%s', configsvr: %s, members: [{ _id: 0, host: '%s:%d'}]})",
-                        clusterRole.replicaSetName,
-                        clusterRole == ShardingClusterRole.CONFIG,
-                        clusterRole.hostname,
-                        MONGODB_PORT));
-
-        LOG.info("Waiting for single node replica set initialized...");
-        executeCommand(
-                String.format(
-                        "var attempt = 0; "
-                                + "while"
-                                + "(%s) "
-                                + "{ "
-                                + "if (attempt > %d) {quit(1);} "
-                                + "print('%s ' + attempt); sleep(100);  attempt++; "
-                                + " }",
-                        "db.runCommand( { isMaster: 1 } ).ismaster==false",
-                        60,
-                        "An attempt to await for a single node replica set initialization:"));
-    }
-
-    protected void initShard() {
-        LOG.info("Initializing a sharded cluster...");
-        // decrease chunk size from default 64mb to 1mb to make splitter test easier.
-        executeCommand(
-                "db.getSiblingDB('config').settings.updateOne(\n"
-                        + "   { _id: \"chunksize\" },\n"
-                        + "   { $set: { _id: \"chunksize\", value: 1 } },\n"
-                        + "   { upsert: true }\n"
-                        + ");");
-        executeCommand(
-                String.format(
-                        "sh.addShard('%s/%s:%d')",
-                        ShardingClusterRole.SHARD.replicaSetName,
-                        ShardingClusterRole.SHARD.hostname,
-                        MONGODB_PORT));
-    }
-
-    /** Executes a mongo command file. */
-    public String executeCommandFile(String fileNameIgnoreSuffix) {
-        return executeCommandFileInDatabase(fileNameIgnoreSuffix, fileNameIgnoreSuffix);
+    /** Executes a mongo command in separate database. */
+    public String executeCommandInSeparateDatabase(String command, String baseName) {
+        return executeCommandInDatabase(
+                command, baseName + "_" + Integer.toUnsignedString(new Random().nextInt(), 36));
     }
 
     /** Executes a mongo command file in separate database. */
@@ -215,52 +175,12 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
         }
     }
 
-    /** A MongoDB sharded cluster roles. */
-    public enum ShardingClusterRole {
-        // Config servers store metadata and configuration settings for the cluster.
-        CONFIG("config0", "rs0-config", Wait.forLogMessage(".*[Ww]aiting for connections.*", 2)),
+    public String getConnectionString() {
+        return String.format(
+                "mongodb://%s:%d", getContainerIpAddress(), getMappedPort(MONGODB_PORT));
+    }
 
-        // Each shard contains a subset of the sharded data. Each shard can be deployed as a replica
-        // set.
-        SHARD("shard0", "rs0-shard", Wait.forLogMessage(".*[Ww]aiting for connections.*", 2)),
-
-        // The mongos acts as a query router, providing an interface between client applications and
-        // the sharded cluster.
-        ROUTER("router0", null, Wait.forLogMessage(".*[Ww]aiting for connections.*", 1)),
-
-        // None sharded cluster.
-        NONE("mongo0", "rs0", Wait.forLogMessage(".*Replication has not yet been configured.*", 1));
-
-        private final String hostname;
-        private final String replicaSetName;
-        private final WaitStrategy waitStrategy;
-
-        ShardingClusterRole(String hostname, String replicaSetName, WaitStrategy waitStrategy) {
-            this.hostname = hostname;
-            this.replicaSetName = replicaSetName;
-            this.waitStrategy = waitStrategy;
-        }
-
-        public static String startupCommand(ShardingClusterRole clusterRole) {
-            switch (clusterRole) {
-                case CONFIG:
-                    return String.format(
-                            "mongod --configsvr --port %d --replSet %s --keyFile /data/keyfile/random.key",
-                            MONGODB_PORT, clusterRole.replicaSetName);
-                case SHARD:
-                    return String.format(
-                            "mongod --shardsvr --port %d --replSet %s --keyFile /data/keyfile/random.key",
-                            MONGODB_PORT, clusterRole.replicaSetName);
-                case ROUTER:
-                    return String.format(
-                            "mongos --configdb %s/%s:%d --bind_ip_all --keyFile /data/keyfile/random.key",
-                            CONFIG.replicaSetName, CONFIG.hostname, MONGODB_PORT);
-                case NONE:
-                default:
-                    return String.format(
-                            "mongod --port %d --replSet %s --keyFile /data/keyfile/random.key",
-                            MONGODB_PORT, NONE.replicaSetName);
-            }
-        }
+    public String getHostAndPort() {
+        return String.format("%s:%s", getContainerIpAddress(), getMappedPort(MONGODB_PORT));
     }
 }


### PR DESCRIPTION
This PR comes with the following changes:

* Updates `org.mongodb.kafka` and `mongodb-driver-sync` to fit MongoDB 6, and did minor fixes to handle breaking changes of dependencies.

* Adds a MongoDB CDC config `full.document.pre.post.image` to switch pre- and post-image retrieving feature on / off. Requires `scan.incremental.snapshot.enabled = true`.

* Generates normal `UPDATE BEFORE` and `DELETE` events when `full.document.pre.post.image = true`.

* Provides `UPDATE AFTER` events by post-image atomically when `full.document.pre.post.image = true`.

* Creates `MongoDBFullDocumentBeforeChangeITCase` to test its functionality.

> Declared a new dependency (`org.testcontainers:mongodb`) to implement `MongoDBContainer` that works with MongoDB 6. Original version was moved to `LegacyMongoDBContainer` and still used by `Legacy-` testcases.