### PR TITLE
[mongodb] Disable hashed index for sharded split strategy

### DIFF
--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/internal/MongoDBEnvelope.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/internal/MongoDBEnvelope.java
@@ -51,6 +51,8 @@ public class MongoDBEnvelope {
 
     public static final String DROPPED_FIELD = "dropped";
 
+    public static final String HASHED_FIELD = "hashed";
+
     public static final String KEY_FIELD = "key";
 
     public static final String MAX_FIELD = "max";


### PR DESCRIPTION
The value of the Hash indexing boundary is the hash code of the shard keys, so it is difficult to determine whether the change record belongs to the chunk range.

Therefore, we do not support hashed index in the sharded split strategy.