### PR TITLE
[mysql] Fix a potential npe because "currentSplittingTableId" is nullable.

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlChunkSplitter.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlChunkSplitter.java
@@ -132,7 +132,7 @@ public class MySqlChunkSplitter implements ChunkSplitter {
             }
         } else {
             Preconditions.checkState(
-                    currentSplittingTableId.equals(tableId),
+                    tableId.equals(currentSplittingTableId),
                     "Can not split a new table before the previous table splitting finish.");
             if (currentSplittingTable == null) {
                 analyzeTable(partition, currentSplittingTableId);


### PR DESCRIPTION
Using "currentSplittingTableId.equals" may cause a npe, because currentSplittingTableId is nullable.