### PR TITLE
[tests][e2e] add log properties file to e2e tests

### DIFF
--- a/flink-cdc-e2e-tests/src/test/resources/log4j2-test.properties
+++ b/flink-cdc-e2e-tests/src/test/resources/log4j2-test.properties
@@ -1,0 +1,26 @@
+################################################################################
+#  Copyright 2023 Ververica Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level=INFO
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c - %m%n


### PR DESCRIPTION
There is no `log4j2-test.properties` file in e2e tests, so it's hard to find problem in test.Now add `log4j2-test.properties` flie to e2e tests.