### PR TITLE
[docs] Remove support for Flink 1.13 in docs and upgrade Flink version in tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ This README is meant as a brief walkthrough on the core features of CDC Connecto
 
 We need several steps to setup a Flink cluster with the provided connector.
 
-1. Setup a Flink cluster with version 1.12+ and Java 8+ installed.
+1. Setup a Flink cluster with version 1.14+ and Java 8+ installed.
 2. Download the connector SQL jars from the [Download](https://github.com/ververica/flink-cdc-connectors/releases) page (or [build yourself](#building-from-source)).
 3. Put the downloaded jars under `FLINK_HOME/lib/`.
 4. Restart the Flink cluster.
 
-The example shows how to create a MySQL CDC source in [Flink SQL Client](https://ci.apache.org/projects/flink/flink-docs-release-1.13/dev/table/sqlClient.html) and execute queries on it.
+The example shows how to create a MySQL CDC source in [Flink SQL Client](https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/table/sqlclient/) and execute queries on it.
 
 ```sql
 -- creates a mysql cdc table source
@@ -66,7 +66,7 @@ Include following Maven dependency (available through Maven Central):
   <groupId>com.ververica</groupId>
   <!-- add the dependency matching your database -->
   <artifactId>flink-connector-mysql-cdc</artifactId>
-  <!-- The dependency is available only for stable releases, SNAPSHOT dependency need build by yourself. -->
+  <!-- The dependency is available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself. -->
   <version>2.5-SNAPSHOT</version>
 </dependency>
 ```

--- a/docs/content/about.md
+++ b/docs/content/about.md
@@ -32,8 +32,9 @@ The following table shows the version mapping between Flink<sup>®</sup> CDC Con
 | <font color="DarkCyan">2.0.*</font> |                                                                                             <font color="MediumVioletRed">1.13.*</font>                                                                                             |
 | <font color="DarkCyan">2.1.*</font> |                                                                                             <font color="MediumVioletRed">1.13.*</font>                                                                                             |
 | <font color="DarkCyan">2.2.*</font> |                                                                     <font color="MediumVioletRed">1.13.\*</font>, <font color="MediumVioletRed">1.14.\*</font>                                                                      |
-| <font color="DarkCyan">2.3.*</font> |                        <font color="MediumVioletRed">1.13.\*</font>, <font color="MediumVioletRed">1.14.\*</font>, <font color="MediumVioletRed">1.15.\*</font>, <font color="MediumVioletRed">1.16.0</font>                        |
-| <font color="DarkCyan">2.4.*</font> | <font color="MediumVioletRed">1.13.\*</font>, <font color="MediumVioletRed">1.14.\*</font>, <font color="MediumVioletRed">1.15.\*</font>, <font color="MediumVioletRed">1.16.\*</font>, <font color="MediumVioletRed">1.17.0</font> |
+| <font color="DarkCyan">2.3.*</font> |                       <font color="MediumVioletRed">1.13.\*</font>, <font color="MediumVioletRed">1.14.\*</font>, <font color="MediumVioletRed">1.15.\*</font>, <font color="MediumVioletRed">1.16.\*</font>                        |
+| <font color="DarkCyan">2.4.*</font> | <font color="MediumVioletRed">1.13.\*</font>, <font color="MediumVioletRed">1.14.\*</font>, <font color="MediumVioletRed">1.15.\*</font>, <font color="MediumVioletRed">1.16.\*</font>, <font color="MediumVioletRed">1.17.\*</font> |
+| <font color="DarkCyan">2.5.*</font> |                       <font color="MediumVioletRed">1.14.\*</font>, <font color="MediumVioletRed">1.15.\*</font>, <font color="MediumVioletRed">1.16.\*</font>, <font color="MediumVioletRed">1.17.\*</font>                        |
 
 ## Features
 
@@ -64,7 +65,7 @@ We need several steps to setup a Flink cluster with the provided connector.
 3. Put the downloaded jars under `FLINK_HOME/lib/`.
 4. Restart the Flink cluster.
 
-The example shows how to create a MySQL CDC source in [Flink SQL Client](https://ci.apache.org/projects/flink/flink-docs-release-1.13/dev/table/sqlClient.html) and execute queries on it.
+The example shows how to create a MySQL CDC source in [Flink SQL Client](https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/table/sqlclient/) and execute queries on it.
 
 ```sql
 -- creates a mysql cdc table source
@@ -97,7 +98,7 @@ Include following Maven dependency (available through Maven Central):
   <groupId>com.ververica</groupId>
   <!-- add the dependency matching your database -->
   <artifactId>flink-connector-mysql-cdc</artifactId>
-  <!-- The dependency is available only for stable releases, SNAPSHOT dependency need build by yourself. -->
+  <!-- The dependency is available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself. -->
   <version>2.5-SNAPSHOT</version>
 </dependency>
 ```

--- a/docs/content/connectors/db2-cdc.md
+++ b/docs/content/connectors/db2-cdc.md
@@ -22,7 +22,7 @@ using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR
 <dependency>
   <groupId>com.ververica</groupId>
   <artifactId>flink-connector-db2-cdc</artifactId>
-  <!-- The dependency is available only for stable releases, SNAPSHOT dependency need build by yourself. -->
+  <!-- The dependency is available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself. -->
   <version>2.5-SNAPSHOT</version>
 </dependency>
 ```
@@ -31,7 +31,7 @@ using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR
 
 ```Download link is available only for stable releases.```
 
-Download [flink-sql-connector-db2-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-db2-cdc/2.5-SNAPSHOT/flink-sql-connector-db2-cdc-2.5-SNAPSHOT.jar) and 
+Download flink-sql-connector-db2-cdc-2.5-SNAPSHOT.jar and 
 put it under `<FLINK_HOME>/lib/`.
 
 **Note:** flink-sql-connector-db2-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users 

--- a/docs/content/connectors/mongodb-cdc.md
+++ b/docs/content/connectors/mongodb-cdc.md
@@ -12,7 +12,7 @@ In order to setup the MongoDB CDC connector, the following table provides depend
 <dependency>
   <groupId>com.ververica</groupId>
   <artifactId>flink-connector-mongodb-cdc</artifactId>
-  <!-- The dependency is available only for stable releases, SNAPSHOT dependency need build by yourself. -->
+  <!-- The dependency is available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself. -->
   <version>2.5-SNAPSHOT</version>
 </dependency>
 ```

--- a/docs/content/connectors/mysql-cdc(ZH).md
+++ b/docs/content/connectors/mysql-cdc(ZH).md
@@ -28,7 +28,7 @@ MySQL CDC 连接器允许从 MySQL 数据库读取快照数据和增量数据。
 
 ```下载链接仅在已发布版本可用，请在文档网站左下角选择浏览已发布的版本。```
 
-下载 [flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-mysql-cdc/2.5-SNAPSHOT/flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar) 到 `<FLINK_HOME>/lib/` 目录下。
+下载 flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar 到 `<FLINK_HOME>/lib/` 目录下。
 
 **注意:** flink-sql-connector-mysql-cdc-XXX-SNAPSHOT 版本是开发分支`release-XXX`对应的快照版本，快照版本用户需要下载源代码并编译相应的 jar。用户应使用已经发布的版本，例如 [flink-sql-connector-mysql-cdc-2.2.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-mysql-cdc) 当前已发布的所有版本都可以在 Maven 中央仓库获取。
 

--- a/docs/content/connectors/mysql-cdc.md
+++ b/docs/content/connectors/mysql-cdc.md
@@ -20,7 +20,7 @@ In order to setup the MySQL CDC connector, the following table provides dependen
 <dependency>
   <groupId>com.ververica</groupId>
   <artifactId>flink-connector-mysql-cdc</artifactId>
-  <!-- The dependency is available only for stable releases, SNAPSHOT dependency need build by yourself. -->
+  <!-- The dependency is available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself. -->
   <version>2.5-SNAPSHOT</version>
 </dependency>
 ```
@@ -29,7 +29,7 @@ In order to setup the MySQL CDC connector, the following table provides dependen
 
 ```Download link is available only for stable releases.```
 
-Download [flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-mysql-cdc/2.5-SNAPSHOT/flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar) and put it under `<FLINK_HOME>/lib/`.
+Download flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar and put it under `<FLINK_HOME>/lib/`.
 
 **Note:** flink-sql-connector-mysql-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users need to download the source code and compile the corresponding jar. Users should use the released version, such as [flink-sql-connector-mysql-cdc-2.3.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-connector-mysql-cdc), the released version will be available in the Maven central warehouse. 
 

--- a/docs/content/connectors/oceanbase-cdc.md
+++ b/docs/content/connectors/oceanbase-cdc.md
@@ -11,7 +11,7 @@ In order to set up the OceanBase CDC connector, the following table provides dep
 <dependency>
   <groupId>com.ververica</groupId>
   <artifactId>flink-connector-oceanbase-cdc</artifactId>
-  <!-- The dependency is available only for stable releases, SNAPSHOT dependency need build by yourself. -->
+  <!-- The dependency is available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself. -->
   <version>2.5-SNAPSHOT</version>
 </dependency>
 ```

--- a/docs/content/connectors/oracle-cdc.md
+++ b/docs/content/connectors/oracle-cdc.md
@@ -13,7 +13,7 @@ In order to setup the Oracle CDC connector, the following table provides depende
 <dependency>
   <groupId>com.ververica</groupId>
   <artifactId>flink-connector-oracle-cdc</artifactId>
-  <!-- The dependency is available only for stable releases, SNAPSHOT dependency need build by yourself. -->
+  <!-- The dependency is available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself. -->
   <version>2.5-SNAPSHOT</version>
 </dependency>
 ```

--- a/docs/content/connectors/postgres-cdc.md
+++ b/docs/content/connectors/postgres-cdc.md
@@ -13,7 +13,7 @@ In order to setup the Postgres CDC connector, the following table provides depen
 <dependency>
   <groupId>com.ververica</groupId>
   <artifactId>flink-connector-postgres-cdc</artifactId>
-  <!-- The dependency is available only for stable releases, SNAPSHOT dependency need build by yourself. -->
+  <!-- The dependency is available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself. -->
   <version>2.5-SNAPSHOT</version>
 </dependency>
 ```
@@ -22,7 +22,7 @@ In order to setup the Postgres CDC connector, the following table provides depen
 
 ```Download link is available only for stable releases.```
 
-Download [flink-sql-connector-postgres-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-postgres-cdc/2.5-SNAPSHOT/flink-sql-connector-postgres-cdc-2.5-SNAPSHOT.jar) and put it under `<FLINK_HOME>/lib/`.
+Download flink-sql-connector-postgres-cdc-2.5-SNAPSHOT.jar and put it under `<FLINK_HOME>/lib/`.
 
 **Note:** flink-sql-connector-postgres-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users need to download the source code and compile the corresponding jar. Users should use the released version, such as [flink-sql-connector-postgres-cdc-2.3.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-postgres-cdc), the released version will be available in the Maven central warehouse.
 

--- a/docs/content/connectors/sqlserver-cdc.md
+++ b/docs/content/connectors/sqlserver-cdc.md
@@ -13,7 +13,7 @@ In order to setup the SQLServer CDC connector, the following table provides depe
 <dependency>
   <groupId>com.ververica</groupId>
   <artifactId>flink-connector-sqlserver-cdc</artifactId>
-  <!-- The dependency is available only for stable releases, SNAPSHOT dependency need build by yourself. -->
+  <!-- The dependency is available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself. -->
   <version>2.5-SNAPSHOT</version>
 </dependency>
 ```

--- a/docs/content/connectors/tidb-cdc.md
+++ b/docs/content/connectors/tidb-cdc.md
@@ -13,7 +13,7 @@ In order to setup the TiDB CDC connector, the following table provides dependenc
 <dependency>
   <groupId>com.ververica</groupId>
   <artifactId>flink-connector-tidb-cdc</artifactId>
-  <!-- The dependency is available only for stable releases, SNAPSHOT dependency need build by yourself. -->
+  <!-- The dependency is available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself. -->
   <version>2.5-SNAPSHOT</version>
 </dependency>
 ```

--- a/docs/content/quickstart/db2-tutorial.md
+++ b/docs/content/quickstart/db2-tutorial.md
@@ -59,10 +59,10 @@ docker-compose down
 
 **2. Download following JAR package to `<FLINK_HOME>/lib`**
 
-*Download links are available only for stable releases, SNAPSHOT dependency need build by yourself. *
+**Download links are available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself.**
 
 - [flink-sql-connector-elasticsearch7-3.0.1-1.17.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/3.0.1-1.17/flink-sql-connector-elasticsearch7-3.0.1-1.17.jar)
-- [flink-sql-connector-db2-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-db2-cdc/2.5-SNAPSHOT/flink-sql-connector-db2-cdc-2.5-SNAPSHOT.jar)
+- flink-sql-connector-db2-cdc-2.5-SNAPSHOT.jar
 
 **3. Launch a Flink cluster and start a Flink SQL CLI**
 

--- a/docs/content/quickstart/mongodb-tutorial.md
+++ b/docs/content/quickstart/mongodb-tutorial.md
@@ -107,7 +107,7 @@ db.customers.insertMany([
 
 3. Download following JAR package to `<FLINK_HOME>/lib/`:
 
-```Download links are available only for stable releases, SNAPSHOT dependency need build by yourself. ```
+```Download links are available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself. ```
 
 - [flink-sql-connector-elasticsearch7-3.0.1-1.17.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/3.0.1-1.17/flink-sql-connector-elasticsearch7-3.0.1-1.17.jar)
 - [flink-sql-connector-mongodb-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-mongodb-cdc/2.5-SNAPSHOT/flink-sql-connector-mongodb-cdc-2.5-SNAPSHOT.jar)

--- a/docs/content/quickstart/mysql-postgres-tutorial.md
+++ b/docs/content/quickstart/mysql-postgres-tutorial.md
@@ -76,10 +76,10 @@ We can also visit [http://localhost:5601/](http://localhost:5601/) to see if Kib
 1. Download [Flink 1.17.0](https://archive.apache.org/dist/flink/flink-1.17.0/flink-1.17.0-bin-scala_2.12.tgz) and unzip it to the directory `flink-1.17.0`
 2. Download following JAR package required and put them under `flink-1.17.0/lib/`:
 
-   **Download links are available only for stable releases, SNAPSHOT dependency need build by yourself. **
+   **Download links are available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself.**
     - [flink-sql-connector-elasticsearch7-3.0.1-1.17.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/3.0.1-1.17/flink-sql-connector-elasticsearch7-3.0.1-1.17.jar)
-    - [flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-mysql-cdc/2.5-SNAPSHOT/flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar)
-    - [flink-sql-connector-postgres-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-postgres-cdc/2.5-SNAPSHOT/flink-sql-connector-postgres-cdc-2.5-SNAPSHOT.jar)
+    - flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar
+    - flink-sql-connector-postgres-cdc-2.5-SNAPSHOT.jar
 
 ### Preparing data in databases
 #### Preparing data in MySQL

--- a/docs/content/quickstart/oracle-tutorial.md
+++ b/docs/content/quickstart/oracle-tutorial.md
@@ -52,7 +52,7 @@ docker-compose down
 
 **2. Download following JAR package to `<FLINK_HOME>/lib`**
 
-*Download links are available only for stable releases, SNAPSHOT dependency need build by yourself. *
+**Download links are available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself.**
 
 - [flink-sql-connector-elasticsearch7-3.0.1-1.17.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/3.0.1-1.17/flink-sql-connector-elasticsearch7-3.0.1-1.17.jar)
 - [flink-sql-connector-oracle-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-oracle-cdc/2.5-SNAPSHOT/flink-sql-connector-oracle-cdc-2.5-SNAPSHOT.jar)

--- a/docs/content/quickstart/polardbx-tutorial.md
+++ b/docs/content/quickstart/polardbx-tutorial.md
@@ -66,8 +66,8 @@ We can also visit [http://localhost:5601/](http://localhost:5601/) to see if Kib
 1. Download [Flink 1.17.0](https://archive.apache.org/dist/flink/flink-1.17.0/flink-1.17.0-bin-scala_2.12.tgz) and unzip it to the directory `flink-1.17.0`
 2. Download following JAR package required and put them under `flink-1.17.0/lib/`:
 
-   **Download links are available only for stable releases, SNAPSHOT dependency need build by yourself. **
-    - [flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-mysql-cdc/2.5-SNAPSHOT/flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar)
+   **Download links are available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself.**
+    - flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar
     - [flink-sql-connector-elasticsearch7-3.0.1-1.17.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/3.0.1-1.17/flink-sql-connector-elasticsearch7-3.0.1-1.17.jar)
    
 ### Preparing data in databases

--- a/docs/content/quickstart/sqlserver-tutorial.md
+++ b/docs/content/quickstart/sqlserver-tutorial.md
@@ -61,7 +61,7 @@ docker-compose down
 
 **Download following JAR package to `<FLINK_HOME>/lib`:**
 
-*Download links are available only for stable releases, SNAPSHOT dependency need build by yourself. *
+**Download links are available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself.**
 
 - [flink-sql-connector-elasticsearch7-3.0.1-1.17.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/3.0.1-1.17/flink-sql-connector-elasticsearch7-3.0.1-1.17.jar)
 - [flink-sql-connector-sqlserver-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-sqlserver-cdc/2.5-SNAPSHOT/flink-sql-connector-sqlserver-cdc-2.5-SNAPSHOT.jar)

--- a/docs/content/quickstart/tidb-tutorial.md
+++ b/docs/content/quickstart/tidb-tutorial.md
@@ -114,7 +114,7 @@ docker-compose down
 
 **Download following JAR package to `<FLINK_HOME>/lib`:**
 
-*Download links are available only for stable releases, SNAPSHOT dependency need build by yourself. *
+**Download links are available only for stable releases, SNAPSHOT dependencies need to be built based on master or release- branches by yourself.**
 
 - [flink-sql-connector-elasticsearch7-3.0.1-1.17.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/3.0.1-1.17/flink-sql-connector-elasticsearch7-3.0.1-1.17.jar)
 - [flink-sql-connector-tidb-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-tidb-cdc/2.5-SNAPSHOT/flink-sql-connector-tidb-cdc-2.5-SNAPSHOT.jar)

--- a/docs/content/快速上手/mongodb-tutorial-zh.md
+++ b/docs/content/快速上手/mongodb-tutorial-zh.md
@@ -107,7 +107,7 @@ db.customers.insertMany([
 
 3. 下载以下 jar 包到 `<FLINK_HOME>/lib/`:
 
-```下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地编译```
+```下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地基于 master 或 release- 分支编译```
 
  - [flink-sql-connector-elasticsearch7-3.0.1-1.17.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/3.0.1-1.17/flink-sql-connector-elasticsearch7-3.0.1-1.17.jar)
  - [flink-sql-connector-mongodb-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-mongodb-cdc/2.5-SNAPSHOT/flink-sql-connector-mongodb-cdc-2.5-SNAPSHOT.jar)

--- a/docs/content/快速上手/mysql-postgres-tutorial-zh.md
+++ b/docs/content/快速上手/mysql-postgres-tutorial-zh.md
@@ -72,10 +72,10 @@ docker-compose up -d
 1. 下载 [Flink 1.17.0](https://archive.apache.org/dist/flink/flink-1.17.0/flink-1.17.0-bin-scala_2.12.tgz) 并将其解压至目录 `flink-1.17.0`
 2. 下载下面列出的依赖包，并将它们放到目录 `flink-1.17.0/lib/` 下：
 
-   **下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地编译**
+   **下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地基于 master 或 release- 分支编译**
     - [flink-sql-connector-elasticsearch7-3.0.1-1.17.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/3.0.1-1.17/flink-sql-connector-elasticsearch7-3.0.1-1.17.jar)
-    - [flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-mysql-cdc/2.5-SNAPSHOT/flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar)
-    - [flink-sql-connector-postgres-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-postgres-cdc/2.5-SNAPSHOT/flink-sql-connector-postgres-cdc-2.5-SNAPSHOT.jar)
+    - flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar
+    - flink-sql-connector-postgres-cdc-2.5-SNAPSHOT.jar
 
 ### 准备数据
 #### 在 MySQL 数据库中准备数据

--- a/docs/content/快速上手/oceanbase-tutorial-zh.md
+++ b/docs/content/快速上手/oceanbase-tutorial-zh.md
@@ -136,7 +136,7 @@ VALUES (default, '2020-07-30 10:08:22', 'Jark', 50.50, 102, false),
 
 ### 下载所需要的依赖包
 
-```下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地编译```
+```下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地基于 master 或 release- 分支编译```
 
 - [flink-sql-connector-elasticsearch7-3.0.1-1.17.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/3.0.1-1.17/flink-sql-connector-elasticsearch7-3.0.1-1.17.jar)
 - [flink-sql-connector-oceanbase-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-oceanbase-cdc/2.5-SNAPSHOT/flink-sql-connector-oceanbase-cdc-2.5-SNAPSHOT.jar)

--- a/docs/content/快速上手/oracle-tutorial-zh.md
+++ b/docs/content/快速上手/oracle-tutorial-zh.md
@@ -52,7 +52,7 @@ docker-compose down
 
 **2. 下载以下 jar 包到 `<FLINK_HOME>/lib/`:**
 
-*下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地编译*
+*下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地基于 master 或 release- 分支编译*
 
 - [flink-sql-connector-elasticsearch7-3.0.1-1.17.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/3.0.1-1.17/flink-sql-connector-elasticsearch7-3.0.1-1.17.jar)
 - [flink-sql-connector-oracle-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-oracle-cdc/2.5-SNAPSHOT/flink-sql-connector-oracle-cdc-2.5-SNAPSHOT.jar)

--- a/docs/content/快速上手/polardbx-tutorial-zh.md
+++ b/docs/content/快速上手/polardbx-tutorial-zh.md
@@ -108,8 +108,8 @@ VALUES (default, '2020-07-30 10:08:22', 'Jark', 50.50, 102, false),
 1. 下载 [Flink 1.17.0](https://archive.apache.org/dist/flink/flink-1.17.0/flink-1.17.0-bin-scala_2.12.tgz) 并将其解压至目录 `flink-1.17.0`
 2. 下载下面列出的依赖包，并将它们放到目录 `flink-1.17.0/lib/` 下
 
-```下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地编译```
-- 用于订阅PolarDB-X Binlog: [flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-mysql-cdc/2.5-SNAPSHOT/flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar)
+```下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地基于 master 或 release- 分支编译```
+- 用于订阅PolarDB-X Binlog: flink-sql-connector-mysql-cdc-2.5-SNAPSHOT.jar
 - 用于写入Elasticsearch: [flink-sql-connector-elasticsearch7-3.0.1-1.17.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/3.0.1-1.17/flink-sql-connector-elasticsearch7-3.0.1-1.17.jar)
 3. 启动flink服务:
 ```shell

--- a/docs/content/快速上手/sqlserver-tutorial-zh.md
+++ b/docs/content/快速上手/sqlserver-tutorial-zh.md
@@ -61,7 +61,7 @@ docker-compose down
 
 **下载以下 jar 包到 `<FLINK_HOME>/lib/`：**
 
-```下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地编译```
+```下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地基于 master 或 release- 分支编译```
 
 - [flink-sql-connector-elasticsearch7-3.0.1-1.17.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/3.0.1-1.17/flink-sql-connector-elasticsearch7-3.0.1-1.17.jar)
 - [flink-sql-connector-sqlserver-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-sqlserver-cdc/2.5-SNAPSHOT/flink-sql-connector-sqlserver-cdc-2.5-SNAPSHOT.jar)

--- a/docs/content/快速上手/tidb-tutorial-zh.md
+++ b/docs/content/快速上手/tidb-tutorial-zh.md
@@ -114,7 +114,7 @@ docker-compose down
 
 **下载以下 jar 包到 `<FLINK_HOME>/lib/`：**
 
-```下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地编译```
+```下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地基于 master 或 release- 分支编译```
 
 - [flink-sql-connector-elasticsearch7-3.0.1-1.17.jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/3.0.1-1.17/flink-sql-connector-elasticsearch7-3.0.1-1.17.jar)
 - [flink-sql-connector-tidb-cdc-2.5-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-tidb-cdc/2.5-SNAPSHOT/flink-sql-connector-tidb-cdc-2.5-SNAPSHOT.jar)


### PR DESCRIPTION
As showed in https://github.com/ververica/flink-cdc-connectors/issues/2526, Flink CDC 2.5 is no longer supported for flink 1.13, thus remove support for Flink 1.13 in docs and upgrade Flink version in tutorial.