### PR TITLE
[mysql] Fix attempted load of isSuspended in MySqlSplitSerializer::deserializeSplit

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSplitSerializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSplitSerializer.java
@@ -165,7 +165,8 @@ public final class MySqlSplitSerializer implements SimpleVersionedSerializer<MyS
                     try {
                         isSuspended = in.readBoolean();
                     } catch (EOFException e) {
-                        // cdc version <= v2.2.0 does not serialize isSuspended value, skip reading it
+                        // cdc version <= v2.2.0 does not serialize isSuspended value, skip reading
+                        // it
                     }
                 }
             }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSplitSerializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSplitSerializer.java
@@ -30,6 +30,7 @@ import io.debezium.document.DocumentWriter;
 import io.debezium.relational.TableId;
 import io.debezium.relational.history.TableChanges.TableChange;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -161,7 +162,11 @@ public final class MySqlSplitSerializer implements SimpleVersionedSerializer<MyS
             if (version >= 3) {
                 totalFinishedSplitSize = in.readInt();
                 if (version > 3) {
-                    isSuspended = in.readBoolean();
+                    try {
+                        isSuspended = in.readBoolean();
+                    } catch (EOFException e) {
+                        // v2.2.0 has no isSuspended value, continue
+                    }
                 }
             }
             in.releaseArrays();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSplitSerializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSplitSerializer.java
@@ -165,7 +165,7 @@ public final class MySqlSplitSerializer implements SimpleVersionedSerializer<MyS
                     try {
                         isSuspended = in.readBoolean();
                     } catch (EOFException e) {
-                        // v2.2.0 has no isSuspended value, continue
+                        // cdc version <= v2.2.0 does not serialize isSuspended value, skip reading it
                     }
                 }
             }


### PR DESCRIPTION
This supports users upgrading from v2.2.0, where the flag is not present

Verified by starting a Flink job using this branch, which had a previous save point written from v2.2.0

Closes https://github.com/ververica/flink-cdc-connectors/issues/2549