### PR TITLE
[test] close jdbc and client after each test

### DIFF
--- a/flink-connector-db2-cdc/src/test/java/com/ververica/cdc/connectors/db2/Db2SourceTest.java
+++ b/flink-connector-db2-cdc/src/test/java/com/ververica/cdc/connectors/db2/Db2SourceTest.java
@@ -131,7 +131,6 @@ public class Db2SourceTest extends Db2TestBase {
             assertUpdate(records.get(0), "ID", 2001);
 
             // cleanup
-            source.cancel();
             source.close();
             runThread.sync();
         }
@@ -198,7 +197,6 @@ public class Db2SourceTest extends Db2TestBase {
             assertTrue(lsn.compareTo(prevLsn) > 0);
             prevLsn = lsn;
 
-            source.cancel();
             source.close();
             runThread.sync();
         }
@@ -253,7 +251,6 @@ public class Db2SourceTest extends Db2TestBase {
             }
 
             // cancel the source
-            source2.cancel();
             source2.close();
             runThread2.sync();
         }
@@ -306,7 +303,6 @@ public class Db2SourceTest extends Db2TestBase {
             String lsn = JsonPath.read(state, "$.sourceOffset.commit_lsn");
             assertTrue(lsn.compareTo(prevLsn) > 0);
 
-            source3.cancel();
             source3.close();
             runThread3.sync();
         }

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBSourceTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/LegacyMongoDBSourceTest.java
@@ -138,7 +138,6 @@ public class LegacyMongoDBSourceTest extends LegacyMongoDBTestBase {
         assertDelete(records.get(0), "000000000000000000001001");
 
         // cleanup
-        source.cancel();
         source.close();
         runThread.sync();
     }
@@ -228,7 +227,6 @@ public class LegacyMongoDBSourceTest extends LegacyMongoDBTestBase {
             String resumeToken = JsonPath.read(state, "$.sourceOffset._id");
             assertTrue(resumeToken.contains("_data"));
 
-            source.cancel();
             source.close();
             runThread.sync();
         }
@@ -286,7 +284,6 @@ public class LegacyMongoDBSourceTest extends LegacyMongoDBTestBase {
                     Updates.set("weight", 1345.67));
 
             // cancel the source
-            source2.cancel();
             source2.close();
             runThread2.sync();
         }
@@ -344,7 +341,6 @@ public class LegacyMongoDBSourceTest extends LegacyMongoDBTestBase {
             String resumeToken = JsonPath.read(state, "$.sourceOffset._id");
             assertTrue(resumeToken.contains("_data"));
 
-            source3.cancel();
             source3.close();
             runThread3.sync();
         }

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlSourceExampleTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlSourceExampleTest.java
@@ -49,5 +49,6 @@ public class LegacyMySqlSourceExampleTest extends LegacyMySqlTestBase {
         env.addSource(sourceFunction).print().setParallelism(1);
 
         env.execute("Print MySQL Snapshot + Binlog");
+        inventoryDatabase.dropDatabase();
     }
 }

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlSourceTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlSourceTest.java
@@ -814,6 +814,7 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
         if (useLegacyImplementation) {
             // should fail because user specifies to use the legacy implementation
             try {
+                source.cancel();
                 source.close();
                 runThread.sync();
                 fail("Should fail.");
@@ -917,6 +918,7 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
                                                             + " this might because the debezium engine has been shutdown due to other errors.",
                                                     engineInstanceName)));
                 } finally {
+                    source.cancel();
                     source.close();
                     runThread.sync();
                 }
@@ -982,6 +984,7 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
                 assertTrue(historyState.list.size() > 0);
                 assertTrue(offsetState.list.size() > 0);
 
+                source.cancel();
                 source.close();
                 runThread.sync();
             }
@@ -1061,6 +1064,7 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
                     assertTrue(e.getCause() instanceof Handover.ClosedException);
                     assertTrue(e.getCause().getMessage().contains("Close handover with error."));
                 } finally {
+                    source.cancel();
                     source.close();
                     runThread.sync();
                 }

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlSourceTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlSourceTest.java
@@ -41,6 +41,7 @@ import io.debezium.relational.TableId;
 import io.debezium.relational.history.HistoryRecord;
 import io.debezium.relational.history.TableChanges;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -99,6 +100,11 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
     @Before
     public void before() {
         database.createAndInitialize();
+    }
+
+    @After
+    public void after() {
+        database.dropDatabase();
     }
 
     @Test

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlSourceTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlSourceTest.java
@@ -178,7 +178,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
             assertUpdate(records.get(0), "id", 2001);
 
             // cleanup
-            source.cancel();
             source.close();
             runThread.sync();
         }
@@ -248,7 +247,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
             assertTrue(pos > prevPos);
             prevPos = pos;
 
-            source.cancel();
             source.close();
             runThread.sync();
         }
@@ -309,7 +307,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
             }
 
             // cancel the source
-            source2.cancel();
             source2.close();
             runThread2.sync();
         }
@@ -366,7 +363,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
             int pos = JsonPath.read(state, "$.sourceOffset.pos");
             assertTrue(pos > prevPos);
 
-            source3.cancel();
             source3.close();
             runThread3.sync();
         }
@@ -410,7 +406,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
             int pos = JsonPath.read(state, "$.sourceOffset.pos");
             assertTrue(pos > prevPos);
 
-            source4.cancel();
             source4.close();
             runThread4.sync();
         }
@@ -462,7 +457,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
             int pos = JsonPath.read(state, "$.sourceOffset.pos");
             assertTrue(pos > prevPos);
 
-            source5.cancel();
             source5.close();
             runThread5.sync();
         }
@@ -493,7 +487,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
                 assertInsert(records.get(0), "id", 1003);
             }
 
-            source6.cancel();
             source6.close();
             runThread6.sync();
         }
@@ -555,7 +548,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
                 assertTrue(historyState.list.size() > 0);
                 assertTrue(offsetState.list.size() > 0);
 
-                source.cancel();
                 source.close();
                 runThread.sync();
             }
@@ -586,7 +578,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
                 assertEquals(1, records.size());
                 assertInsert(records.get(0), "id", 113);
 
-                source2.cancel();
                 source2.close();
                 runThread2.sync();
             }
@@ -648,7 +639,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
                 source2.snapshotState(new StateSnapshotContextSynchronousImpl(201, 201));
             }
 
-            source2.cancel();
             source2.close();
             runThread2.sync();
         }
@@ -677,7 +667,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
             assertEquals(1, records.size());
             assertDelete(records.get(0), "id", 2001);
 
-            source3.cancel();
             source3.close();
             runThread3.sync();
         }
@@ -761,7 +750,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
                 assertTrue(pos > prevPos);
             }
 
-            source.cancel();
             source.close();
             runThread.sync();
         }
@@ -814,7 +802,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
         if (useLegacyImplementation) {
             // should fail because user specifies to use the legacy implementation
             try {
-                source.cancel();
                 source.close();
                 runThread.sync();
                 fail("Should fail.");
@@ -828,7 +815,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
             // check the debezium status to verify
             waitDebeziumStartWithTimeout(source, 5_000L);
 
-            source.cancel();
             source.close();
             runThread.sync();
         }
@@ -918,7 +904,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
                                                             + " this might because the debezium engine has been shutdown due to other errors.",
                                                     engineInstanceName)));
                 } finally {
-                    source.cancel();
                     source.close();
                     runThread.sync();
                 }
@@ -984,7 +969,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
                 assertTrue(historyState.list.size() > 0);
                 assertTrue(offsetState.list.size() > 0);
 
-                source.cancel();
                 source.close();
                 runThread.sync();
             }
@@ -1064,7 +1048,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
                     assertTrue(e.getCause() instanceof Handover.ClosedException);
                     assertTrue(e.getCause().getMessage().contains("Close handover with error."));
                 } finally {
-                    source.cancel();
                     source.close();
                     runThread.sync();
                 }
@@ -1127,7 +1110,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
         String offsetFile = JsonPath.read(state, "$.sourceOffset.file");
         int offsetPos = JsonPath.read(state, "$.sourceOffset.pos");
 
-        source.cancel();
         source.close();
         runThread.sync();
 

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/MySqlValidatorTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/MySqlValidatorTest.java
@@ -193,11 +193,7 @@ public class MySqlValidatorTest {
         } else {
             DebeziumSourceFunction<SourceRecord> source =
                     basicSourceBuilder(database, "UTC", false).build();
-            try {
-                setupSource(source);
-            } finally {
-                source.close();
-            }
+            setupSource(source);
         }
     }
 

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
@@ -55,6 +55,7 @@ import io.debezium.relational.history.TableChanges;
 import io.debezium.relational.history.TableChanges.TableChange;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -116,6 +117,17 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         LOG.info("Container MySql8 is stopped.");
     }
 
+    @After
+    public void after() throws Exception {
+        if (mySqlConnection != null) {
+            mySqlConnection.close();
+        }
+        if (binaryLogClient != null) {
+            binaryLogClient.disconnect();
+        }
+        customerDatabase.dropDatabase();
+    }
+
     @Test
     public void testReadSingleBinlogSplit() throws Exception {
         customerDatabase.createAndInitialize();
@@ -153,8 +165,6 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                         expected.length,
                         splits.get(splits.size() - 1).getTableId());
         assertEqualsInAnyOrder(Arrays.asList(expected), actual);
-        mySqlConnection.close();
-        binaryLogClient.disconnect();
     }
 
     @Test
@@ -203,8 +213,6 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                         expected.length,
                         splits.get(splits.size() - 1).getTableId());
         assertEqualsInAnyOrder(Arrays.asList(expected), actual);
-        mySqlConnection.close();
-        binaryLogClient.disconnect();
     }
 
     @Test
@@ -240,8 +248,6 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                         expected.length,
                         splits.get(splits.size() - 1).getTableId());
         assertEqualsInAnyOrder(Arrays.asList(expected), actual);
-        mySqlConnection.close();
-        binaryLogClient.disconnect();
     }
 
     @Test
@@ -299,8 +305,6 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                                         + "."
                                         + "customer_card_single_line"));
         assertEqualsInAnyOrder(Arrays.asList(expected), actual);
-        mySqlConnection.close();
-        binaryLogClient.disconnect();
     }
 
     @Test
@@ -344,8 +348,6 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         assertEqualsInOrder(Arrays.asList(expected), actual);
 
         reader.close();
-        mySqlConnection.close();
-        binaryLogClient.disconnect();
     }
 
     @Test
@@ -409,8 +411,6 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         List<String> actual = readBinlogSplits(dataType, reader, expected.length);
 
         reader.close();
-        mySqlConnection.close();
-        binaryLogClient.disconnect();
         assertEqualsInOrder(Arrays.asList(expected), actual);
     }
 
@@ -445,8 +445,6 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                 ExceptionUtils.findThrowable(throwable, SchemaOutOfSyncException.class);
 
         reader.close();
-        mySqlConnection.close();
-        binaryLogClient.disconnect();
         assertTrue(schemaOutOfSyncException.isPresent());
         assertEquals(
                 "Internal schema representation is probably out of sync with real database schema. "
@@ -506,8 +504,6 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         List<String> actual = readBinlogSplits(dataType, reader, expected.length);
 
         reader.close();
-        mySqlConnection.close();
-        binaryLogClient.disconnect();
         assertEqualsInOrder(Arrays.asList(expected), actual);
     }
 
@@ -563,8 +559,6 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         List<String> actual = readBinlogSplits(dataType, reader, expected.length);
 
         reader.close();
-        mySqlConnection.close();
-        binaryLogClient.disconnect();
         assertEqualsInOrder(Arrays.asList(expected), actual);
     }
 
@@ -618,8 +612,6 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         List<String> actual = readBinlogSplits(dataType, reader, expected.length);
 
         reader.close();
-        mySqlConnection.close();
-        binaryLogClient.disconnect();
         assertEqualsInOrder(Arrays.asList(expected), actual);
     }
 
@@ -675,8 +667,6 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         List<String> actual = readBinlogSplits(dataType, reader, expected.length);
 
         reader.close();
-        mySqlConnection.close();
-        binaryLogClient.disconnect();
         assertEqualsInOrder(Arrays.asList(expected), actual);
     }
 
@@ -737,8 +727,6 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         List<String> actual = readBinlogSplits(dataType, reader, expected.length);
 
         reader.close();
-        mySqlConnection.close();
-        binaryLogClient.disconnect();
         assertEqualsInOrder(Arrays.asList(expected), actual);
     }
 
@@ -791,8 +779,6 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                 DEFAULT_TIMEOUT,
                 "Timeout waiting for heartbeat event");
         binlogReader.close();
-        mySqlConnection.close();
-        binaryLogClient.disconnect();
     }
 
     @Test
@@ -851,8 +837,6 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                             + "2. The job runs normally, but something happens in the database and lead to the binlog cleanup. You can try to check why this cleanup happens from MySQL side.");
         } finally {
             reader.close();
-            mySqlConnection.close();
-            binaryLogClient.disconnect();
         }
     }
 

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
@@ -153,6 +153,8 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                         expected.length,
                         splits.get(splits.size() - 1).getTableId());
         assertEqualsInAnyOrder(Arrays.asList(expected), actual);
+        mySqlConnection.close();
+        binaryLogClient.disconnect();
     }
 
     @Test
@@ -201,6 +203,8 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                         expected.length,
                         splits.get(splits.size() - 1).getTableId());
         assertEqualsInAnyOrder(Arrays.asList(expected), actual);
+        mySqlConnection.close();
+        binaryLogClient.disconnect();
     }
 
     @Test
@@ -236,6 +240,8 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                         expected.length,
                         splits.get(splits.size() - 1).getTableId());
         assertEqualsInAnyOrder(Arrays.asList(expected), actual);
+        mySqlConnection.close();
+        binaryLogClient.disconnect();
     }
 
     @Test
@@ -293,6 +299,8 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                                         + "."
                                         + "customer_card_single_line"));
         assertEqualsInAnyOrder(Arrays.asList(expected), actual);
+        mySqlConnection.close();
+        binaryLogClient.disconnect();
     }
 
     @Test
@@ -336,6 +344,8 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         assertEqualsInOrder(Arrays.asList(expected), actual);
 
         reader.close();
+        mySqlConnection.close();
+        binaryLogClient.disconnect();
     }
 
     @Test
@@ -399,7 +409,8 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         List<String> actual = readBinlogSplits(dataType, reader, expected.length);
 
         reader.close();
-
+        mySqlConnection.close();
+        binaryLogClient.disconnect();
         assertEqualsInOrder(Arrays.asList(expected), actual);
     }
 
@@ -434,7 +445,8 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                 ExceptionUtils.findThrowable(throwable, SchemaOutOfSyncException.class);
 
         reader.close();
-
+        mySqlConnection.close();
+        binaryLogClient.disconnect();
         assertTrue(schemaOutOfSyncException.isPresent());
         assertEquals(
                 "Internal schema representation is probably out of sync with real database schema. "
@@ -494,7 +506,8 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         List<String> actual = readBinlogSplits(dataType, reader, expected.length);
 
         reader.close();
-
+        mySqlConnection.close();
+        binaryLogClient.disconnect();
         assertEqualsInOrder(Arrays.asList(expected), actual);
     }
 
@@ -550,7 +563,8 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         List<String> actual = readBinlogSplits(dataType, reader, expected.length);
 
         reader.close();
-
+        mySqlConnection.close();
+        binaryLogClient.disconnect();
         assertEqualsInOrder(Arrays.asList(expected), actual);
     }
 
@@ -604,7 +618,8 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         List<String> actual = readBinlogSplits(dataType, reader, expected.length);
 
         reader.close();
-
+        mySqlConnection.close();
+        binaryLogClient.disconnect();
         assertEqualsInOrder(Arrays.asList(expected), actual);
     }
 
@@ -660,7 +675,8 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         List<String> actual = readBinlogSplits(dataType, reader, expected.length);
 
         reader.close();
-
+        mySqlConnection.close();
+        binaryLogClient.disconnect();
         assertEqualsInOrder(Arrays.asList(expected), actual);
     }
 
@@ -721,7 +737,8 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         List<String> actual = readBinlogSplits(dataType, reader, expected.length);
 
         reader.close();
-
+        mySqlConnection.close();
+        binaryLogClient.disconnect();
         assertEqualsInOrder(Arrays.asList(expected), actual);
     }
 
@@ -774,6 +791,8 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                 DEFAULT_TIMEOUT,
                 "Timeout waiting for heartbeat event");
         binlogReader.close();
+        mySqlConnection.close();
+        binaryLogClient.disconnect();
     }
 
     @Test
@@ -830,6 +849,10 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                     "The required binary logs are no longer available on the server. This may happen in following situations:\n"
                             + "1. The speed of CDC source reading is too slow to exceed the binlog expired period. You can consider increasing the binary log expiration period, you can also to check whether there is back pressure in the job and optimize your job.\n"
                             + "2. The job runs normally, but something happens in the database and lead to the binlog cleanup. You can try to check why this cleanup happens from MySQL side.");
+        } finally {
+            reader.close();
+            mySqlConnection.close();
+            binaryLogClient.disconnect();
         }
     }
 

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
@@ -43,6 +43,7 @@ import io.debezium.schema.DataCollectionSchema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -79,6 +80,17 @@ public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
                 getConfig(customerDatabase, new String[] {"customers"}, 10);
         binaryLogClient = DebeziumUtils.createBinaryClient(sourceConfig.getDbzConfiguration());
         mySqlConnection = DebeziumUtils.createMySqlConnection(sourceConfig);
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        if (mySqlConnection != null) {
+            mySqlConnection.close();
+        }
+
+        if (binaryLogClient != null) {
+            binaryLogClient.disconnect();
+        }
     }
 
     @Test
@@ -457,12 +469,6 @@ public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
             }
         }
 
-        if (mySqlConnection != null) {
-            mySqlConnection.close();
-        }
-        if (binaryLogClient != null) {
-            binaryLogClient.disconnect();
-        }
         snapshotSplitReader.close();
 
         assertNotNull(snapshotSplitReader.getExecutorService());

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/SpecificStartingOffsetITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/SpecificStartingOffsetITCase.java
@@ -163,7 +163,7 @@ public class SpecificStartingOffsetITCase {
                                 savepointDir.toAbsolutePath().toString(),
                                 SavepointFormatType.DEFAULT)
                         .get();
-        jobClient.cancel();
+        jobClient.cancel().get();
 
         // Make some changes after the savepoint
         executeStatements(
@@ -179,7 +179,7 @@ public class SpecificStartingOffsetITCase {
                 .containsExactly(
                         "-U[15213, Alice, Rome, 123456987]", "+U[15213, Alicia, Rome, 123456987]");
 
-        restoredJobClient.cancel();
+        restoredJobClient.cancel().get();
     }
 
     @Test
@@ -239,7 +239,7 @@ public class SpecificStartingOffsetITCase {
                                 savepointDir.toAbsolutePath().toString(),
                                 SavepointFormatType.DEFAULT)
                         .get();
-        jobClient.cancel();
+        jobClient.cancel().get();
 
         // Make some changes after the savepoint
         executeStatements(
@@ -255,7 +255,7 @@ public class SpecificStartingOffsetITCase {
                 .containsExactly(
                         "-U[15213, Alice, Rome, 123456987]", "+U[15213, Alicia, Rome, 123456987]");
 
-        restoredJobClient.cancel();
+        restoredJobClient.cancel().get();
     }
 
     @Test
@@ -325,7 +325,7 @@ public class SpecificStartingOffsetITCase {
                                 savepointDir.toAbsolutePath().toString(),
                                 SavepointFormatType.DEFAULT)
                         .get();
-        jobClient.cancel();
+        jobClient.cancel().get();
 
         // Make some changes after the savepoint
         executeStatements(
@@ -342,7 +342,7 @@ public class SpecificStartingOffsetITCase {
                         "-U[18213, Charlie, Paris, 123456987]",
                         "+U[18213, George, Paris, 123456987]");
 
-        restoredJobClient.cancel();
+        restoredJobClient.cancel().get();
     }
 
     private MySqlSourceBuilder<RowData> getSourceBuilder() {

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlBinlogSplitAssignerTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlBinlogSplitAssignerTest.java
@@ -76,6 +76,7 @@ public class MySqlBinlogSplitAssignerTest {
         assertEquals(BinlogOffset.ofNonStopping(), split.getEndingOffset());
         // There should be only one split to assign
         assertFalse(assigner.getNext().isPresent());
+        assigner.close();
     }
 
     private MySqlSourceConfig getConfig(StartupOptions startupOptions) {

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssignerTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssignerTest.java
@@ -136,6 +136,7 @@ public class MySqlHybridSplitAssignerTest extends MySqlSourceTestBase {
                         new HashMap<>(),
                         finishedSnapshotSplitInfos.size());
         assertEquals(expected, mySqlBinlogSplit);
+        assigner.close();
     }
 
     private MySqlSourceConfig getConfig(String[] captureTables) {

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlRecordEmitterTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlRecordEmitterTest.java
@@ -81,6 +81,7 @@ public class MySqlRecordEmitterTest {
                         throw new RuntimeException("Failed to emit heartbeat record", e);
                     }
                 });
+        heartbeat.close();
         assertNotNull(splitState.getStartingOffset());
         assertEquals(0, splitState.getStartingOffset().compareTo(fakeOffset));
     }

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
@@ -61,6 +61,7 @@ import io.debezium.relational.history.HistoryRecord;
 import io.debezium.relational.history.TableChanges;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,6 +107,12 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
             new UniqueDatabase(MYSQL_CONTAINER, "customer", "mysqluser", "mysqlpw");
     private final UniqueDatabase inventoryDatabase =
             new UniqueDatabase(MYSQL_CONTAINER, "inventory", "mysqluser", "mysqlpw");
+
+    @After
+    public void clear() {
+        customerDatabase.dropDatabase();
+        inventoryDatabase.dropDatabase();
+    }
 
     @Test
     public void testBinlogReadFailoverCrossTransaction() throws Exception {
@@ -169,7 +176,6 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
         List<String> restRecords = consumeRecords(restartReader, dataType);
         assertEqualsInOrder(Arrays.asList(expectedRestRecords), restRecords);
         restartReader.close();
-        customerDatabase.dropDatabase();
     }
 
     @Test
@@ -227,7 +233,6 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
         List<MySqlSplit> mySqlSplits = reader.snapshotState(1L);
         assertEquals(1, mySqlSplits.size());
         reader.close();
-        inventoryDatabase.dropDatabase();
     }
 
     @Test
@@ -327,7 +332,6 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
             }
         }
         reader.close();
-        inventoryDatabase.dropDatabase();
     }
 
     private MySqlSourceReader<SourceRecord> createReader(MySqlSourceConfig configuration, int limit)

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
@@ -169,6 +169,7 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
         List<String> restRecords = consumeRecords(restartReader, dataType);
         assertEqualsInOrder(Arrays.asList(expectedRestRecords), restRecords);
         restartReader.close();
+        customerDatabase.dropDatabase();
     }
 
     @Test
@@ -225,6 +226,8 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
         reader.addSplits(splits);
         List<MySqlSplit> mySqlSplits = reader.snapshotState(1L);
         assertEquals(1, mySqlSplits.size());
+        reader.close();
+        inventoryDatabase.dropDatabase();
     }
 
     @Test
@@ -323,6 +326,8 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
                 recordByKey.put(record.key(), record);
             }
         }
+        reader.close();
+        inventoryDatabase.dropDatabase();
     }
 
     private MySqlSourceReader<SourceRecord> createReader(MySqlSourceConfig configuration, int limit)

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MysqlConnectorCharsetITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MysqlConnectorCharsetITCase.java
@@ -387,7 +387,7 @@ public class MysqlConnectorCharsetITCase extends MySqlSourceTestBase {
         }
         assertEqualsInAnyOrder(
                 Arrays.asList(binlogExpected), fetchRows(iterator, binlogExpected.length));
-        result.getJobClient().ifPresent(client -> client.cancel());
+        result.getJobClient().get().cancel().get();
     }
 
     private String getServerId() {

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/polardbx/PolardbxCharsetITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/polardbx/PolardbxCharsetITCase.java
@@ -196,7 +196,7 @@ public class PolardbxCharsetITCase extends PolardbxSourceTestBase {
         }
         assertEqualsInAnyOrder(
                 Arrays.asList(binlogExpected), fetchRows(iterator, binlogExpected.length));
-        result.getJobClient().ifPresent(client -> client.cancel());
+        result.getJobClient().get().cancel().get();
     }
 
     private static void waitForSnapshotStarted(CloseableIterator<Row> iterator) throws Exception {

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/polardbx/PolardbxSourceITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/polardbx/PolardbxSourceITCase.java
@@ -123,7 +123,7 @@ public class PolardbxSourceITCase extends PolardbxSourceTestBase {
                         + " 'connector' = 'values',"
                         + " 'sink-insert-only' = 'false'"
                         + ")");
-        tEnv.executeSql("insert into sink select * from orders_source");
+        tableResult = tEnv.executeSql("insert into sink select * from orders_source");
 
         waitForSinkSize("sink", realSnapshotData.size());
         assertEqualsInAnyOrder(expectedSnapshotData, TestValuesTableFactory.getRawResults("sink"));
@@ -155,10 +155,11 @@ public class PolardbxSourceITCase extends PolardbxSourceTestBase {
         }
         List<String> realBinlog = fetchRows(iterator, expectedBinlog.length);
         assertEqualsInOrder(expectedBinlogData, realBinlog);
+        tableResult.getJobClient().get().cancel();
     }
 
     @Test
-    public void testFullTypesDdl() {
+    public void testFullTypesDdl() throws Exception {
         int parallelism = 1;
         String[] captureCustomerTables = new String[] {"polardbx_full_types"};
 
@@ -262,6 +263,7 @@ public class PolardbxSourceITCase extends PolardbxSourceTestBase {
                             + "\"type\":\"GeometryCollection\",\"srid\":0}]",
                 };
         assertEqualsInAnyOrder(Arrays.asList(expectedSnapshotData), realSnapshotData);
+        tableResult.getJobClient().get().cancel().get();
     }
 
     @Test
@@ -372,5 +374,6 @@ public class PolardbxSourceITCase extends PolardbxSourceTestBase {
                 };
         List<String> realBinlog = fetchRows(iterator, expectedBinlog.length);
         assertEqualsInAnyOrder(Arrays.asList(expectedBinlog), realBinlog);
+        tableResult.getJobClient().get().cancel().get();
     }
 }

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/polardbx/PolardbxSourceITCase.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/polardbx/PolardbxSourceITCase.java
@@ -155,7 +155,7 @@ public class PolardbxSourceITCase extends PolardbxSourceTestBase {
         }
         List<String> realBinlog = fetchRows(iterator, expectedBinlog.length);
         assertEqualsInOrder(expectedBinlogData, realBinlog);
-        tableResult.getJobClient().get().cancel();
+        tableResult.getJobClient().get().cancel().get();
     }
 
     @Test

--- a/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/OracleSourceTest.java
+++ b/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/OracleSourceTest.java
@@ -160,7 +160,6 @@ public class OracleSourceTest extends AbstractTestBase {
             assertUpdate(records.get(0), "ID", 2001);
 
             // cleanup
-            source.cancel();
             source.close();
             runThread.sync();
         }
@@ -226,7 +225,6 @@ public class OracleSourceTest extends AbstractTestBase {
             assertFalse(state.contains("server_id"));
             assertFalse(state.contains("event"));
 
-            source.cancel();
             source.close();
             runThread.sync();
         }
@@ -429,7 +427,6 @@ public class OracleSourceTest extends AbstractTestBase {
                 assertTrue(historyState.list.size() > 0);
                 assertTrue(offsetState.list.size() > 0);
 
-                source.cancel();
                 source.close();
                 runThread.sync();
             }
@@ -537,7 +534,6 @@ public class OracleSourceTest extends AbstractTestBase {
                 assertEquals("oracle_logminer", JsonPath.read(state, "$.sourcePartition.server"));
             }
 
-            source.cancel();
             source.close();
             runThread.sync();
         }

--- a/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/OracleSourceTest.java
+++ b/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/OracleSourceTest.java
@@ -226,6 +226,7 @@ public class OracleSourceTest extends AbstractTestBase {
             assertFalse(state.contains("server_id"));
             assertFalse(state.contains("event"));
 
+            source.cancel();
             source.close();
             runThread.sync();
         }
@@ -428,6 +429,7 @@ public class OracleSourceTest extends AbstractTestBase {
                 assertTrue(historyState.list.size() > 0);
                 assertTrue(offsetState.list.size() > 0);
 
+                source.cancel();
                 source.close();
                 runThread.sync();
             }

--- a/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/PostgreSQLSourceTest.java
+++ b/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/PostgreSQLSourceTest.java
@@ -174,7 +174,6 @@ public class PostgreSQLSourceTest extends PostgresTestBase {
             assertUpdate(records.get(0), "id", 2001);
 
             // cleanup
-            source.cancel();
             source.close();
             runThread.sync();
         }
@@ -245,7 +244,6 @@ public class PostgreSQLSourceTest extends PostgresTestBase {
             assertTrue(lsn > prevLsn);
             prevLsn = lsn;
 
-            source.cancel();
             source.close();
             runThread.sync();
         }
@@ -305,7 +303,6 @@ public class PostgreSQLSourceTest extends PostgresTestBase {
             }
 
             // cancel the source
-            source2.cancel();
             source2.close();
             runThread2.sync();
         }
@@ -361,7 +358,6 @@ public class PostgreSQLSourceTest extends PostgresTestBase {
             int lsn = JsonPath.read(state, "$.sourceOffset.lsn");
             assertTrue(lsn > prevLsn);
 
-            source3.cancel();
             source3.close();
             runThread3.sync();
         }
@@ -405,7 +401,6 @@ public class PostgreSQLSourceTest extends PostgresTestBase {
             assertTrue(lsn > prevLsn);
             prevLsn = lsn;
 
-            source4.cancel();
             source4.close();
             runThread4.sync();
         }
@@ -456,7 +451,6 @@ public class PostgreSQLSourceTest extends PostgresTestBase {
             int pos = JsonPath.read(state, "$.sourceOffset.lsn");
             assertTrue(pos > prevLsn);
 
-            source5.cancel();
             source5.close();
             runThread5.sync();
         }
@@ -488,7 +482,6 @@ public class PostgreSQLSourceTest extends PostgresTestBase {
                 assertInsert(records.get(0), "id", 112);
             }
 
-            source6.cancel();
             source6.close();
             runThread6.sync();
         }
@@ -545,7 +538,6 @@ public class PostgreSQLSourceTest extends PostgresTestBase {
             // make sure there is no more events
             assertFalse(waitForAvailableRecords(Duration.ofSeconds(3), sourceContext));
 
-            source.cancel();
             source.close();
             runThread.sync();
         }
@@ -600,7 +592,6 @@ public class PostgreSQLSourceTest extends PostgresTestBase {
             // make sure there is no more events
             assertFalse(waitForAvailableRecords(Duration.ofSeconds(3), sourceContext2));
 
-            source2.cancel();
             source2.close();
             runThread.sync();
         }

--- a/flink-connector-vitess-cdc/src/test/java/com/vervetica/cdc/connectors/vitess/VitessSourceTest.java
+++ b/flink-connector-vitess-cdc/src/test/java/com/vervetica/cdc/connectors/vitess/VitessSourceTest.java
@@ -127,7 +127,6 @@ public class VitessSourceTest extends VitessTestBase {
             assertUpdate(records.get(0), "id", 2001);
 
             // cleanup
-            source.cancel();
             source.close();
             runThread.sync();
         }


### PR DESCRIPTION
In mysql and postgres test unit, the connections to database and Flink cluster are not closed after test.
This connections may influence other test unit.