### PR TITLE
Remove `SOURCE_IDLE_TIME` and `CURRENT_EMIT_EVENT_TIME_LAG` metrics

### DIFF
--- a/docs/content/about.md
+++ b/docs/content/about.md
@@ -34,6 +34,7 @@ The following table shows the version mapping between Flink<sup>®</sup> CDC Con
 | <font color="DarkCyan">2.2.*</font> |                                                                     <font color="MediumVioletRed">1.13.\*</font>, <font color="MediumVioletRed">1.14.\*</font>                                                                      |
 | <font color="DarkCyan">2.3.*</font> |                        <font color="MediumVioletRed">1.13.\*</font>, <font color="MediumVioletRed">1.14.\*</font>, <font color="MediumVioletRed">1.15.\*</font>, <font color="MediumVioletRed">1.16.0</font>                        |
 | <font color="DarkCyan">2.4.*</font> | <font color="MediumVioletRed">1.13.\*</font>, <font color="MediumVioletRed">1.14.\*</font>, <font color="MediumVioletRed">1.15.\*</font>, <font color="MediumVioletRed">1.16.\*</font>, <font color="MediumVioletRed">1.17.0</font> |
+| <font color="DarkCyan">2.5.*</font> |                        <font color="MediumVioletRed">1.14.\*</font>, <font color="MediumVioletRed">1.15.\*</font>, <font color="MediumVioletRed">1.16.\*</font>, <font color="MediumVioletRed">1.17.0</font>                        |
 
 ## Features
 

--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/metrics/SourceReaderMetrics.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/metrics/SourceReaderMetrics.java
@@ -29,23 +29,10 @@ public class SourceReaderMetrics {
     private final MetricGroup metricGroup;
 
     /**
-     * The last record processing time, which is updated after {@link IncrementalSourceReader}
-     * fetches a batch of data. It's mainly used to report metrics sourceIdleTime for sourceIdleTime
-     * = System.currentTimeMillis() - processTime.
-     */
-    private volatile long processTime = 0L;
-
-    /**
      * currentFetchEventTimeLag = FetchTime - messageTimestamp, where the FetchTime is the time the
      * record fetched into the source operator.
      */
     private volatile long fetchDelay = 0L;
-
-    /**
-     * emitDelay = EmitTime - messageTimestamp, where the EmitTime is the time the record leaves the
-     * source operator.
-     */
-    private volatile long emitDelay = 0L;
 
     /**
      * The number of records that have not been fetched by the source. e.g. the available records
@@ -65,11 +52,6 @@ public class SourceReaderMetrics {
                 SourceReaderMetricConstants.CURRENT_FETCH_EVENT_TIME_LAG,
                 (Gauge<Long>) this::getFetchDelay);
         metricGroup.gauge(
-                SourceReaderMetricConstants.CURRENT_EMIT_EVENT_TIME_LAG,
-                (Gauge<Long>) this::getEmitDelay);
-        metricGroup.gauge(
-                SourceReaderMetricConstants.SOURCE_IDLE_TIME, (Gauge<Long>) this::getIdleTime);
-        metricGroup.gauge(
                 SourceReaderMetricConstants.PENDING_RECORDS, (Gauge<Long>) this::getPendingRecords);
         metricGroup.gauge(
                 SourceReaderMetricConstants.NUM_RECORDS_IN_ERRORS,
@@ -80,18 +62,6 @@ public class SourceReaderMetrics {
         return fetchDelay;
     }
 
-    public long getEmitDelay() {
-        return emitDelay;
-    }
-
-    public long getIdleTime() {
-        // no previous process time at the beginning, return 0 as idle time
-        if (processTime == 0) {
-            return 0;
-        }
-        return System.currentTimeMillis() - processTime;
-    }
-
     public long getPendingRecords() {
         return pendingRecords;
     }
@@ -100,16 +70,8 @@ public class SourceReaderMetrics {
         return numRecordsInErrors.get();
     }
 
-    public void recordProcessTime(long processTime) {
-        this.processTime = processTime;
-    }
-
     public void recordFetchDelay(long fetchDelay) {
         this.fetchDelay = fetchDelay;
-    }
-
-    public void recordEmitDelay(long emitDelay) {
-        this.emitDelay = emitDelay;
     }
 
     public void recordPendingRecords(long pendingRecords) {

--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/IncrementalSourceRecordEmitter.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/IncrementalSourceRecordEmitter.java
@@ -155,9 +155,6 @@ public class IncrementalSourceRecordEmitter<T>
     }
 
     protected void reportMetrics(SourceRecord element) {
-        long now = System.currentTimeMillis();
-        // record the latest process time
-        sourceReaderMetrics.recordProcessTime(now);
         Long messageTimestamp = getMessageTimestamp(element);
 
         if (messageTimestamp != null && messageTimestamp > 0L) {
@@ -166,8 +163,6 @@ public class IncrementalSourceRecordEmitter<T>
             if (fetchTimestamp != null) {
                 sourceReaderMetrics.recordFetchDelay(fetchTimestamp - messageTimestamp);
             }
-            // report emit delay
-            sourceReaderMetrics.recordEmitDelay(now - messageTimestamp);
         }
     }
 

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBRecordEmitter.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBRecordEmitter.java
@@ -101,9 +101,6 @@ public final class MongoDBRecordEmitter<T> extends IncrementalSourceRecordEmitte
 
     @Override
     protected void reportMetrics(SourceRecord element) {
-        long now = System.currentTimeMillis();
-        // record the latest process time
-        sourceReaderMetrics.recordProcessTime(now);
         Long messageTimestamp = getMessageTimestamp(element);
 
         if (messageTimestamp != null && messageTimestamp > 0L) {
@@ -112,8 +109,6 @@ public final class MongoDBRecordEmitter<T> extends IncrementalSourceRecordEmitte
             if (fetchTimestamp != null && fetchTimestamp >= messageTimestamp) {
                 sourceReaderMetrics.recordFetchDelay(fetchTimestamp - messageTimestamp);
             }
-            // report emit delay
-            sourceReaderMetrics.recordEmitDelay(now - messageTimestamp);
         }
     }
 }


### PR DESCRIPTION
[Flink operators](https://github.com/apache/flink/blob/fc3035b40fbdf32694eb90c78c4dd68608c1c9d1/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSourceReaderMetricGroup.java#L62-L63) have registered these metrics. Connectors don't have to report them correspondingly. This PR removes these metrics from CDC connectors.

Note: This feature was added in Flink 1.14+ ([FLINK-23652](https://issues.apache.org/jira/browse/FLINK-23652)), so with 1.13 these metrics will be missing.