### PR TITLE
Fix  the  PostgresSourceBuilder's class can't be init with datastream api

### DIFF
--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresSourceBuilder.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresSourceBuilder.java
@@ -49,7 +49,7 @@ public class PostgresSourceBuilder<T> {
     private final PostgresSourceConfigFactory configFactory = new PostgresSourceConfigFactory();
     private DebeziumDeserializationSchema<T> deserializer;
 
-    private PostgresSourceBuilder() {}
+    public PostgresSourceBuilder() {}
 
     /**
      * The name of the Postgres logical decoding plug-in installed on the server. Supported values


### PR DESCRIPTION
if the build function is  private ,user can not init the PostgresSourceBuilder's class.