### PR TITLE
[cdc-base] refactor param of JdbcConnectionPoolFactory

### DIFF
--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/DataSourcePoolConfig.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/DataSourcePoolConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.base.config;
+
+import java.io.Serializable;
+import java.time.Duration;
+
+/** A config to create HikariDataSource. */
+public class DataSourcePoolConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final Duration connectTimeout;
+    private final int connectMaxRetries;
+    private final int connectionPoolSize;
+
+    private final String driverClassName;
+
+    private final String serverTimeZone;
+
+    public String getDriverClassName() {
+        return driverClassName;
+    }
+
+    public DataSourcePoolConfig(
+            Duration connectTimeout,
+            int connectMaxRetries,
+            int connectionPoolSize,
+            String driverClassName,
+            String serverTimeZone) {
+        this.connectTimeout = connectTimeout;
+        this.connectMaxRetries = connectMaxRetries;
+        this.connectionPoolSize = connectionPoolSize;
+        this.driverClassName = driverClassName;
+        this.serverTimeZone = serverTimeZone;
+    }
+
+    public Duration getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public int getConnectMaxRetries() {
+        return connectMaxRetries;
+    }
+
+    public int getConnectionPoolSize() {
+        return connectionPoolSize;
+    }
+
+    public String getServerTimeZone() {
+        return serverTimeZone;
+    }
+}

--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfig.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfig.java
@@ -21,7 +21,6 @@ import com.ververica.cdc.connectors.base.source.IncrementalSource;
 import io.debezium.config.Configuration;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Properties;
 
@@ -30,20 +29,17 @@ import java.util.Properties;
  */
 public abstract class JdbcSourceConfig extends BaseSourceConfig {
 
-    protected final String driverClassName;
     protected final String hostname;
     protected final int port;
     protected final String username;
     protected final String password;
+
     protected final List<String> databaseList;
     protected final List<String> schemaList;
     protected final List<String> tableList;
     protected final int fetchSize;
-    protected final String serverTimeZone;
-    protected final Duration connectTimeout;
-    protected final int connectMaxRetries;
-    protected final int connectionPoolSize;
     protected final String chunkKeyColumn;
+    protected final DataSourcePoolConfig dataSourcePoolConfig;
 
     public JdbcSourceConfig(
             StartupOptions startupOptions,
@@ -58,17 +54,13 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
             boolean closeIdleReaders,
             Properties dbzProperties,
             Configuration dbzConfiguration,
-            String driverClassName,
             String hostname,
             int port,
             String username,
             String password,
             int fetchSize,
-            String serverTimeZone,
-            Duration connectTimeout,
-            int connectMaxRetries,
-            int connectionPoolSize,
-            String chunkKeyColumn) {
+            String chunkKeyColumn,
+            DataSourcePoolConfig dataSourcePoolConfig) {
         super(
                 startupOptions,
                 splitSize,
@@ -79,7 +71,7 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
                 closeIdleReaders,
                 dbzProperties,
                 dbzConfiguration);
-        this.driverClassName = driverClassName;
+
         this.hostname = hostname;
         this.port = port;
         this.username = username;
@@ -88,18 +80,11 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
         this.schemaList = schemaList;
         this.tableList = tableList;
         this.fetchSize = fetchSize;
-        this.serverTimeZone = serverTimeZone;
-        this.connectTimeout = connectTimeout;
-        this.connectMaxRetries = connectMaxRetries;
-        this.connectionPoolSize = connectionPoolSize;
         this.chunkKeyColumn = chunkKeyColumn;
+        this.dataSourcePoolConfig = dataSourcePoolConfig;
     }
 
     public abstract RelationalDatabaseConnectorConfig getDbzConnectorConfig();
-
-    public String getDriverClassName() {
-        return driverClassName;
-    }
 
     public String getHostname() {
         return hostname;
@@ -129,20 +114,8 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
         return fetchSize;
     }
 
-    public String getServerTimeZone() {
-        return serverTimeZone;
-    }
-
-    public Duration getConnectTimeout() {
-        return connectTimeout;
-    }
-
-    public int getConnectMaxRetries() {
-        return connectMaxRetries;
-    }
-
-    public int getConnectionPoolSize() {
-        return connectionPoolSize;
+    public DataSourcePoolConfig getDataPoolConfig() {
+        return dataSourcePoolConfig;
     }
 
     public String getChunkKeyColumn() {

--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/relational/connection/ConnectionPools.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/relational/connection/ConnectionPools.java
@@ -18,15 +18,19 @@ package com.ververica.cdc.connectors.base.relational.connection;
 
 import org.apache.flink.annotation.Experimental;
 
-import com.ververica.cdc.connectors.base.config.SourceConfig;
+import com.ververica.cdc.connectors.base.config.DataSourcePoolConfig;
+import io.debezium.jdbc.JdbcConfiguration;
 
 /** A pool collection that consists of multiple connection pools. */
 @Experimental
-public interface ConnectionPools<P, C extends SourceConfig> {
+public interface ConnectionPools<P> {
 
     /**
      * Gets a connection pool from pools, create a new pool if the pool does not exists in the
      * connection pools .
      */
-    P getOrCreateConnectionPool(ConnectionPoolId poolId, C sourceConfig);
+    P getOrCreateConnectionPool(
+            ConnectionPoolId poolId,
+            DataSourcePoolConfig sourceConfig,
+            JdbcConfiguration jdbcConfiguration);
 }

--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/relational/connection/JdbcConnectionPoolFactory.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/relational/connection/JdbcConnectionPoolFactory.java
@@ -16,9 +16,10 @@
 
 package com.ververica.cdc.connectors.base.relational.connection;
 
-import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
+import com.ververica.cdc.connectors.base.config.DataSourcePoolConfig;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.debezium.jdbc.JdbcConfiguration;
 
 /** A connection pool factory to create pooled DataSource {@link HikariDataSource}. */
 public abstract class JdbcConnectionPoolFactory {
@@ -27,23 +28,23 @@ public abstract class JdbcConnectionPoolFactory {
     public static final String SERVER_TIMEZONE_KEY = "serverTimezone";
     public static final int MINIMUM_POOL_SIZE = 1;
 
-    public HikariDataSource createPooledDataSource(JdbcSourceConfig sourceConfig) {
+    public HikariDataSource createPooledDataSource(
+            DataSourcePoolConfig dataSourcePoolConfig, JdbcConfiguration jdbcConfiguration) {
         final HikariConfig config = new HikariConfig();
-
-        String hostName = sourceConfig.getHostname();
-        int port = sourceConfig.getPort();
+        String hostName = jdbcConfiguration.getHostname();
+        int port = jdbcConfiguration.getPort();
 
         config.setPoolName(CONNECTION_POOL_PREFIX + hostName + ":" + port);
-        config.setJdbcUrl(getJdbcUrl(sourceConfig));
-        config.setUsername(sourceConfig.getUsername());
-        config.setPassword(sourceConfig.getPassword());
+        config.setJdbcUrl(getJdbcUrl(jdbcConfiguration));
+        config.setUsername(jdbcConfiguration.getUser());
+        config.setPassword(jdbcConfiguration.getPassword());
         config.setMinimumIdle(MINIMUM_POOL_SIZE);
-        config.setMaximumPoolSize(sourceConfig.getConnectionPoolSize());
-        config.setConnectionTimeout(sourceConfig.getConnectTimeout().toMillis());
-        config.setDriverClassName(sourceConfig.getDriverClassName());
+        config.setMaximumPoolSize(dataSourcePoolConfig.getConnectionPoolSize());
+        config.setConnectionTimeout(dataSourcePoolConfig.getConnectTimeout().toMillis());
+        config.setDriverClassName(dataSourcePoolConfig.getDriverClassName());
 
         // note: the following properties should be optional (only applied to MySQL)
-        config.addDataSourceProperty(SERVER_TIMEZONE_KEY, sourceConfig.getServerTimeZone());
+        config.addDataSourceProperty(SERVER_TIMEZONE_KEY, dataSourcePoolConfig.getServerTimeZone());
         // optional optimization configurations for pooled DataSource
         config.addDataSourceProperty("cachePrepStmts", "true");
         config.addDataSourceProperty("prepStmtCacheSize", "250");
@@ -60,8 +61,8 @@ public abstract class JdbcConnectionPoolFactory {
      * jdbc:sybase:Tds:<em>hostname</em>:<em>port</em></code>, so generate a jdbc url by specific
      * database.
      *
-     * @param sourceConfig a basic Source configuration.
+     * @param jdbcConfiguration a basic Source configuration.
      * @return a database url.
      */
-    public abstract String getJdbcUrl(JdbcSourceConfig sourceConfig);
+    public abstract String getJdbcUrl(JdbcConfiguration jdbcConfiguration);
 }

--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/relational/connection/JdbcConnectionPools.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/relational/connection/JdbcConnectionPools.java
@@ -16,8 +16,9 @@
 
 package com.ververica.cdc.connectors.base.relational.connection;
 
-import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
+import com.ververica.cdc.connectors.base.config.DataSourcePoolConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.debezium.jdbc.JdbcConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,7 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /** A Jdbc Connection pools implementation. */
-public class JdbcConnectionPools implements ConnectionPools<HikariDataSource, JdbcSourceConfig> {
+public class JdbcConnectionPools implements ConnectionPools<HikariDataSource> {
 
     private static final Logger LOG = LoggerFactory.getLogger(JdbcConnectionPools.class);
 
@@ -46,11 +47,16 @@ public class JdbcConnectionPools implements ConnectionPools<HikariDataSource, Jd
 
     @Override
     public HikariDataSource getOrCreateConnectionPool(
-            ConnectionPoolId poolId, JdbcSourceConfig sourceConfig) {
+            ConnectionPoolId poolId,
+            DataSourcePoolConfig dataSourcePoolConfig,
+            JdbcConfiguration jdbcConfiguration) {
         synchronized (pools) {
             if (!pools.containsKey(poolId)) {
                 LOG.info("Create and register connection pool {}", poolId);
-                pools.put(poolId, jdbcConnectionPoolFactory.createPooledDataSource(sourceConfig));
+                pools.put(
+                        poolId,
+                        jdbcConnectionPoolFactory.createPooledDataSource(
+                                dataSourcePoolConfig, jdbcConfiguration));
             }
             return pools.get(poolId);
         }

--- a/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/MySqlDialect.java
+++ b/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/MySqlDialect.java
@@ -59,12 +59,10 @@ public class MySqlDialect implements JdbcDataSourceDialect {
     private static final String QUOTED_CHARACTER = "`";
 
     private static final long serialVersionUID = 1L;
-    private final MySqlSourceConfigFactory configFactory;
     private final MySqlSourceConfig sourceConfig;
     private transient MySqlSchema mySqlSchema;
 
     public MySqlDialect(MySqlSourceConfigFactory configFactory) {
-        this.configFactory = configFactory;
         this.sourceConfig = configFactory.create(0);
     }
 
@@ -77,7 +75,8 @@ public class MySqlDialect implements JdbcDataSourceDialect {
         JdbcConnection jdbc =
                 new JdbcConnection(
                         JdbcConfiguration.adapt(sourceConfig.getDbzConfiguration()),
-                        new JdbcConnectionFactory(sourceConfig, getPooledDataSourceFactory()),
+                        new JdbcConnectionFactory(
+                                sourceConfig.getDataPoolConfig(), getPooledDataSourceFactory()),
                         QUOTED_CHARACTER,
                         QUOTED_CHARACTER);
         try {

--- a/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/MysqlPooledDataSourceFactory.java
+++ b/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/MysqlPooledDataSourceFactory.java
@@ -18,8 +18,8 @@ package com.ververica.cdc.connectors.base.experimental;
 
 import org.apache.flink.annotation.Experimental;
 
-import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
 import com.ververica.cdc.connectors.base.relational.connection.JdbcConnectionPoolFactory;
+import io.debezium.jdbc.JdbcConfiguration;
 
 /** A MySQL datasource factory. */
 @Experimental
@@ -29,9 +29,9 @@ public class MysqlPooledDataSourceFactory extends JdbcConnectionPoolFactory {
             "jdbc:mysql://%s:%s/?useInformationSchema=true&nullCatalogMeansCurrent=false&useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8&zeroDateTimeBehavior=CONVERT_TO_NULL";
 
     @Override
-    public String getJdbcUrl(JdbcSourceConfig sourceConfig) {
-        String hostName = sourceConfig.getHostname();
-        int port = sourceConfig.getPort();
+    public String getJdbcUrl(JdbcConfiguration jdbcConfiguration) {
+        String hostName = jdbcConfiguration.getHostname();
+        int port = jdbcConfiguration.getPort();
 
         return String.format(JDBC_URL_PATTERN, hostName, port);
     }

--- a/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/config/MySqlSourceConfig.java
+++ b/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/config/MySqlSourceConfig.java
@@ -16,13 +16,13 @@
 
 package com.ververica.cdc.connectors.base.experimental.config;
 
+import com.ververica.cdc.connectors.base.config.DataSourcePoolConfig;
 import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
 import com.ververica.cdc.connectors.base.options.StartupOptions;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.relational.RelationalTableFilters;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Properties;
 
@@ -48,16 +48,12 @@ public class MySqlSourceConfig extends JdbcSourceConfig {
             boolean closeIdleReaders,
             Properties dbzProperties,
             Configuration dbzConfiguration,
-            String driverClassName,
             String hostname,
             int port,
             String username,
             String password,
             int fetchSize,
-            String serverTimeZone,
-            Duration connectTimeout,
-            int connectMaxRetries,
-            int connectionPoolSize) {
+            DataSourcePoolConfig dataSourcePoolConfig) {
         super(
                 startupOptions,
                 databaseList,
@@ -71,17 +67,13 @@ public class MySqlSourceConfig extends JdbcSourceConfig {
                 closeIdleReaders,
                 dbzProperties,
                 dbzConfiguration,
-                driverClassName,
                 hostname,
                 port,
                 username,
                 password,
                 fetchSize,
-                serverTimeZone,
-                connectTimeout,
-                connectMaxRetries,
-                connectionPoolSize,
-                null);
+                null,
+                dataSourcePoolConfig);
     }
 
     @Override

--- a/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/config/MySqlSourceConfigFactory.java
+++ b/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/config/MySqlSourceConfigFactory.java
@@ -16,6 +16,7 @@
 
 package com.ververica.cdc.connectors.base.experimental.config;
 
+import com.ververica.cdc.connectors.base.config.DataSourcePoolConfig;
 import com.ververica.cdc.connectors.base.config.JdbcSourceConfigFactory;
 import com.ververica.cdc.connectors.base.experimental.EmbeddedFlinkDatabaseHistory;
 import io.debezium.config.Configuration;
@@ -118,15 +119,16 @@ public class MySqlSourceConfigFactory extends JdbcSourceConfigFactory {
                 closeIdleReaders,
                 props,
                 dbzConfiguration,
-                driverClassName,
                 hostname,
                 port,
                 username,
                 password,
                 fetchSize,
-                serverTimeZone,
-                connectTimeout,
-                connectMaxRetries,
-                connectionPoolSize);
+                new DataSourcePoolConfig(
+                        connectTimeout,
+                        connectMaxRetries,
+                        connectionPoolSize,
+                        driverClassName,
+                        serverTimeZone));
     }
 }

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OraclePooledDataSourceFactory.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OraclePooledDataSourceFactory.java
@@ -16,25 +16,25 @@
 
 package com.ververica.cdc.connectors.oracle.source;
 
-import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
 import com.ververica.cdc.connectors.base.relational.connection.JdbcConnectionPoolFactory;
-import com.ververica.cdc.connectors.oracle.source.config.OracleSourceConfig;
+import com.ververica.cdc.connectors.oracle.source.config.OracleDataSourceConfig;
+import io.debezium.jdbc.JdbcConfiguration;
 import org.apache.commons.lang3.StringUtils;
 
-/** A Oracle datasource factory. */
+/** An Oracle datasource factory. */
 public class OraclePooledDataSourceFactory extends JdbcConnectionPoolFactory {
 
     public static final String JDBC_URL_PATTERN = "jdbc:oracle:thin:@%s:%s:%s";
 
     @Override
-    public String getJdbcUrl(JdbcSourceConfig sourceConfig) {
-        OracleSourceConfig oracleSourceConfig = (OracleSourceConfig) sourceConfig;
+    public String getJdbcUrl(JdbcConfiguration jdbcConfiguration) {
+        OracleDataSourceConfig oracleSourceConfig = (OracleDataSourceConfig) jdbcConfiguration;
         if (StringUtils.isNotBlank(oracleSourceConfig.getUrl())) {
             return oracleSourceConfig.getUrl();
         } else {
-            String hostName = sourceConfig.getHostname();
-            int port = sourceConfig.getPort();
-            String database = sourceConfig.getDatabaseList().get(0);
+            String hostName = jdbcConfiguration.getHostname();
+            int port = jdbcConfiguration.getPort();
+            String database = jdbcConfiguration.getDatabase();
             return String.format(JDBC_URL_PATTERN, hostName, port, database);
         }
     }

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleDataSourceConfig.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleDataSourceConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.oracle.source.config;
+
+import com.ververica.cdc.connectors.base.config.DataSourcePoolConfig;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+
+/**
+ * An oracle config to create HikariDataSource, which provide url to use when connecting to the
+ * Oracle database server.
+ */
+public class OracleDataSourceConfig extends DataSourcePoolConfig {
+    @Nullable private String url;
+
+    public OracleDataSourceConfig(
+            Duration connectTimeout,
+            int connectMaxRetries,
+            int connectionPoolSize,
+            String driverClassName,
+            String serverTimeZone,
+            String url) {
+        super(
+                connectTimeout,
+                connectMaxRetries,
+                connectionPoolSize,
+                driverClassName,
+                serverTimeZone);
+        this.url = url;
+    }
+
+    @Nullable
+    public String getUrl() {
+        return url;
+    }
+}

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfig.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfig.java
@@ -22,9 +22,6 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.relational.RelationalTableFilters;
 
-import javax.annotation.Nullable;
-
-import java.time.Duration;
 import java.util.List;
 import java.util.Properties;
 
@@ -35,8 +32,6 @@ import java.util.Properties;
 public class OracleSourceConfig extends JdbcSourceConfig {
 
     private static final long serialVersionUID = 1L;
-
-    @Nullable private String url;
 
     public OracleSourceConfig(
             StartupOptions startupOptions,
@@ -50,18 +45,13 @@ public class OracleSourceConfig extends JdbcSourceConfig {
             boolean closeIdleReaders,
             Properties dbzProperties,
             Configuration dbzConfiguration,
-            String driverClassName,
-            @Nullable String url,
             String hostname,
             int port,
             String username,
             String password,
             int fetchSize,
-            String serverTimeZone,
-            Duration connectTimeout,
-            int connectMaxRetries,
-            int connectionPoolSize,
-            String chunkKeyColumn) {
+            String chunkKeyColumn,
+            OracleDataSourceConfig oracleDataSourceConfig) {
         super(
                 startupOptions,
                 databaseList,
@@ -75,18 +65,13 @@ public class OracleSourceConfig extends JdbcSourceConfig {
                 closeIdleReaders,
                 dbzProperties,
                 dbzConfiguration,
-                driverClassName,
                 hostname,
                 port,
                 username,
                 password,
                 fetchSize,
-                serverTimeZone,
-                connectTimeout,
-                connectMaxRetries,
-                connectionPoolSize,
-                chunkKeyColumn);
-        this.url = url;
+                chunkKeyColumn,
+                oracleDataSourceConfig);
     }
 
     @Override
@@ -100,10 +85,5 @@ public class OracleSourceConfig extends JdbcSourceConfig {
 
     public RelationalTableFilters getTableFilters() {
         return getDbzConnectorConfig().getTableFilters();
-    }
-
-    @Nullable
-    public String getUrl() {
-        return url;
     }
 }

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfigFactory.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfigFactory.java
@@ -119,17 +119,18 @@ public class OracleSourceConfigFactory extends JdbcSourceConfigFactory {
                 closeIdleReaders,
                 props,
                 dbzConfiguration,
-                DRIVER_ClASS_NAME,
-                url,
                 hostname,
                 port,
                 username,
                 password,
                 fetchSize,
-                serverTimeZone,
-                connectTimeout,
-                connectMaxRetries,
-                connectionPoolSize,
-                chunkKeyColumn);
+                chunkKeyColumn,
+                new OracleDataSourceConfig(
+                        connectTimeout,
+                        connectMaxRetries,
+                        connectionPoolSize,
+                        DRIVER_ClASS_NAME,
+                        serverTimeZone,
+                        url));
     }
 }

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresConnectionPoolFactory.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresConnectionPoolFactory.java
@@ -16,20 +16,20 @@
 
 package com.ververica.cdc.connectors.postgres.source;
 
-import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
 import com.ververica.cdc.connectors.base.relational.connection.JdbcConnectionPoolFactory;
 import com.zaxxer.hikari.HikariDataSource;
+import io.debezium.jdbc.JdbcConfiguration;
 
 /** A connection pool factory to create pooled Postgres {@link HikariDataSource}. */
 public class PostgresConnectionPoolFactory extends JdbcConnectionPoolFactory {
     public static final String JDBC_URL_PATTERN = "jdbc:postgresql://%s:%s/%s";
 
     @Override
-    public String getJdbcUrl(JdbcSourceConfig sourceConfig) {
+    public String getJdbcUrl(JdbcConfiguration jdbcConfiguration) {
 
-        String hostName = sourceConfig.getHostname();
-        int port = sourceConfig.getPort();
-        String database = sourceConfig.getDatabaseList().get(0);
+        String hostName = jdbcConfiguration.getHostname();
+        int port = jdbcConfiguration.getPort();
+        String database = jdbcConfiguration.getDatabase();
         return String.format(JDBC_URL_PATTERN, hostName, port, database);
     }
 }

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresDialect.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresDialect.java
@@ -86,7 +86,8 @@ public class PostgresDialect implements JdbcDataSourceDialect {
                         dbzConfig.getJdbcConfig(),
                         valueConverterBuilder,
                         CONNECTION_NAME,
-                        new JdbcConnectionFactory(sourceConfig, getPooledDataSourceFactory()));
+                        new JdbcConnectionFactory(
+                                sourceConfig.getDataPoolConfig(), getPooledDataSourceFactory()));
 
         try {
             jdbc.connect();

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
@@ -16,6 +16,7 @@
 
 package com.ververica.cdc.connectors.postgres.source.config;
 
+import com.ververica.cdc.connectors.base.config.DataSourcePoolConfig;
 import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
 import com.ververica.cdc.connectors.base.options.StartupOptions;
 import io.debezium.config.Configuration;
@@ -24,7 +25,6 @@ import io.debezium.relational.RelationalTableFilters;
 
 import javax.annotation.Nullable;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Properties;
 
@@ -51,17 +51,13 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
             boolean closeIdleReaders,
             Properties dbzProperties,
             Configuration dbzConfiguration,
-            String driverClassName,
             String hostname,
             int port,
             String username,
             String password,
             int fetchSize,
-            String serverTimeZone,
-            Duration connectTimeout,
-            int connectMaxRetries,
-            int connectionPoolSize,
-            @Nullable String chunkKeyColumn) {
+            @Nullable String chunkKeyColumn,
+            DataSourcePoolConfig dataSourcePoolConfig) {
         super(
                 startupOptions,
                 databaseList,
@@ -75,17 +71,13 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
                 closeIdleReaders,
                 dbzProperties,
                 dbzConfiguration,
-                driverClassName,
                 hostname,
                 port,
                 username,
                 password,
                 fetchSize,
-                serverTimeZone,
-                connectTimeout,
-                connectMaxRetries,
-                connectionPoolSize,
-                chunkKeyColumn);
+                chunkKeyColumn,
+                dataSourcePoolConfig);
         this.subtaskId = subtaskId;
     }
 

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfigFactory.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfigFactory.java
@@ -16,6 +16,7 @@
 
 package com.ververica.cdc.connectors.postgres.source.config;
 
+import com.ververica.cdc.connectors.base.config.DataSourcePoolConfig;
 import com.ververica.cdc.connectors.base.config.JdbcSourceConfigFactory;
 import com.ververica.cdc.connectors.base.source.EmbeddedFlinkDatabaseHistory;
 import io.debezium.config.Configuration;
@@ -114,17 +115,18 @@ public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
                 closeIdleReaders,
                 props,
                 dbzConfiguration,
-                JDBC_DRIVER,
                 hostname,
                 port,
                 username,
                 password,
                 fetchSize,
-                serverTimeZone,
-                connectTimeout,
-                connectMaxRetries,
-                connectionPoolSize,
-                chunkKeyColumn);
+                chunkKeyColumn,
+                new DataSourcePoolConfig(
+                        connectTimeout,
+                        connectMaxRetries,
+                        connectionPoolSize,
+                        JDBC_DRIVER,
+                        serverTimeZone));
     }
 
     /**

--- a/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfig.java
+++ b/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfig.java
@@ -16,12 +16,12 @@
 
 package com.ververica.cdc.connectors.sqlserver.source.config;
 
+import com.ververica.cdc.connectors.base.config.DataSourcePoolConfig;
 import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
 import com.ververica.cdc.connectors.base.options.StartupOptions;
 import io.debezium.config.Configuration;
 import io.debezium.connector.sqlserver.SqlServerConnectorConfig;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Properties;
 
@@ -43,17 +43,13 @@ public class SqlServerSourceConfig extends JdbcSourceConfig {
             boolean closeIdleReaders,
             Properties dbzProperties,
             Configuration dbzConfiguration,
-            String driverClassName,
             String hostname,
             int port,
             String username,
             String password,
             int fetchSize,
-            String serverTimeZone,
-            Duration connectTimeout,
-            int connectMaxRetries,
-            int connectionPoolSize,
-            String chunkKeyColumn) {
+            String chunkKeyColumn,
+            DataSourcePoolConfig dataSourcePoolConfig) {
         super(
                 startupOptions,
                 databaseList,
@@ -67,17 +63,13 @@ public class SqlServerSourceConfig extends JdbcSourceConfig {
                 closeIdleReaders,
                 dbzProperties,
                 dbzConfiguration,
-                driverClassName,
                 hostname,
                 port,
                 username,
                 password,
                 fetchSize,
-                serverTimeZone,
-                connectTimeout,
-                connectMaxRetries,
-                connectionPoolSize,
-                chunkKeyColumn);
+                chunkKeyColumn,
+                dataSourcePoolConfig);
     }
 
     @Override

--- a/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfigFactory.java
+++ b/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfigFactory.java
@@ -16,6 +16,7 @@
 
 package com.ververica.cdc.connectors.sqlserver.source.config;
 
+import com.ververica.cdc.connectors.base.config.DataSourcePoolConfig;
 import com.ververica.cdc.connectors.base.config.JdbcSourceConfigFactory;
 import com.ververica.cdc.connectors.base.source.EmbeddedFlinkDatabaseHistory;
 import io.debezium.config.Configuration;
@@ -90,16 +91,17 @@ public class SqlServerSourceConfigFactory extends JdbcSourceConfigFactory {
                 closeIdleReaders,
                 props,
                 dbzConfiguration,
-                DRIVER_ClASS_NAME,
                 hostname,
                 port,
                 username,
                 password,
                 fetchSize,
-                serverTimeZone,
-                connectTimeout,
-                connectMaxRetries,
-                connectionPoolSize,
-                chunkKeyColumn);
+                chunkKeyColumn,
+                new DataSourcePoolConfig(
+                        connectTimeout,
+                        connectMaxRetries,
+                        connectionPoolSize,
+                        DRIVER_ClASS_NAME,
+                        serverTimeZone));
     }
 }

--- a/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/dialect/SqlServerPooledDataSourceFactory.java
+++ b/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/dialect/SqlServerPooledDataSourceFactory.java
@@ -16,8 +16,8 @@
 
 package com.ververica.cdc.connectors.sqlserver.source.dialect;
 
-import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
 import com.ververica.cdc.connectors.base.relational.connection.JdbcConnectionPoolFactory;
+import io.debezium.jdbc.JdbcConfiguration;
 
 /** Factory to create {@link JdbcConnectionPoolFactory} for SQL Server. */
 public class SqlServerPooledDataSourceFactory extends JdbcConnectionPoolFactory {
@@ -25,10 +25,10 @@ public class SqlServerPooledDataSourceFactory extends JdbcConnectionPoolFactory 
     private static final String URL_PATTERN = "jdbc:sqlserver://%s:%s;databaseName=%s";
 
     @Override
-    public String getJdbcUrl(JdbcSourceConfig sourceConfig) {
-        String hostName = sourceConfig.getHostname();
-        int port = sourceConfig.getPort();
-        String database = sourceConfig.getDatabaseList().get(0);
+    public String getJdbcUrl(JdbcConfiguration jdbcConfiguration) {
+        String hostName = jdbcConfiguration.getHostname();
+        int port = jdbcConfiguration.getPort();
+        String database = jdbcConfiguration.getDatabase();
         return String.format(URL_PATTERN, hostName, port, database);
     }
 }

--- a/flink-connector-vitess-cdc/pom.xml
+++ b/flink-connector-vitess-cdc/pom.xml
@@ -143,6 +143,12 @@ under the License.
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## What is the purpose of the change
This is not a bug, but an improving change for now JdbcConnectionPoolFactory.

Current JdbcConnectionPoolFactory  produce new datasources based on initial params JdbcSourceConfig, rather than JdbcConfiguration in real JDBC, which occur will problems.
For example: add a new test in MySqlChangeEventSourceExampleTest:
```java
    @Test
    public void testJdbcConnectionTest() throws SQLException {

        JdbcConfiguration jdbcConfiguration =
                JdbcConfiguration.create()
                        .withHostname("testhost1")
                        .withPort(8080)
                        .withDatabase("test-database")
                        .withUser("test-user")
                        .withPassword("test-passwotd")
                        .build();

        // if this two configurations is not same, what will happens
        MySqlSourceConfig mySqlSourceConfig =
                new MySqlSourceConfig(
                        StartupOptions.latest(),
                        Lists.newArrayList(inventoryDatabase.getDatabaseName()),
                        Lists.newArrayList(inventoryDatabase.getDatabaseName() + ".products"),
                        1,
                        1,
                        1.00,
                        2.00,
                        false,
                        false,
                        new Properties(),
                        jdbcConfiguration,
                        "com.mysql.cj.jdbc.Driver",
                        MYSQL_CONTAINER.getHost(),
                        MYSQL_CONTAINER.getDatabasePort(),
                        inventoryDatabase.getUsername(),
                        inventoryDatabase.getPassword(),
                        100,
                        "UTC+8",
                        Duration.ofSeconds(5),
                        1,
                        10);

        JdbcConnection jdbc =
                new JdbcConnection(
                        jdbcConfiguration,
                        new JdbcConnectionFactory(
                                mySqlSourceConfig, new MysqlPooledDataSourceFactory()),
                        "`",
                        "`");

        jdbc.connect();
        Assert.assertTrue(jdbc.isConnected());
        Assert.assertFalse(jdbc.username().equals(inventoryDatabase.getDatabaseName()));
        Assert.assertFalse(jdbc.config().getHostname().equals(inventoryDatabase.getHost()));
    }
```
It turns out that Jdbc 's username and hostname are different from real connection.

## Brief Change Log
JdbcSourceConfig contains too much informations for JdbcConnectionPoolFactory. So extract a new param DataSourcePoolConfig, which contains the informations needed for thread pool. Combine DataSourcePoolConfig and JDBC's JdbcConfiguration to produce a new datasource.