### PR TITLE
[pom] Use ${revision} replace specific version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ build-targetatlassian-ide-plugin.xml
 *.ipr
 *.iws
 docs/_build
+**/.flattened-pom.xml

--- a/flink-cdc-cli/pom.xml
+++ b/flink-cdc-cli/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-common/pom.xml
+++ b/flink-cdc-common/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-composer/pom.xml
+++ b/flink-cdc-composer/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-connect</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-db2-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-db2-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oceanbase-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oceanbase-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <properties>
         <!-- Because of oceanbase docker image can not expose port quickly, so we need to specify testcontainers version to 1.15.3 -->

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <properties>
         <xdb.version>19.3.0.0</xdb.version>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-test-util/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-test-util/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-vitess-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-vitess-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-db2-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-db2-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mongodb-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mongodb-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mysql-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mysql-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-oceanbase-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-oceanbase-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-oracle-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-oracle-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-postgres-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-postgres-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-sqlserver-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-sqlserver-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-tidb-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-tidb-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-vitess-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-vitess-cdc/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-source-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-connect</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-connect/pom.xml
+++ b/flink-cdc-connect/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-dist/pom.xml
+++ b/flink-cdc-dist/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/pom.xml
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-e2e-tests</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/pom.xml
+++ b/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-e2e-tests</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-e2e-tests/pom.xml
+++ b/flink-cdc-e2e-tests/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-cdc-runtime/pom.xml
+++ b/flink-cdc-runtime/pom.xml
@@ -19,7 +19,7 @@ under the License.
     <parent>
         <artifactId>flink-cdc-connectors</artifactId>
         <groupId>com.ververica</groupId>
-        <version>3.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ under the License.
 
     <groupId>com.ververica</groupId>
     <artifactId>flink-cdc-connectors</artifactId>
-    <version>3.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -60,6 +60,7 @@ under the License.
     </distributionManagement>
 
     <properties>
+        <revision>3.0-SNAPSHOT</revision>
         <java.version>1.8</java.version>
         <scala.binary.version>2.12</scala.binary.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -84,6 +85,7 @@ under the License.
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <json-path.version>2.7.0</json-path.version>
         <markBundledAsOptional>true</markBundledAsOptional>
+        <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -464,6 +466,33 @@ under the License.
                 <configuration>
                     <doclint>none</doclint>
                 </configuration>
+            </plugin>
+
+            <!-- This plugin takes effect for Maven version upper more than 3.5.0 -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>${flatten-maven-plugin.version}</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <phase>clean</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
As we use specific version like "3.0-SNAPSHOT", we need to repeat modifications between different modules. So why not use a placeholder like ${revision}.