### PR TITLE
[postgres] close jdbc connection when close replication connection

### DIFF
--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresDialect.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresDialect.java
@@ -100,10 +100,9 @@ public class PostgresDialect implements JdbcDataSourceDialect {
         return (PostgresConnection) openJdbcConnection(sourceConfig);
     }
 
-    public PostgresReplicationConnection openPostgresReplicationConnection() {
+    public PostgresReplicationConnection openPostgresReplicationConnection(
+            PostgresConnection jdbcConnection) {
         try {
-            PostgresConnection jdbcConnection =
-                    (PostgresConnection) openJdbcConnection(sourceConfig);
             PostgresConnectorConfig pgConnectorConfig = sourceConfig.getDbzConnectorConfig();
             TopicSelector<TableId> topicSelector = PostgresTopicSelector.create(pgConnectorConfig);
             PostgresConnection.PostgresValueConverterBuilder valueConverterBuilder =

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/enumerator/PostgresSourceEnumerator.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/enumerator/PostgresSourceEnumerator.java
@@ -78,9 +78,9 @@ public class PostgresSourceEnumerator extends IncrementalSourceEnumerator {
             return;
         }
 
-        try {
+        try (PostgresConnection connection = postgresDialect.openJdbcConnection()) {
             PostgresReplicationConnection replicationConnection =
-                    postgresDialect.openPostgresReplicationConnection();
+                    postgresDialect.openPostgresReplicationConnection(connection);
             replicationConnection.createReplicationSlot();
             replicationConnection.close(false);
         } catch (Throwable t) {

--- a/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/testutils/UniqueDatabase.java
+++ b/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/testutils/UniqueDatabase.java
@@ -23,7 +23,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
@@ -153,10 +152,6 @@ public class UniqueDatabase {
         } catch (final Exception e) {
             throw new IllegalStateException(e);
         }
-    }
-
-    public Connection getJdbcConnection() throws SQLException {
-        return DriverManager.getConnection(container.getJdbcUrl(), username, password);
     }
 
     private String convertSQL(final String sql) {


### PR DESCRIPTION
### What is the purpose of the change
In PostgresSourceEnumerator#createSlotForGlobalStreamSplit, PostgresReplicationConnection will be closed after create slot.
However, not any PostgresReplicationConnection.close will close the PostgresConnection in messageDecoder, which is generated by Hikari pool and is passed to PostgresReplicationConnection.

See AbstractMessageDecoder.close:
*  NonStreamingWal2JsonMessageDecoder.close： do nothing
* PgProtoMessageDecoder.close: do nothing
* StreamingWal2JsonMessageDecoder.close: do nothing
* PgOutputMessageDecoder.close: **the only one to close jdbc connection**.

Thus, the Hikari pool will be full if there is too much pg source.

### Verified this problem
Debug  PostgresReplicationConnection.close in any test.