### PR TITLE
[mysql] fix com.ververica.cdc.connectors.mysql.source.MySqlSourceExampleTest#testConsumingAllEvents

### DIFF
--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceExampleTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceExampleTest.java
@@ -44,6 +44,7 @@ public class MySqlSourceExampleTest extends MySqlSourceTestBase {
                         .password(inventoryDatabase.getPassword())
                         .serverId("5401-5404")
                         .deserializer(new JsonDebeziumDeserializationSchema())
+                        .serverTimeZone("UTC")
                         .includeSchemaChanges(true) // output the schema changes as well
                         .build();
 


### PR DESCRIPTION
before:
![image](https://github.com/ververica/flink-cdc-connectors/assets/49054376/8359ad20-f2d8-48fd-9e68-528d691b5627)
after:
<img width="1370" alt="image" src="https://github.com/ververica/flink-cdc-connectors/assets/49054376/bd19a63a-9988-4594-a928-084dda08dc4a">
