### PR TITLE
[doc] fix errors in PostgresParallelSourceExample

### DIFF
--- a/docs/content/connectors/postgres-cdc.md
+++ b/docs/content/connectors/postgres-cdc.md
@@ -429,7 +429,7 @@ public class PostgresParallelSourceExample {
                 new JsonDebeziumDeserializationSchema();
 
         JdbcIncrementalSource<String> postgresIncrementalSource =
-                new PostgresSourceBuilder<String>()
+                PostgresSourceBuilder.PostgresIncrementalSource.<String>builder()
                         .hostname("localhost")
                         .port(5432)
                         .database("postgres")


### PR DESCRIPTION
PostgresSourceBuilder is private, failed to compile.