### PR TITLE
[mongodb] mongo-cdc connector cleanup

### DIFF
--- a/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
+++ b/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
@@ -440,6 +440,8 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
                 (Gauge<Long>) () -> debeziumChangeFetcher.getEmitDelay());
         metricGroup.gauge(
                 "sourceIdleTime", (Gauge<Long>) () -> debeziumChangeFetcher.getIdleTime());
+        metricGroup.gauge(
+                "pendingRecords", (Gauge<Long>) () -> debeziumChangeFetcher.getPendingRecords());
 
         // start the real debezium consumer
         try {

--- a/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/internal/MetricRecord.java
+++ b/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/internal/MetricRecord.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.debezium.internal;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+/** Records used for carrying metric information. */
+public class MetricRecord extends SourceRecord {
+
+    private final String metricKey;
+
+    private final Object metricValue;
+
+    public MetricRecord(String metricKey, Object metricValue) {
+        super(null, null, null, null, null);
+        this.metricKey = metricKey;
+        this.metricValue = metricValue;
+    }
+
+    public String getMetricKey() {
+        return metricKey;
+    }
+
+    public Object getMetricValue() {
+        return metricValue;
+    }
+}

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/MongoDBSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/MongoDBSource.java
@@ -17,7 +17,6 @@
 package com.ververica.cdc.connectors.mongodb.source;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
 
@@ -59,8 +58,8 @@ import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
  *
  * @param <T> the output type of the source.
  */
-@Internal
 @Experimental
+@PublicEvolving
 public class MongoDBSource<T> extends IncrementalSource<T, MongoDBSourceConfig> {
 
     private static final long serialVersionUID = 1L;

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBConnectorDeserializationSchema.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBConnectorDeserializationSchema.java
@@ -16,6 +16,7 @@
 
 package com.ververica.cdc.connectors.mongodb.table;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericArrayData;
@@ -80,6 +81,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * Deserialization schema from Mongodb ChangeStreamDocument to Flink Table/SQL internal data
  * structure {@link RowData}.
  */
+@PublicEvolving
 public class MongoDBConnectorDeserializationSchema
         implements DebeziumDeserializationSchema<RowData> {
 

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBConnectorFullChangelogDeserializationSchema.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBConnectorFullChangelogDeserializationSchema.java
@@ -16,6 +16,8 @@
 
 package com.ververica.cdc.connectors.mongodb.table;
 
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -37,6 +39,8 @@ import java.time.ZoneId;
  * Deserialization schema from Mongodb ChangeStreamDocument to Flink Table/SQL internal data that
  * produces full changelog mode structure {@link RowData}.
  */
+@Experimental
+@PublicEvolving
 public class MongoDBConnectorFullChangelogDeserializationSchema
         extends MongoDBConnectorDeserializationSchema {
 

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/utils/BsonUtilsTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/utils/BsonUtilsTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mongodb.source.utils;
+
+import org.bson.BsonArray;
+import org.bson.BsonBinary;
+import org.bson.BsonBoolean;
+import org.bson.BsonDateTime;
+import org.bson.BsonDecimal128;
+import org.bson.BsonDocument;
+import org.bson.BsonJavaScriptWithScope;
+import org.bson.BsonNull;
+import org.bson.BsonRegularExpression;
+import org.bson.BsonString;
+import org.bson.BsonTimestamp;
+import org.bson.types.Decimal128;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+/** Unit test cases for <code>BsonUtils</code> utility class. */
+public class BsonUtilsTest {
+
+    @Test
+    public void testCompareBsonValue() {
+        // test compare Decimal128
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonDecimal128(Decimal128.parse("18")),
+                                new BsonDecimal128(Decimal128.parse("17")))
+                        > 0);
+        assertEquals(
+                0,
+                BsonUtils.compareBsonValue(
+                        new BsonDecimal128(Decimal128.parse("17")),
+                        new BsonDecimal128(Decimal128.parse("17"))));
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonDecimal128(Decimal128.parse("16")),
+                                new BsonDecimal128(Decimal128.parse("17")))
+                        < 0);
+
+        // test compare String
+        assertTrue(
+                BsonUtils.compareBsonValue(new BsonString("apple"), new BsonString("banana")) < 0);
+
+        assertEquals(
+                0, BsonUtils.compareBsonValue(new BsonString("banana"), new BsonString("banana")));
+
+        assertTrue(
+                BsonUtils.compareBsonValue(new BsonString("cherry"), new BsonString("banana")) > 0);
+
+        // test compare Array
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonArray(
+                                        Arrays.asList(
+                                                new BsonString("fruit"), new BsonString("apple"))),
+                                new BsonArray(
+                                        Arrays.asList(
+                                                new BsonString("fruit"), new BsonString("banana"))))
+                        < 0);
+
+        assertEquals(
+                0,
+                BsonUtils.compareBsonValue(
+                        new BsonArray(
+                                Arrays.asList(new BsonString("fruit"), new BsonString("banana"))),
+                        new BsonArray(
+                                Arrays.asList(new BsonString("fruit"), new BsonString("banana")))));
+
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonArray(
+                                        Arrays.asList(
+                                                new BsonString("fruit"), new BsonString("cherry"))),
+                                new BsonArray(
+                                        Arrays.asList(
+                                                new BsonString("fruit"), new BsonString("banana"))))
+                        > 0);
+
+        // test compare Binary
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonBinary("apple".getBytes()),
+                                new BsonBinary("banana".getBytes()))
+                        < 0);
+
+        assertEquals(
+                0,
+                BsonUtils.compareBsonValue(
+                        new BsonBinary("banana".getBytes()), new BsonBinary("banana".getBytes())));
+
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonBinary("cherry".getBytes()),
+                                new BsonBinary("banana".getBytes()))
+                        > 0);
+
+        // test compare Boolean
+        assertTrue(BsonUtils.compareBsonValue(new BsonBoolean(false), new BsonBoolean(true)) < 0);
+
+        assertEquals(0, BsonUtils.compareBsonValue(new BsonBoolean(true), new BsonBoolean(true)));
+
+        assertTrue(BsonUtils.compareBsonValue(new BsonBoolean(true), new BsonBoolean(false)) > 0);
+
+        // test compare DateTime
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonDateTime(1600000000), new BsonDateTime(1700000000))
+                        < 0);
+
+        assertEquals(
+                0,
+                BsonUtils.compareBsonValue(
+                        new BsonDateTime(1700000000), new BsonDateTime(1700000000)));
+
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonDateTime(1800000000), new BsonDateTime(1700000000))
+                        > 0);
+
+        // test compare document
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonDocument("fruit", new BsonString("apple")),
+                                new BsonDocument("fruit", new BsonString("banana")))
+                        < 0);
+
+        assertEquals(
+                0,
+                BsonUtils.compareBsonValue(
+                        new BsonDocument("fruit", new BsonString("banana")),
+                        new BsonDocument("fruit", new BsonString("banana"))));
+
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonDocument("fruit", new BsonString("cherry")),
+                                new BsonDocument("fruit", new BsonString("banana")))
+                        > 0);
+
+        // test compare Timestamp
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonTimestamp(1600000000), new BsonTimestamp(1700000000))
+                        < 0);
+
+        assertEquals(
+                0,
+                BsonUtils.compareBsonValue(
+                        new BsonTimestamp(1700000000), new BsonTimestamp(1700000000)));
+
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonTimestamp(1800000000), new BsonTimestamp(1700000000))
+                        > 0);
+
+        // test compare RegEx
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonRegularExpression("[a-xA-X]"),
+                                new BsonRegularExpression("[b-yB-Y]"))
+                        < 0);
+
+        assertEquals(
+                0,
+                BsonUtils.compareBsonValue(
+                        new BsonRegularExpression("[b-yB-Y]"),
+                        new BsonRegularExpression("[b-yB-Y]")));
+
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonRegularExpression("[c-zC-Z]"),
+                                new BsonRegularExpression("[b-yB-Y]"))
+                        > 0);
+
+        // test compare JavaScript
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonJavaScriptWithScope(
+                                        "console.log('apple');", new BsonDocument()),
+                                new BsonJavaScriptWithScope(
+                                        "console.log('banana');", new BsonDocument()))
+                        < 0);
+
+        assertEquals(
+                0,
+                BsonUtils.compareBsonValue(
+                        new BsonJavaScriptWithScope("console.log('banana');", new BsonDocument()),
+                        new BsonJavaScriptWithScope("console.log('banana');", new BsonDocument())));
+
+        assertTrue(
+                BsonUtils.compareBsonValue(
+                                new BsonJavaScriptWithScope(
+                                        "console.log('cherry');", new BsonDocument()),
+                                new BsonJavaScriptWithScope(
+                                        "console.log('banana');", new BsonDocument()))
+                        > 0);
+
+        // test inter-type comparison
+        assertTrue(BsonUtils.compareBsonValue(new BsonNull(), new BsonString("")) < 0);
+
+        assertTrue(BsonUtils.compareBsonValue(new BsonBoolean(true), new BsonString("")) > 0);
+
+        // test null comparison
+        assertEquals(0, BsonUtils.compareBsonValue(new BsonNull(), new BsonNull()));
+    }
+}


### PR DESCRIPTION
This PR comes with minor fixes in MongoDB CDC connector.

* Add missing class visibility annotations.
* Add unit test cases for utility class to improve coverage.
* Add `pendingRecords` monitoring metrics for legacy source function. (Source with modern API is not supported since it isn't based on `mongodb-kafka-connector`.)
> In this primitive implementation, I added a `MetricRecord` subclass to carry metric data. Needs more discussion on this.