### PR TITLE
[oceanbase] Use global timestamp to start log client

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oceanbase-cdc/src/main/java/com/ververica/cdc/connectors/oceanbase/source/OceanBaseConnection.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oceanbase-cdc/src/main/java/com/ververica/cdc/connectors/oceanbase/source/OceanBaseConnection.java
@@ -105,6 +105,22 @@ public class OceanBaseConnection extends JdbcConnection {
                 formatJdbcUrl(jdbcDriver, jdbcProperties), jdbcDriver, classLoader);
     }
 
+    private String getSystemSchema() {
+        return "mysql".equalsIgnoreCase(compatibleMode) ? "oceanbase" : "SYS";
+    }
+
+    /**
+     * Get current timestamp in nanoseconds from GTS (Global Timestamp Service).
+     *
+     * @return the global timestamp.
+     * @throws SQLException If a database access error occurs.
+     */
+    public Long getGlobalTimestamp() throws SQLException {
+        return queryAndMap(
+                String.format("SELECT TS_VALUE FROM %s.V$OB_TIMESTAMP_SERVICE", getSystemSchema()),
+                rs -> rs.next() ? rs.getLong(1) : null);
+    }
+
     /**
      * Get table list by database name pattern and table name pattern.
      *

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oceanbase-cdc/src/main/java/com/ververica/cdc/connectors/oceanbase/source/OceanBaseRichSourceFunction.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oceanbase-cdc/src/main/java/com/ververica/cdc/connectors/oceanbase/source/OceanBaseRichSourceFunction.java
@@ -295,7 +295,7 @@ public class OceanBaseRichSourceFunction<T> extends RichSourceFunction<T>
     protected void readChangeRecords() throws InterruptedException, TimeoutException {
         if (resolvedTimestamp > 0) {
             obReaderConfig.updateCheckpoint(Long.toString(resolvedTimestamp));
-            LOG.info("Read change events from timestamp: {}", resolvedTimestamp);
+            LOG.info("Restore from timestamp: {}", resolvedTimestamp);
         }
 
         logProxyClient =
@@ -363,12 +363,17 @@ public class OceanBaseRichSourceFunction<T> extends RichSourceFunction<T>
                     }
                 });
 
+        LOG.info(
+                "Try to start LogProxyClient with client id: {}, config: {}",
+                logProxyClientConf.getClientId(),
+                obReaderConfig);
         logProxyClient.start();
-        LOG.info("LogProxyClient started");
+
         if (!latch.await(connectTimeout.getSeconds(), TimeUnit.SECONDS)) {
-            throw new TimeoutException("Timeout to receive messages in RecordListener");
+            throw new TimeoutException(
+                    "Timeout to receive log messages in LogProxyClient.RecordListener");
         }
-        LOG.info("LogProxyClient packet processing started");
+        LOG.info("LogProxyClient started successfully");
 
         logProxyClient.join();
     }


### PR DESCRIPTION
This pr changed the startup order of snapshot and change events reading, and it will reduce the risk of change events buffer OOM.