### PR TITLE
[flink-connector-mysql-cdc] fix snapshot read thread exit due to erro…

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
@@ -174,7 +174,7 @@ public class SnapshotSplitReader implements DebeziumReader<SourceRecords, MySqlS
                                                     "Read snapshot for mysql split %s fail",
                                                     currentSnapshotSplit)));
                         }
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         setReadException(e);
                     }
                 });


### PR DESCRIPTION
Currently when OutOfMemoryError or other Error not Exception caused in fetcher thread, outside will not know it but the fetcher thread is exit; So this patch change the Exception catch to Throwable which will catch OutOfMemoryError and something else.