### PR TITLE
[Improve]Support customer debezium properties in DebeziumSourceFunction

### DIFF
--- a/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
+++ b/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
@@ -368,30 +368,30 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
     @Override
     public void run(SourceContext<T> sourceContext) throws Exception {
         properties.putIfAbsent("name", "engine");
-        properties.putIfAbsent("offset.storage", FlinkOffsetBackingStore.class.getCanonicalName());
+        properties.setProperty("offset.storage", FlinkOffsetBackingStore.class.getCanonicalName());
         if (restoredOffsetState != null) {
             // restored from state
-            properties.putIfAbsent(FlinkOffsetBackingStore.OFFSET_STATE_VALUE, restoredOffsetState);
+            properties.setProperty(FlinkOffsetBackingStore.OFFSET_STATE_VALUE, restoredOffsetState);
         }
         // DO NOT include schema change, e.g. DDL
         properties.putIfAbsent("include.schema.changes", "false");
         // disable the offset flush totally
         properties.putIfAbsent("offset.flush.interval.ms", String.valueOf(Long.MAX_VALUE));
         // disable tombstones
-        properties.putIfAbsent("tombstones.on.delete", "false");
+        properties.setProperty("tombstones.on.delete", "false");
         if (engineInstanceName == null) {
             // not restore from recovery
             engineInstanceName = UUID.randomUUID().toString();
         }
         // history instance name to initialize FlinkDatabaseHistory
-        properties.putIfAbsent(
+        properties.setProperty(
                 FlinkDatabaseHistory.DATABASE_HISTORY_INSTANCE_NAME, engineInstanceName);
         // we have to use a persisted DatabaseHistory implementation, otherwise, recovery can't
         // continue to read binlog
         // see
         // https://stackoverflow.com/questions/57147584/debezium-error-schema-isnt-know-to-this-connector
         // and https://debezium.io/blog/2018/03/16/note-on-database-history-topic-configuration/
-        properties.putIfAbsent("database.history", determineDatabase().getCanonicalName());
+        properties.setProperty("database.history", determineDatabase().getCanonicalName());
 
         // we have to filter out the heartbeat events, otherwise the deserializer will fail
         String dbzHeartbeatPrefix =

--- a/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
+++ b/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
@@ -367,31 +367,31 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
 
     @Override
     public void run(SourceContext<T> sourceContext) throws Exception {
-        properties.setProperty("name", "engine");
-        properties.setProperty("offset.storage", FlinkOffsetBackingStore.class.getCanonicalName());
+        properties.putIfAbsent("name", "engine");
+        properties.putIfAbsent("offset.storage", FlinkOffsetBackingStore.class.getCanonicalName());
         if (restoredOffsetState != null) {
             // restored from state
-            properties.setProperty(FlinkOffsetBackingStore.OFFSET_STATE_VALUE, restoredOffsetState);
+            properties.putIfAbsent(FlinkOffsetBackingStore.OFFSET_STATE_VALUE, restoredOffsetState);
         }
         // DO NOT include schema change, e.g. DDL
-        properties.setProperty("include.schema.changes", "false");
+        properties.putIfAbsent("include.schema.changes", "false");
         // disable the offset flush totally
-        properties.setProperty("offset.flush.interval.ms", String.valueOf(Long.MAX_VALUE));
+        properties.putIfAbsent("offset.flush.interval.ms", String.valueOf(Long.MAX_VALUE));
         // disable tombstones
-        properties.setProperty("tombstones.on.delete", "false");
+        properties.putIfAbsent("tombstones.on.delete", "false");
         if (engineInstanceName == null) {
             // not restore from recovery
             engineInstanceName = UUID.randomUUID().toString();
         }
         // history instance name to initialize FlinkDatabaseHistory
-        properties.setProperty(
+        properties.putIfAbsent(
                 FlinkDatabaseHistory.DATABASE_HISTORY_INSTANCE_NAME, engineInstanceName);
         // we have to use a persisted DatabaseHistory implementation, otherwise, recovery can't
         // continue to read binlog
         // see
         // https://stackoverflow.com/questions/57147584/debezium-error-schema-isnt-know-to-this-connector
         // and https://debezium.io/blog/2018/03/16/note-on-database-history-topic-configuration/
-        properties.setProperty("database.history", determineDatabase().getCanonicalName());
+        properties.putIfAbsent("database.history", determineDatabase().getCanonicalName());
 
         // we have to filter out the heartbeat events, otherwise the deserializer will fail
         String dbzHeartbeatPrefix =


### PR DESCRIPTION
Currently, in DebeziumSourceFunction, some properties are hardcoded, such as `include.schema.changes`, so that even opening this property peripherally will not work. 
Therefore, the modification is that if the key exists in the `properties`, it will not be overwritten.