### PR TITLE
[hotfix] Fix e2e CI timeout problems

### DIFF
--- a/flink-cdc-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/TiDBE2eITCase.java
+++ b/flink-cdc-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/TiDBE2eITCase.java
@@ -275,6 +275,7 @@ public class TiDBE2eITCase extends FlinkContainerTestEnvironment {
                 statement.execute(stmt);
             }
         } catch (Exception e) {
+            log.error("initialize Tidb table fails: ", e);
             throw new RuntimeException(e);
         }
     }

--- a/flink-connector-oceanbase-cdc/pom.xml
+++ b/flink-connector-oceanbase-cdc/pom.xml
@@ -52,7 +52,7 @@ under the License.
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.47</version>
+            <version>${mysql.driver.version}</version>
         </dependency>
 
         <!-- test dependencies on Flink -->

--- a/flink-connector-vitess-cdc/pom.xml
+++ b/flink-connector-vitess-cdc/pom.xml
@@ -68,7 +68,7 @@ under the License.
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.26</version>
+            <version>${mysql.driver.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@ under the License.
         <flink.forkCount>1</flink.forkCount>
         <flink.reuseForks>true</flink.reuseForks>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <mysql.driver.version>8.0.27</mysql.driver.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Fix e2e CI timeout problems .MYSQL container is not stoped after class.Thus there are too many MYSQL containers during e2e CI test.