### PR TITLE
[Improve-2579][Oracle] Support capturing only target tables to improve Debezium's efficiency and reduce resource consumption

### DIFF
--- a/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -43,7 +43,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * A {@link StreamingChangeEventSource} for Oracle.
+ * Copied from Debezium 1.9.7.
+ *
+ * <p>Line 118-138: Add table filter by tableIncludeList and tableExcludeList. Only add designated
+ * tables to the list of capture schema tables.
+ *
+ * <p>A {@link StreamingChangeEventSource} for Oracle.
  *
  * @author Gunnar Morling
  */
@@ -130,7 +135,6 @@ public class OracleSnapshotChangeEventSource
                                         && !tableExcludeSet.contains(t.schema() + "." + t.table()))
                 .collect(Collectors.toSet());
 
-        // this very slow approach(commented out), it took 30 minutes on an instance with 600 tables
         // return jdbcConnection.getAllTableIds(ctx.catalogName);
         // this very slow approach(commented out), it took 30 minutes on an instance with 600 tables
         // return jdbcConnection.readTableNames(ctx.catalogName, null, null, new String[] {"TABLE"}

--- a/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.oracle;
+
+import io.debezium.DebeziumException;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
+import io.debezium.relational.RelationalSnapshotChangeEventSource;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.schema.SchemaChangeEvent;
+import io.debezium.util.Clock;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link StreamingChangeEventSource} for Oracle.
+ *
+ * @author Gunnar Morling
+ */
+public class OracleSnapshotChangeEventSource
+        extends RelationalSnapshotChangeEventSource<OraclePartition, OracleOffsetContext> {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(OracleSnapshotChangeEventSource.class);
+
+    private final OracleConnectorConfig connectorConfig;
+    private final OracleConnection jdbcConnection;
+    private final OracleDatabaseSchema databaseSchema;
+
+    public OracleSnapshotChangeEventSource(
+            OracleConnectorConfig connectorConfig,
+            OracleConnection jdbcConnection,
+            OracleDatabaseSchema schema,
+            EventDispatcher<OraclePartition, TableId> dispatcher,
+            Clock clock,
+            SnapshotProgressListener<OraclePartition> snapshotProgressListener) {
+        super(connectorConfig, jdbcConnection, schema, dispatcher, clock, snapshotProgressListener);
+
+        this.connectorConfig = connectorConfig;
+        this.jdbcConnection = jdbcConnection;
+        this.databaseSchema = schema;
+    }
+
+    @Override
+    protected SnapshottingTask getSnapshottingTask(
+            OraclePartition partition, OracleOffsetContext previousOffset) {
+        boolean snapshotSchema = true;
+        boolean snapshotData = true;
+
+        // found a previous offset and the earlier snapshot has completed
+        if (previousOffset != null && !previousOffset.isSnapshotRunning()) {
+            LOGGER.info("The previous offset has been found.");
+            snapshotSchema = databaseSchema.isStorageInitializationExecuted();
+            snapshotData = false;
+        } else {
+            LOGGER.info("No previous offset has been found.");
+            snapshotData = connectorConfig.getSnapshotMode().includeData();
+        }
+
+        if (snapshotData && snapshotSchema) {
+            LOGGER.info(
+                    "According to the connector configuration both schema and data will be snapshot.");
+        } else if (snapshotSchema) {
+            LOGGER.info("According to the connector configuration only schema will be snapshot.");
+        }
+
+        return new SnapshottingTask(snapshotSchema, snapshotData);
+    }
+
+    @Override
+    protected SnapshotContext<OraclePartition, OracleOffsetContext> prepare(
+            OraclePartition partition) throws Exception {
+        if (connectorConfig.getPdbName() != null) {
+            jdbcConnection.setSessionToPdb(connectorConfig.getPdbName());
+        }
+
+        return new OracleSnapshotContext(partition, connectorConfig.getCatalogName());
+    }
+
+    @Override
+    protected Set<TableId> getAllTableIds(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> ctx) throws Exception {
+        Set<TableId> allTableIds = jdbcConnection.getAllTableIds(ctx.catalogName);
+        Set<String> tableIncludeSet = new HashSet<>();
+        Set<String> tableExcludeSet = new HashSet<>();
+        String tableIncludeList = this.connectorConfig.tableIncludeList();
+        String tableExcludeList = this.connectorConfig.tableExcludeList();
+        LOGGER.info("TableIncludeList: {}", tableIncludeList);
+        if (tableIncludeList != null && !tableIncludeList.isEmpty()) {
+            tableIncludeSet.addAll(Arrays.asList(tableIncludeList.split(",")));
+        }
+        LOGGER.info("TableExcludeList: {}", tableExcludeList);
+        if (tableExcludeList != null && !tableExcludeList.isEmpty()) {
+            tableExcludeSet.addAll(Arrays.asList(tableExcludeList.split(",")));
+        }
+        return allTableIds.stream()
+                .filter(
+                        t ->
+                                tableIncludeSet.contains(t.schema() + "." + t.table())
+                                        && !tableExcludeSet.contains(t.schema() + "." + t.table()))
+                .collect(Collectors.toSet());
+
+        // this very slow approach(commented out), it took 30 minutes on an instance with 600 tables
+        // return jdbcConnection.getAllTableIds(ctx.catalogName);
+        // this very slow approach(commented out), it took 30 minutes on an instance with 600 tables
+        // return jdbcConnection.readTableNames(ctx.catalogName, null, null, new String[] {"TABLE"}
+        // );
+    }
+
+    @Override
+    protected void lockTablesForSchemaSnapshot(
+            ChangeEventSourceContext sourceContext,
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext)
+            throws SQLException, InterruptedException {
+        if (connectorConfig.getSnapshotLockingMode().usesLocking()) {
+            ((OracleSnapshotContext) snapshotContext).preSchemaSnapshotSavepoint =
+                    jdbcConnection.connection().setSavepoint("dbz_schema_snapshot");
+
+            try (Statement statement = jdbcConnection.connection().createStatement()) {
+                for (TableId tableId : snapshotContext.capturedTables) {
+                    if (!sourceContext.isRunning()) {
+                        throw new InterruptedException(
+                                "Interrupted while locking table " + tableId);
+                    }
+
+                    LOGGER.debug("Locking table {}", tableId);
+                    statement.execute("LOCK TABLE " + quote(tableId) + " IN ROW SHARE MODE");
+                }
+            }
+        } else {
+            LOGGER.info("Schema locking was disabled in connector configuration");
+        }
+    }
+
+    @Override
+    protected void releaseSchemaSnapshotLocks(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext)
+            throws SQLException {
+        if (connectorConfig.getSnapshotLockingMode().usesLocking()) {
+            jdbcConnection
+                    .connection()
+                    .rollback(((OracleSnapshotContext) snapshotContext).preSchemaSnapshotSavepoint);
+        }
+    }
+
+    @Override
+    protected void determineSnapshotOffset(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> ctx,
+            OracleOffsetContext previousOffset)
+            throws Exception {
+        // Support the existence of the case when the previous offset.
+        // e.g., schema_only_recovery snapshot mode
+        if (previousOffset != null) {
+            ctx.offset = previousOffset;
+            tryStartingSnapshot(ctx);
+            return;
+        }
+
+        ctx.offset =
+                connectorConfig
+                        .getAdapter()
+                        .determineSnapshotOffset(ctx, connectorConfig, jdbcConnection);
+    }
+
+    @Override
+    protected void readTableStructure(
+            ChangeEventSourceContext sourceContext,
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            OracleOffsetContext offsetContext)
+            throws SQLException, InterruptedException {
+        Set<TableId> capturedSchemaTables;
+        if (databaseSchema.storeOnlyCapturedTables()) {
+            capturedSchemaTables = snapshotContext.capturedTables;
+            LOGGER.info(
+                    "Only captured tables schema should be captured, capturing: {}",
+                    capturedSchemaTables);
+        } else {
+            capturedSchemaTables = snapshotContext.capturedSchemaTables;
+            LOGGER.info(
+                    "All eligible tables schema should be captured, capturing: {}",
+                    capturedSchemaTables);
+        }
+
+        Set<String> schemas =
+                capturedSchemaTables.stream().map(TableId::schema).collect(Collectors.toSet());
+
+        // reading info only for the schemas we're interested in as per the set of captured tables;
+        // while the passed table name filter alone would skip all non-included tables, reading the
+        // schema
+        // would take much longer that way
+        for (String schema : schemas) {
+            if (!sourceContext.isRunning()) {
+                throw new InterruptedException(
+                        "Interrupted while reading structure of schema " + schema);
+            }
+
+            // todo: DBZ-137 the new readSchemaForCapturedTables seems to cause failures.
+            // For now, reverted to the default readSchema implementation as the intended goal
+            // with the new implementation was to be faster, not change behavior.
+            // if
+            // (connectorConfig.getAdapter().equals(OracleConnectorConfig.ConnectorAdapter.LOG_MINER)) {
+            // jdbcConnection.readSchemaForCapturedTables(
+            // snapshotContext.tables,
+            // snapshotContext.catalogName,
+            // schema,
+            // connectorConfig.getColumnFilter(),
+            // false,
+            // snapshotContext.capturedTables);
+            // }
+            // else {
+            jdbcConnection.readSchema(snapshotContext.tables, null, schema, null, null, false);
+            // }
+        }
+    }
+
+    @Override
+    protected String enhanceOverriddenSelect(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            String overriddenSelect,
+            TableId tableId) {
+        String snapshotOffset = (String) snapshotContext.offset.getOffset().get(SourceInfo.SCN_KEY);
+        String token = connectorConfig.getTokenToReplaceInSnapshotPredicate();
+        if (token != null) {
+            return overriddenSelect.replaceAll(token, " AS OF SCN " + snapshotOffset);
+        }
+        return overriddenSelect;
+    }
+
+    @Override
+    protected void createSchemaChangeEventsForTables(
+            ChangeEventSourceContext sourceContext,
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            SnapshottingTask snapshottingTask)
+            throws Exception {
+        tryStartingSnapshot(snapshotContext);
+        for (Iterator<TableId> iterator = snapshotContext.capturedSchemaTables.iterator();
+                iterator.hasNext(); ) {
+            final TableId tableId = iterator.next();
+            if (!sourceContext.isRunning()) {
+                throw new InterruptedException(
+                        "Interrupted while capturing schema of table " + tableId);
+            }
+
+            LOGGER.info("Capturing structure of table {}", tableId);
+
+            Table table = snapshotContext.tables.forTable(tableId);
+
+            if (schema().isHistorized()) {
+                snapshotContext.offset.event(tableId, getClock().currentTime());
+
+                // If data are not snapshotted then the last schema change must set last snapshot
+                // flag
+                if (!snapshottingTask.snapshotData() && !iterator.hasNext()) {
+                    lastSnapshotRecord(snapshotContext);
+                }
+
+                dispatcher.dispatchSchemaChangeEvent(
+                        snapshotContext.partition,
+                        table.id(),
+                        (receiver) -> {
+                            try {
+                                receiver.schemaChangeEvent(
+                                        getCreateTableEvent(snapshotContext, table));
+                            } catch (Exception e) {
+                                throw new DebeziumException(e);
+                            }
+                        });
+            }
+        }
+    }
+
+    @Override
+    protected SchemaChangeEvent getCreateTableEvent(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            Table table)
+            throws SQLException {
+        return SchemaChangeEvent.ofCreate(
+                snapshotContext.partition,
+                snapshotContext.offset,
+                snapshotContext.catalogName,
+                table.id().schema(),
+                jdbcConnection.getTableMetadataDdl(table.id()),
+                table,
+                true);
+    }
+
+    @Override
+    protected Instant getSnapshotSourceTimestamp(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            TableId tableId) {
+        try {
+            Optional<OffsetDateTime> snapshotTs =
+                    jdbcConnection.getScnToTimestamp(snapshotContext.offset.getScn());
+            if (!snapshotTs.isPresent()) {
+                throw new ConnectException("Failed reading SCN timestamp from source database");
+            }
+
+            return snapshotTs.get().toInstant();
+        } catch (SQLException e) {
+            throw new ConnectException("Failed reading SCN timestamp from source database", e);
+        }
+    }
+
+    /**
+     * Generate a valid Oracle query string for the specified table and columns
+     *
+     * @param tableId the table to generate a query for
+     * @return a valid query string
+     */
+    @Override
+    protected Optional<String> getSnapshotSelect(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            TableId tableId,
+            List<String> columns) {
+        final OracleOffsetContext offset = snapshotContext.offset;
+        final String snapshotOffset = offset.getScn().toString();
+        String snapshotSelectColumns = columns.stream().collect(Collectors.joining(", "));
+        assert snapshotOffset != null;
+        return Optional.of(
+                String.format(
+                        "SELECT %s FROM %s AS OF SCN %s",
+                        snapshotSelectColumns, quote(tableId), snapshotOffset));
+    }
+
+    @Override
+    protected void complete(SnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext) {
+        if (connectorConfig.getPdbName() != null) {
+            jdbcConnection.resetSessionToCdb();
+        }
+    }
+
+    private static String quote(TableId tableId) {
+        return TableId.parse(tableId.schema() + "." + tableId.table(), true).toDoubleQuotedString();
+    }
+
+    /** Mutable context which is populated in the course of snapshotting. */
+    private static class OracleSnapshotContext
+            extends RelationalSnapshotContext<OraclePartition, OracleOffsetContext> {
+
+        private Savepoint preSchemaSnapshotSavepoint;
+
+        public OracleSnapshotContext(OraclePartition partition, String catalogName)
+                throws SQLException {
+            super(partition, catalogName);
+        }
+    }
+}


### PR DESCRIPTION
When Debezium executes an Oracle CDC task, it will load all tables which the data will be snapshotted, causing unnecessary resource consumption and increasing latency, and may even cause the task to fail due to issues with other unrelated tables.

io.debezium.relational.RelationalSnapshotChangeEventSource.determineCapturedTables

After modifying the source code of Debezium, only the target table can be captured, improving job efficiency and reducing resource consumption.

This optimization has been applied in production.

close #2579 