### PR TITLE
[hotfix] Mongo CDC fails to capture collections with `.` in names

### DIFF
--- a/flink-cdc-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/MongoE2eITCase.java
+++ b/flink-cdc-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/MongoE2eITCase.java
@@ -89,7 +89,7 @@ public class MongoE2eITCase extends FlinkContainerTestEnvironment {
         super.before();
 
         container =
-                new MongoDBContainer("mongo:6.0.6")
+                new MongoDBContainer("mongo:6.0.9")
                         .withSharding()
                         .withNetwork(NETWORK)
                         .withNetworkAliases(INTER_CONTAINER_MONGO_ALIAS)

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/dialect/MongoDBDialect.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/dialect/MongoDBDialect.java
@@ -70,11 +70,29 @@ public class MongoDBDialect implements DataSourceDialect<MongoDBSourceConfig> {
         return "MongoDB";
     }
 
+    private static TableId parseTableId(String str) {
+        return parseTableId(str, true);
+    }
+
+    private static TableId parseTableId(String str, boolean useCatalogBeforeSchema) {
+        String[] parts = str.split("[.]", 2);
+        int numParts = parts.length;
+        if (numParts == 1) {
+            return new TableId(null, null, parts[0]);
+        } else if (numParts == 2) {
+            return useCatalogBeforeSchema
+                    ? new TableId(parts[0], null, parts[1])
+                    : new TableId(null, parts[0], parts[1]);
+        } else {
+            return null;
+        }
+    }
+
     @Override
     public List<TableId> discoverDataCollections(MongoDBSourceConfig sourceConfig) {
         CollectionDiscoveryInfo discoveryInfo = discoverAndCacheDataCollections(sourceConfig);
         return discoveryInfo.getDiscoveredCollections().stream()
-                .map(TableId::parse)
+                .map(MongoDBDialect::parseTableId)
                 .collect(Collectors.toList());
     }
 

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
@@ -173,7 +173,8 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                 checkDatabaseNameValidity(database);
                 checkCollectionNameValidity(collection);
                 databaseList = database;
-                collectionList = database + "." + collection;
+                // match dot explicitly since it will be used for regex match later
+                collectionList = database + "[.]" + collection;
             } else {
                 databaseList = database;
                 collectionList = collection;

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/MongoDBFullChangelogITCase.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/MongoDBFullChangelogITCase.java
@@ -79,7 +79,7 @@ public class MongoDBFullChangelogITCase extends MongoDBSourceTestBase {
                         .pollAwaitTimeMillis(500)
                         .create(0);
 
-        assertEquals(MongoUtils.getMongoVersion(config), "6.0.6");
+        assertEquals(MongoUtils.getMongoVersion(config), "6.0.9");
     }
 
     @Test

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/MongoDBSourceTestBase.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/MongoDBSourceTestBase.java
@@ -71,7 +71,7 @@ public class MongoDBSourceTestBase {
 
     @ClassRule
     public static final MongoDBContainer CONTAINER =
-            new MongoDBContainer("mongo:6.0.6")
+            new MongoDBContainer("mongo:6.0.9")
                     .withSharding()
                     .withLogConsumer(new Slf4jLogConsumer(LOG));
 }

--- a/flink-connector-mongodb-cdc/src/test/resources/ddl/ns-dotted.js
+++ b/flink-connector-mongodb-cdc/src/test/resources/ddl/ns-dotted.js
@@ -1,0 +1,17 @@
+// Copyright 2023 Ververica Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+db.getCollection('coll.name').insertOne({"seq": "A101"});
+db.getCollection('coll.name').insertOne({"seq": "A102"});
+db.getCollection('coll.name').insertOne({"seq": "A103"});


### PR DESCRIPTION
For now, [MongoDB allows](https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limit-Restriction-on-Collection-Names) collection names containing dots (`.`). According to [Mongo CDC docs](https://ververica.github.io/flink-cdc-connectors/master/content/connectors/mongodb-cdc.html#connector-options), it should be ok to match them with fully-qualified regex like this:

```javascript
db[.]coll[.]name[.]with[.]dots // matches collection "coll.name.with.dots" in "db" database
```

However, it doesn't work when incremental snapshot option is enabled. Here's the minimum POC:

```java
@Test
public void testMatchCollectionWithDots() throws Exception {
    // 1. Given colllections:
    // db: [coll.name]
    String db = CONTAINER.executeCommandFileInSeparateDatabase("ns-dotted");

    TableResult result = submitTestCase(db, db + "[.]coll[.]name");

    // 2. Wait change stream records come
    waitForSinkSize("mongodb_sink", 3);

    // 3. Check results
    String[] expected =
            new String[] {
                String.format("+I[%s, coll.name, A101]", db),
                String.format("+I[%s, coll.name, A102]", db),
                String.format("+I[%s, coll.name, A103]", db)
            };

    List<String> actual = TestValuesTableFactory.getResults("mongodb_sink");
    assertThat(actual, containsInAnyOrder(expected));

    result.getJobClient().get().cancel().get();
}
```

It might be caused by a glitch in [Debezium framework](https://github.com/debezium/debezium/blob/5e243e2480f1bd2525c7de27672f98fe7649d01b/debezium-core/src/main/java/io/debezium/relational/TableId.java#L104C5-L118C6) which simply regards `.` as a separator between catalog, schema, and table (instead of a valid character in table name).

Currently, Mongo CDC never requests schema field (`useCatalogBeforeSchema` is always true), so a weaker version of `splitTableId` function was implemented, and hopefully it could correctly handle dots presenting in collection names.