### PR TITLE
[postgres] never drop slot for stream split, which is also global split

### DIFF
--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/external/JdbcSourceFetchTaskContext.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/external/JdbcSourceFetchTaskContext.java
@@ -46,7 +46,7 @@ public abstract class JdbcSourceFetchTaskContext implements FetchTask.Context {
 
     protected final JdbcSourceConfig sourceConfig;
     protected final JdbcDataSourceDialect dataSourceDialect;
-    protected final CommonConnectorConfig dbzConnectorConfig;
+    protected CommonConnectorConfig dbzConnectorConfig;
     protected final SchemaNameAdjuster schemaNameAdjuster;
 
     public JdbcSourceFetchTaskContext(
@@ -154,6 +154,10 @@ public abstract class JdbcSourceFetchTaskContext implements FetchTask.Context {
 
     public CommonConnectorConfig getDbzConnectorConfig() {
         return dbzConnectorConfig;
+    }
+
+    public void setDbzConnectorConfig(CommonConnectorConfig dbzConnectorConfig) {
+        this.dbzConnectorConfig = dbzConnectorConfig;
     }
 
     public SchemaNameAdjuster getSchemaNameAdjuster() {

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java
@@ -128,6 +128,11 @@ public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
                                     .getConfig()
                                     .edit()
                                     .with(
+                                            "table.include.list",
+                                            ((SnapshotSplit) sourceSplitBase)
+                                                    .getTableId()
+                                                    .toString())
+                                    .with(
                                             SLOT_NAME.name(),
                                             ((PostgresSourceConfig) sourceConfig)
                                                     .getSlotNameForBackfillTask())
@@ -138,6 +143,7 @@ public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
                                     .build());
         }
 
+        setDbzConnectorConfig(dbzConfig);
         PostgresConnectorConfig.SnapshotMode snapshotMode =
                 PostgresConnectorConfig.SnapshotMode.parse(
                         dbzConfig.getConfig().getString(SNAPSHOT_MODE));

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java
@@ -152,6 +152,7 @@ public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
                                     .build());
         }
 
+        LOG.info("PostgresConnectorConfig is ", dbzConfig.getConfig().asProperties().toString());
         setDbzConnectorConfig(dbzConfig);
         PostgresConnectorConfig.SnapshotMode snapshotMode =
                 PostgresConnectorConfig.SnapshotMode.parse(

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java
@@ -141,6 +141,15 @@ public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
                                     // Disable heartbeat event in snapshot split fetcher
                                     .with(Heartbeat.HEARTBEAT_INTERVAL, 0)
                                     .build());
+        } else {
+            dbzConfig =
+                    new PostgresConnectorConfig(
+                            dbzConfig
+                                    .getConfig()
+                                    .edit()
+                                    // never drop slot for stream split, which is also global split
+                                    .with(DROP_SLOT_ON_STOP.name(), false)
+                                    .build());
         }
 
         setDbzConnectorConfig(dbzConfig);


### PR DESCRIPTION
Fix https://github.com/ververica/flink-cdc-connectors/issues/2431