### PR TITLE
Use SampleBucketSplitStrategy for shard collection with hashed keys #2504

### DIFF
--- a/docs/content/connectors/mongodb-cdc(ZH).md
+++ b/docs/content/connectors/mongodb-cdc(ZH).md
@@ -273,7 +273,7 @@ upstart 流需要一个唯一的密钥，所以我们必须声明 `_id` 作为�
     <tr>
       <td>scan.incremental.snapshot.chunk.samples</td>
       <td>optional</td>
-      <td style="word-wrap: break-word;">64</td>
+      <td style="word-wrap: break-word;">20</td>
       <td>Integer</td>
       <td>读取增量快照时，如果采用采样方式划分chunk，每个chunk采样的数据条数。</td>
     </tr>

--- a/docs/content/connectors/mongodb-cdc(ZH).md
+++ b/docs/content/connectors/mongodb-cdc(ZH).md
@@ -271,6 +271,13 @@ upstart 流需要一个唯一的密钥，所以我们必须声明 `_id` 作为�
       <td>增量快照的区块大小 mb。</td>
     </tr>
     <tr>
+      <td>scan.incremental.snapshot.chunk.samples</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">64</td>
+      <td>Integer</td>
+      <td>读取增量快照时，如果采用采样方式划分chunk，每个chunk采样的数据条数。</td>
+    </tr>
+    <tr>
       <td>scan.incremental.close-idle-reader.enabled</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">false</td>

--- a/docs/content/connectors/mongodb-cdc(ZH).md
+++ b/docs/content/connectors/mongodb-cdc(ZH).md
@@ -275,7 +275,7 @@ upstart 流需要一个唯一的密钥，所以我们必须声明 `_id` 作为�
       <td>optional</td>
       <td style="word-wrap: break-word;">20</td>
       <td>Integer</td>
-      <td>读取增量快照时，如果采用采样方式划分chunk，每个chunk采样的数据条数。</td>
+      <td>采样分片策略，每个chunk采样的数据条数。</td>
     </tr>
     <tr>
       <td>scan.incremental.close-idle-reader.enabled</td>

--- a/docs/content/connectors/mongodb-cdc.md
+++ b/docs/content/connectors/mongodb-cdc.md
@@ -277,6 +277,13 @@ Connector Options
       <td>The chunk size mb of incremental snapshot.</td>
     </tr>
     <tr>
+      <td>scan.incremental.snapshot.chunk.samples</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">64</td>
+      <td>Integer</td>
+      <td>The sample count per chunk when using SampleBucketSplitStrategy during incremental snapshot.</td>
+    </tr>
+    <tr>
       <td>scan.incremental.close-idle-reader.enabled</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">false</td>

--- a/docs/content/connectors/mongodb-cdc.md
+++ b/docs/content/connectors/mongodb-cdc.md
@@ -279,7 +279,7 @@ Connector Options
     <tr>
       <td>scan.incremental.snapshot.chunk.samples</td>
       <td>optional</td>
-      <td style="word-wrap: break-word;">64</td>
+      <td style="word-wrap: break-word;">20</td>
       <td>Integer</td>
       <td>The sample count per chunk when using SampleBucketSplitStrategy during incremental snapshot.</td>
     </tr>

--- a/docs/content/connectors/mongodb-cdc.md
+++ b/docs/content/connectors/mongodb-cdc.md
@@ -281,7 +281,7 @@ Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">20</td>
       <td>Integer</td>
-      <td>The sample count per chunk when using SampleBucketSplitStrategy during incremental snapshot.</td>
+      <td>The samples count per chunk when using sample partition strategy during incremental snapshot.</td>
     </tr>
     <tr>
       <td>scan.incremental.close-idle-reader.enabled</td>

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/MongoDBSourceBuilder.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/MongoDBSourceBuilder.java
@@ -179,6 +179,16 @@ public class MongoDBSourceBuilder<T> {
     }
 
     /**
+     * scan.incremental.snapshot.chunk.samples
+     *
+     * <p>The number of samples to take per chunk. Defaults to 20.
+     */
+    public MongoDBSourceBuilder<T> samplesPerChunk(int samplesPerChunk) {
+        this.configFactory.samplesPerChunk(samplesPerChunk);
+        return this;
+    }
+
+    /**
      * scan.incremental.close-idle-reader.enabled
      *
      * <p>Whether to close idle readers at the end of the snapshot phase. This feature depends on

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/assigners/splitters/SampleBucketSplitStrategy.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/assigners/splitters/SampleBucketSplitStrategy.java
@@ -72,9 +72,6 @@ public class SampleBucketSplitStrategy implements SplitStrategy {
 
     public static final SampleBucketSplitStrategy INSTANCE = new SampleBucketSplitStrategy();
     private static final int DEFAULT_SAMPLING_THRESHOLD = 102400;
-    private static final double DEFAULT_SAMPLING_RATE = 0.05;
-    private static final int SAMPLING_COUNT_BY_RATE_THRESHOLD = 1000000;
-    private static final int MAX_SAMPLE_PER_CHUNK = 20;
 
     private SampleBucketSplitStrategy() {}
 
@@ -97,12 +94,8 @@ public class SampleBucketSplitStrategy implements SplitStrategy {
             // full sampling if document count less than sampling size threshold.
             numberOfSamples = (int) count;
         } else {
-            // sampled using sample rate.
-            numberOfSamples = (int) Math.floor(count * DEFAULT_SAMPLING_RATE);
             // avoid sampling too much records on a huge collection
-            if (numberOfSamples > SAMPLING_COUNT_BY_RATE_THRESHOLD) {
-                numberOfSamples = numChunks * MAX_SAMPLE_PER_CHUNK;
-            }
+            numberOfSamples = numChunks * splitContext.getSamplesPerChunk();
         }
 
         TableId collectionId = splitContext.getCollectionId();

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/assigners/splitters/SampleBucketSplitStrategy.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/assigners/splitters/SampleBucketSplitStrategy.java
@@ -94,8 +94,7 @@ public class SampleBucketSplitStrategy implements SplitStrategy {
             // full sampling if document count less than sampling size threshold.
             numberOfSamples = (int) count;
         } else {
-            // avoid sampling too much records on a huge collection
-            numberOfSamples = numChunks * splitContext.getSamplesPerChunk();
+            numberOfSamples = Math.min(numChunks * splitContext.getSamplesPerChunk(), (int) count);
         }
 
         TableId collectionId = splitContext.getCollectionId();

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/assigners/splitters/SplitContext.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/assigners/splitters/SplitContext.java
@@ -39,16 +39,19 @@ public class SplitContext {
     private final TableId collectionId;
     private final BsonDocument collectionStats;
     private final int chunkSizeMB;
+    private final int samplesPerChunk;
 
     public SplitContext(
             MongoClient mongoClient,
             TableId collectionId,
             BsonDocument collectionStats,
-            int chunkSizeMB) {
+            int chunkSizeMB,
+            int samplesPerChunk) {
         this.mongoClient = mongoClient;
         this.collectionId = collectionId;
         this.collectionStats = collectionStats;
         this.chunkSizeMB = chunkSizeMB;
+        this.samplesPerChunk = samplesPerChunk;
     }
 
     public static SplitContext of(MongoDBSourceConfig sourceConfig, TableId collectionId) {
@@ -57,7 +60,8 @@ public class SplitContext {
                 mongoClient,
                 collectionId,
                 collStats(mongoClient, collectionId),
-                sourceConfig.getSplitSize());
+                sourceConfig.getSplitSize(),
+                sourceConfig.getSamplesPerChunk());
     }
 
     public MongoClient getMongoClient() {
@@ -70,6 +74,10 @@ public class SplitContext {
 
     public int getChunkSizeMB() {
         return chunkSizeMB;
+    }
+
+    public int getSamplesPerChunk() {
+        return samplesPerChunk;
     }
 
     /** The number of objects or documents in this collection. */

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfig.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfig.java
@@ -48,6 +48,7 @@ public class MongoDBSourceConfig implements SourceConfig {
     private final int heartbeatIntervalMillis;
     private final int splitMetaGroupSize;
     private final int splitSizeMB;
+    private final int samplesPerChunk;
     private final boolean closeIdleReaders;
     private final boolean enableFullDocPrePostImage;
     private final boolean disableCursorTimeout;
@@ -68,6 +69,7 @@ public class MongoDBSourceConfig implements SourceConfig {
             int heartbeatIntervalMillis,
             int splitMetaGroupSize,
             int splitSizeMB,
+            int samplesPerChunk,
             boolean closeIdleReaders,
             boolean enableFullDocPrePostImage,
             boolean disableCursorTimeout) {
@@ -87,6 +89,7 @@ public class MongoDBSourceConfig implements SourceConfig {
         this.heartbeatIntervalMillis = heartbeatIntervalMillis;
         this.splitMetaGroupSize = splitMetaGroupSize;
         this.splitSizeMB = splitSizeMB;
+        this.samplesPerChunk = samplesPerChunk;
         this.closeIdleReaders = closeIdleReaders;
         this.enableFullDocPrePostImage = enableFullDocPrePostImage;
         this.disableCursorTimeout = disableCursorTimeout;
@@ -159,6 +162,10 @@ public class MongoDBSourceConfig implements SourceConfig {
         return splitMetaGroupSize;
     }
 
+    public int getSamplesPerChunk() {
+        return samplesPerChunk;
+    }
+
     @Override
     public boolean isIncludeSchemaChanges() {
         return false;
@@ -194,6 +201,7 @@ public class MongoDBSourceConfig implements SourceConfig {
                 && heartbeatIntervalMillis == that.heartbeatIntervalMillis
                 && splitMetaGroupSize == that.splitMetaGroupSize
                 && splitSizeMB == that.splitSizeMB
+                && samplesPerChunk == that.samplesPerChunk
                 && closeIdleReaders == that.closeIdleReaders
                 && Objects.equals(scheme, that.scheme)
                 && Objects.equals(hosts, that.hosts)
@@ -222,6 +230,7 @@ public class MongoDBSourceConfig implements SourceConfig {
                 heartbeatIntervalMillis,
                 splitMetaGroupSize,
                 splitSizeMB,
+                samplesPerChunk,
                 closeIdleReaders);
     }
 }

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfigFactory.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfigFactory.java
@@ -32,6 +32,7 @@ import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOp
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.HEARTBEAT_INTERVAL_MILLIS;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_AWAIT_TIME_MILLIS;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_MAX_BATCH_SIZE;
+import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCHEME;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -58,6 +59,7 @@ public class MongoDBSourceConfigFactory implements Factory<MongoDBSourceConfig> 
     private Integer heartbeatIntervalMillis = HEARTBEAT_INTERVAL_MILLIS.defaultValue();
     private Integer splitMetaGroupSize = CHUNK_META_GROUP_SIZE.defaultValue();
     private Integer splitSizeMB = SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB.defaultValue();
+    private Integer samplesPerChunk = SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES.defaultValue();
     private boolean closeIdleReaders = false;
     private boolean enableFullDocPrePostImage = false;
     private boolean disableCursorTimeout = true;
@@ -207,6 +209,17 @@ public class MongoDBSourceConfigFactory implements Factory<MongoDBSourceConfig> 
     }
 
     /**
+     * scan.incremental.snapshot.chunk.samples
+     *
+     * <p>The number of samples to take per chunk. Defaults to 20.
+     */
+    public MongoDBSourceConfigFactory samplesPerChunk(int samplesPerChunk) {
+        checkArgument(samplesPerChunk > 0);
+        this.samplesPerChunk = samplesPerChunk;
+        return this;
+    }
+
+    /**
      * Whether to close idle readers at the end of the snapshot phase. This feature depends on
      * FLIP-147: Support Checkpoints After Tasks Finished. The flink version is required to be
      * greater than or equal to 1.14, and the configuration <code>
@@ -261,6 +274,7 @@ public class MongoDBSourceConfigFactory implements Factory<MongoDBSourceConfig> 
                 heartbeatIntervalMillis,
                 splitMetaGroupSize,
                 splitSizeMB,
+                samplesPerChunk,
                 closeIdleReaders,
                 enableFullDocPrePostImage,
                 disableCursorTimeout);

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceOptions.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceOptions.java
@@ -135,6 +135,13 @@ public class MongoDBSourceOptions {
                             "The chunk size mb of incremental snapshot. Defaults to 64mb.");
 
     @Experimental
+    public static final ConfigOption<Integer> SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES =
+            ConfigOptions.key("scan.incremental.snapshot.chunk.samples")
+                    .intType()
+                    .defaultValue(20)
+                    .withDescription("The number of samples to take per chunk. Defaults to 20.");
+
+    @Experimental
     public static final ConfigOption<Boolean> FULL_DOCUMENT_PRE_POST_IMAGE =
             ConfigOptions.key("scan.full-changelog")
                     .booleanType()

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
@@ -79,6 +79,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
     private final boolean enableParallelRead;
     private final Integer splitMetaGroupSize;
     private final Integer splitSizeMB;
+    private final Integer samplesPerChunk;
     private final boolean closeIdlerReaders;
     private final boolean enableFullDocPrePostImage;
     private final boolean noCursorTimeout;
@@ -112,6 +113,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
             boolean enableParallelRead,
             @Nullable Integer splitMetaGroupSize,
             @Nullable Integer splitSizeMB,
+            @Nullable Integer samplesPerChunk,
             boolean closeIdlerReaders,
             boolean enableFullDocPrePostImage,
             boolean noCursorTimeout) {
@@ -135,6 +137,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
         this.enableParallelRead = enableParallelRead;
         this.splitMetaGroupSize = splitMetaGroupSize;
         this.splitSizeMB = splitSizeMB;
+        this.samplesPerChunk = samplesPerChunk;
         this.closeIdlerReaders = closeIdlerReaders;
         this.enableFullDocPrePostImage = enableFullDocPrePostImage;
         this.noCursorTimeout = noCursorTimeout;
@@ -209,6 +212,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                     .ifPresent(builder::heartbeatIntervalMillis);
             Optional.ofNullable(splitMetaGroupSize).ifPresent(builder::splitMetaGroupSize);
             Optional.ofNullable(splitSizeMB).ifPresent(builder::splitSizeMB);
+            Optional.ofNullable(samplesPerChunk).ifPresent(builder::samplesPerChunk);
             return SourceProvider.of(builder.build());
         } else {
             com.ververica.cdc.connectors.mongodb.MongoDBSource.Builder<RowData> builder =
@@ -289,6 +293,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                         enableParallelRead,
                         splitMetaGroupSize,
                         splitSizeMB,
+                        samplesPerChunk,
                         closeIdlerReaders,
                         enableFullDocPrePostImage,
                         noCursorTimeout);
@@ -324,6 +329,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                 && Objects.equals(enableParallelRead, that.enableParallelRead)
                 && Objects.equals(splitMetaGroupSize, that.splitMetaGroupSize)
                 && Objects.equals(splitSizeMB, that.splitSizeMB)
+                && Objects.equals(samplesPerChunk, that.samplesPerChunk)
                 && Objects.equals(producedDataType, that.producedDataType)
                 && Objects.equals(metadataKeys, that.metadataKeys)
                 && Objects.equals(closeIdlerReaders, that.closeIdlerReaders)
@@ -352,6 +358,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                 enableParallelRead,
                 splitMetaGroupSize,
                 splitSizeMB,
+                samplesPerChunk,
                 producedDataType,
                 metadataKeys,
                 closeIdlerReaders,

--- a/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
+++ b/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
@@ -49,6 +49,7 @@ import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOp
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.PASSWORD;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_AWAIT_TIME_MILLIS;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_MAX_BATCH_SIZE;
+import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_NO_CURSOR_TIMEOUT;
@@ -104,6 +105,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
 
         int splitSizeMB = config.get(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB);
         int splitMetaGroupSize = config.get(CHUNK_META_GROUP_SIZE);
+        int samplesPerChunk = config.get(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES);
 
         boolean enableFullDocumentPrePostImage =
                 config.getOptional(FULL_DOCUMENT_PRE_POST_IMAGE).orElse(false);
@@ -135,6 +137,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
                 enableParallelRead,
                 splitMetaGroupSize,
                 splitSizeMB,
+                samplesPerChunk,
                 enableCloseIdleReaders,
                 enableFullDocumentPrePostImage,
                 noCursorTimeout);
@@ -207,6 +210,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
         options.add(HEARTBEAT_INTERVAL_MILLIS);
         options.add(SCAN_INCREMENTAL_SNAPSHOT_ENABLED);
         options.add(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB);
+        options.add(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES);
         options.add(CHUNK_META_GROUP_SIZE);
         options.add(SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED);
         options.add(FULL_DOCUMENT_PRE_POST_IMAGE);

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/MongoDBFullChangelogITCase.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/MongoDBFullChangelogITCase.java
@@ -76,6 +76,7 @@ public class MongoDBFullChangelogITCase extends MongoDBSourceTestBase {
                 new MongoDBSourceConfigFactory()
                         .hosts(CONTAINER.getHostAndPort())
                         .splitSizeMB(1)
+                        .samplesPerChunk(10)
                         .pollAwaitTimeMillis(500)
                         .create(0);
 

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBSnapshotSplitReaderTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBSnapshotSplitReaderTest.java
@@ -79,6 +79,7 @@ public class MongoDBSnapshotSplitReaderTest extends MongoDBSourceTestBase {
                         .username(FLINK_USER)
                         .password(FLINK_USER_PASSWORD)
                         .splitSizeMB(1)
+                        .samplesPerChunk(10)
                         .pollAwaitTimeMillis(500);
 
         sourceConfig = configFactory.create(0);

--- a/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
+++ b/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
@@ -53,6 +53,7 @@ import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOp
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.HEARTBEAT_INTERVAL_MILLIS;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_AWAIT_TIME_MILLIS;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_MAX_BATCH_SIZE;
+import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_NO_CURSOR_TIMEOUT;
@@ -104,6 +105,8 @@ public class MongoDBTableFactoryTest {
             SCAN_INCREMENTAL_SNAPSHOT_ENABLED.defaultValue();
     private static final int SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB_DEFAULT =
             SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB.defaultValue();
+    private static final int SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES_DEFAULT =
+            SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES.defaultValue();
     private static final int CHUNK_META_GROUP_SIZE_DEFAULT = CHUNK_META_GROUP_SIZE.defaultValue();
     private static final boolean SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT =
             SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue();
@@ -140,6 +143,7 @@ public class MongoDBTableFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_ENABLED_DEFAULT,
                         CHUNK_META_GROUP_SIZE_DEFAULT,
                         SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB_DEFAULT,
+                        SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES_DEFAULT,
                         SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT,
                         FULL_DOCUMENT_PRE_POST_IMAGE_ENABLED_DEFAULT,
                         SCAN_NO_CURSOR_TIMEOUT_DEFAULT);
@@ -161,6 +165,7 @@ public class MongoDBTableFactoryTest {
         options.put("scan.incremental.snapshot.enabled", "true");
         options.put("chunk-meta.group.size", "1001");
         options.put("scan.incremental.snapshot.chunk.size.mb", "10");
+        options.put("scan.incremental.snapshot.chunk.samples", "10");
         options.put("scan.incremental.close-idle-reader.enabled", "true");
         options.put("scan.full-changelog", "true");
         options.put("scan.cursor.no-timeout", "false");
@@ -185,6 +190,7 @@ public class MongoDBTableFactoryTest {
                         LOCAL_TIME_ZONE,
                         true,
                         1001,
+                        10,
                         10,
                         true,
                         true,
@@ -224,6 +230,7 @@ public class MongoDBTableFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_ENABLED_DEFAULT,
                         CHUNK_META_GROUP_SIZE_DEFAULT,
                         SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB_DEFAULT,
+                        SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES_DEFAULT,
                         SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT,
                         FULL_DOCUMENT_PRE_POST_IMAGE_ENABLED_DEFAULT,
                         SCAN_NO_CURSOR_TIMEOUT_DEFAULT);


### PR DESCRIPTION
Use SampleBucketSplitStrategy for shard collection which contain hashed key, this would avoid OOM exception if some chunk contains huge records which could not be hold in a local HashMap.

Close #2504 