### PR TITLE
fix: mongo collection regex match logic

### DIFF
--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
@@ -173,8 +173,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                 checkDatabaseNameValidity(database);
                 checkCollectionNameValidity(collection);
                 databaseList = database;
-                // match dot explicitly since it will be used for regex match later
-                collectionList = database + "[.]" + collection;
+                collectionList = database + "." + collection;
             } else {
                 databaseList = database;
                 collectionList = collection;


### PR DESCRIPTION
Commit https://github.com/ververica/flink-cdc-connectors/commit/44cd46e227a5e772a6f740b3a8664b8e8afd2c77 introduces a change that using [.] as delimiter between database name and collection name to avoid conflicts between dot (`.`) and regex meta character. However this turns out to be unnecessary since in Regex mode, full qualified names will always be used and no pasting will be performed then, and such change will deteriorate performance.

This PR reverts the change above.