### PR TITLE
[mongodb] Add `pendingRecords` and `numRecordsInErrors` metrics for legacy source

### DIFF
--- a/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
+++ b/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
@@ -47,6 +47,7 @@ import com.ververica.cdc.debezium.internal.FlinkDatabaseSchemaHistory;
 import com.ververica.cdc.debezium.internal.FlinkOffsetBackingStore;
 import com.ververica.cdc.debezium.internal.Handover;
 import com.ververica.cdc.debezium.internal.SchemaRecord;
+import com.ververica.cdc.debezium.utils.DebeziumSourceMetricConstants;
 import io.debezium.document.DocumentReader;
 import io.debezium.document.DocumentWriter;
 import io.debezium.embedded.Connect;
@@ -433,14 +434,20 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
                 (MetricGroup) getMetricGroupMethod.invoke(getRuntimeContext());
 
         metricGroup.gauge(
-                "currentFetchEventTimeLag",
+                DebeziumSourceMetricConstants.CURRENT_FETCH_EVENT_TIME_LAG,
                 (Gauge<Long>) () -> debeziumChangeFetcher.getFetchDelay());
         metricGroup.gauge(
-                "currentEmitEventTimeLag",
+                DebeziumSourceMetricConstants.CURRENT_EMIT_EVENT_TIME_LAG,
                 (Gauge<Long>) () -> debeziumChangeFetcher.getEmitDelay());
         metricGroup.gauge(
-                "sourceIdleTime", (Gauge<Long>) () -> debeziumChangeFetcher.getIdleTime());
-
+                DebeziumSourceMetricConstants.SOURCE_IDLE_TIME,
+                (Gauge<Long>) () -> debeziumChangeFetcher.getIdleTime());
+        metricGroup.gauge(
+                DebeziumSourceMetricConstants.PENDING_RECORDS,
+                (Gauge<Long>) () -> debeziumChangeFetcher.getPendingRecords());
+        metricGroup.gauge(
+                DebeziumSourceMetricConstants.NUM_RECORDS_IN_ERRORS,
+                (Gauge<Long>) () -> debeziumChangeFetcher.getNumRecordInErrors());
         // start the real debezium consumer
         try {
             debeziumChangeFetcher.runFetchLoop();

--- a/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/internal/DebeziumChangeFetcher.java
+++ b/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/internal/DebeziumChangeFetcher.java
@@ -260,9 +260,10 @@ public class DebeziumChangeFetcher<T> {
             }
             try {
                 deserialization.deserialize(record, debeziumCollector);
-            } catch (Exception e) {
+            } catch (Throwable t) {
                 numRecordInErrors.incrementAndGet();
-                throw e;
+                LOG.error("Failed to deserialize record {}", record, t);
+                throw t;
             }
 
             if (isInDbSnapshotPhase && !isSnapshotRecord(record)) {

--- a/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/internal/MetricRecord.java
+++ b/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/internal/MetricRecord.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.debezium.internal;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+/** Records used for carrying metric information. */
+public class MetricRecord extends SourceRecord {
+
+    private final String metricKey;
+
+    private final Object metricValue;
+
+    public MetricRecord(String metricKey, Object metricValue) {
+        super(null, null, null, null, null);
+        this.metricKey = metricKey;
+        this.metricValue = metricValue;
+    }
+
+    public String getMetricKey() {
+        return metricKey;
+    }
+
+    public Object getMetricValue() {
+        return metricValue;
+    }
+}

--- a/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/utils/DebeziumSourceMetricConstants.java
+++ b/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/utils/DebeziumSourceMetricConstants.java
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package com.ververica.cdc.connectors.base.source.metrics;
+package com.ververica.cdc.debezium.utils;
 
-/** A collection of Source Reader metrics related constant strings. */
-public class SourceReaderMetricConstants {
-
+/** A collection of Source metrics related constant strings. */
+public class DebeziumSourceMetricConstants {
     public static final String SOURCE_IDLE_TIME = "sourceIdleTime";
     public static final String CURRENT_FETCH_EVENT_TIME_LAG = "currentFetchEventTimeLag";
     public static final String CURRENT_EMIT_EVENT_TIME_LAG = "currentEmitEventTimeLag";


### PR DESCRIPTION
This PR contains following changes:

* Added `pendingRecords` and `numRecordsInErrors` for CDC connector metrics
* Registered above two metrics in MongoSource (Legacy)
* Registered `numRecordsInErrors` metric in MongoSource (Modern)

Some concerns:

* `pendingRecords` now yields how many records `ConnectorSourceTask::poll()` received. However it won't exceed `poll.max.batch.size`, so it won't be accurate when pending data is huge.
* Currently, metric guage registering is hard-encoded in base classes, so this change affects every CDC connector. Maybe we should allow each connector decide its metrics?