### PR TITLE
[ci] avoid `tikv disk full` failure

### DIFF
--- a/flink-cdc-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/TiDBE2eITCase.java
+++ b/flink-cdc-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/TiDBE2eITCase.java
@@ -71,7 +71,7 @@ public class TiDBE2eITCase extends FlinkContainerTestEnvironment {
 
     @ClassRule
     public static final GenericContainer<?> PD =
-            new GenericContainer<>("pingcap/pd:v6.0.0")
+            new GenericContainer<>("pingcap/pd:v6.1.0")
                     .withExposedPorts(PD_PORT)
                     .withFileSystemBind("src/test/resources/docker/tidb/pd.toml", "/pd.toml")
                     .withCommand(
@@ -92,7 +92,7 @@ public class TiDBE2eITCase extends FlinkContainerTestEnvironment {
 
     @ClassRule
     public static final GenericContainer<?> TIKV =
-            new GenericContainer<>("pingcap/tikv:v6.0.0")
+            new GenericContainer<>("pingcap/tikv:v6.1.0")
                     .withExposedPorts(TIKV_PORT)
                     .withFileSystemBind("src/test/resources/docker/tidb/tikv.toml", "/tikv.toml")
                     .withCommand(
@@ -110,7 +110,7 @@ public class TiDBE2eITCase extends FlinkContainerTestEnvironment {
 
     @ClassRule
     public static final GenericContainer<?> TIDB =
-            new GenericContainer<>("pingcap/tidb:v6.0.0")
+            new GenericContainer<>("pingcap/tidb:v6.1.0")
                     .withExposedPorts(TIDB_PORT)
                     .withFileSystemBind("src/test/resources/docker/tidb/tidb.toml", "/tidb.toml")
                     .withCommand(

--- a/flink-connector-tidb-cdc/src/test/java/com/ververica/cdc/connectors/tidb/TiDBTestBase.java
+++ b/flink-connector-tidb-cdc/src/test/java/com/ververica/cdc/connectors/tidb/TiDBTestBase.java
@@ -72,7 +72,7 @@ public class TiDBTestBase extends AbstractTestBase {
 
     @ClassRule
     public static final GenericContainer<?> PD =
-            new FixedHostPortGenericContainer<>("pingcap/pd:v6.0.0")
+            new FixedHostPortGenericContainer<>("pingcap/pd:v6.1.0")
                     .withFileSystemBind("src/test/resources/config/pd.toml", "/pd.toml")
                     .withFixedExposedPort(pdPort, PD_PORT_ORIGIN)
                     .withCommand(
@@ -92,7 +92,7 @@ public class TiDBTestBase extends AbstractTestBase {
 
     @ClassRule
     public static final GenericContainer<?> TIKV =
-            new FixedHostPortGenericContainer<>("pingcap/tikv:v6.0.0")
+            new FixedHostPortGenericContainer<>("pingcap/tikv:v6.1.0")
                     .withFixedExposedPort(TIKV_PORT_ORIGIN, TIKV_PORT_ORIGIN)
                     .withFileSystemBind("src/test/resources/config/tikv.toml", "/tikv.toml")
                     .withCommand(
@@ -110,7 +110,7 @@ public class TiDBTestBase extends AbstractTestBase {
 
     @ClassRule
     public static final GenericContainer<?> TIDB =
-            new GenericContainer<>("pingcap/tidb:v6.0.0")
+            new GenericContainer<>("pingcap/tidb:v6.1.0")
                     .withExposedPorts(TIDB_PORT)
                     .withFileSystemBind("src/test/resources/config/tidb.toml", "/tidb.toml")
                     .withCommand(


### PR DESCRIPTION
a test branch to check whether this image can avoid `tikv disk full` like 
https://github.com/ververica/flink-cdc-connectors/pull/2400/checks?check_run_id=15945681519
since this issue had been resolved in https://github.com/tikv/tikv/pull/10264. 
will try to verify whether 6.1.0 is supportable and update the doc later.
