### PR TITLE
[Oracle] Fix option to not include.schema.changes

### DIFF
--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfigFactory.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfigFactory.java
@@ -83,6 +83,7 @@ public class OracleSourceConfigFactory extends JdbcSourceConfigFactory {
         props.setProperty("connect.timeout.ms", String.valueOf(connectTimeout.toMillis()));
         // disable tombstones
         props.setProperty("tombstones.on.delete", String.valueOf(false));
+        props.setProperty("include.schema.changes", String.valueOf(includeSchemaChanges));
 
         if (url != null) {
             props.setProperty("database.url", url);


### PR DESCRIPTION
With this fix it is possible to not include schema changes in the Oracle CDC connector, as mentioned in issue #2350.