### PR TITLE
[flink-cdc-composer] Base interfaces and models for composer and pipeline definition

### DIFF
--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/PipelineComposer.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/PipelineComposer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.composer;
+
+import com.ververica.cdc.composer.definition.PipelineDef;
+
+/** Composer for translating a pipeline definition to an execution. */
+public interface PipelineComposer {
+
+    /**
+     * Composing pipeline execution from the specified pipeline definition.
+     *
+     * @param pipelineDef definition of the pipeline
+     */
+    PipelineExecution compose(PipelineDef pipelineDef);
+}

--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/PipelineExecution.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/PipelineExecution.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.composer;
+
+/** A pipeline execution that can be executed by a computing engine. */
+public interface PipelineExecution {
+
+    /** Execute the pipeline. */
+    ExecutionInfo execute() throws Exception;
+
+    /** Information of the execution. */
+    class ExecutionInfo {
+        private final String id;
+        private final String description;
+
+        public ExecutionInfo(String id, String description) {
+            this.id = id;
+            this.description = description;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+    }
+}

--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/PipelineDef.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/PipelineDef.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.composer.definition;
+
+import org.apache.flink.configuration.Configuration;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Definition of a pipeline.
+ *
+ * <p>A pipeline consists of following components:
+ *
+ * <ul>
+ *   <li>Source: data source of the pipeline. Required in the definition.
+ *   <li>Sink: data destination of the pipeline. Required in the definition.
+ *   <li>Routes: routers specifying the connection between source tables and sink tables. Optional
+ *       in the definition.
+ *   <li>Transforms: transformations for applying modifications to data change events. Optional in
+ *       the definition.
+ *   <li>Config: configurations of the pipeline. Optional in the definition.
+ * </ul>
+ *
+ * <p>This class keeps track of the raw pipeline definition made by users via pipeline definition
+ * file. A definition will be translated to a {@link com.ververica.cdc.composer.PipelineExecution}
+ * by {@link com.ververica.cdc.composer.PipelineComposer} before being submitted to the computing
+ * engine.
+ */
+public class PipelineDef {
+    private final SourceDef source;
+    private final SinkDef sink;
+    private final List<RouteDef> routes;
+    private final List<TransformDef> transforms;
+    private final Configuration config;
+
+    public PipelineDef(
+            SourceDef source,
+            SinkDef sink,
+            List<RouteDef> routes,
+            List<TransformDef> transforms,
+            Configuration config) {
+        this.source = source;
+        this.sink = sink;
+        this.routes = routes;
+        this.transforms = transforms;
+        this.config = config;
+    }
+
+    public SourceDef getSource() {
+        return source;
+    }
+
+    public SinkDef getSink() {
+        return sink;
+    }
+
+    public List<RouteDef> getRoute() {
+        return routes;
+    }
+
+    public List<TransformDef> getTransforms() {
+        return transforms;
+    }
+
+    public Configuration getConfig() {
+        return config;
+    }
+
+    @Override
+    public String toString() {
+        return "PipelineDef{"
+                + "source="
+                + source
+                + ", sink="
+                + sink
+                + ", routes="
+                + routes
+                + ", transforms="
+                + transforms
+                + ", config="
+                + config
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PipelineDef that = (PipelineDef) o;
+        return Objects.equals(source, that.source)
+                && Objects.equals(sink, that.sink)
+                && Objects.equals(routes, that.routes)
+                && Objects.equals(transforms, that.transforms)
+                && Objects.equals(config, that.config);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(source, sink, routes, transforms, config);
+    }
+}

--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/RouteDef.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/RouteDef.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.composer.definition;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * Definition of a router.
+ *
+ * <p>A router definition contains:
+ *
+ * <ul>
+ *   <li>matcher: a regex pattern for matching input table IDs. Required for the definition.
+ *   <li>replace: a string for replacing matched table IDs as output. Required for the definition.
+ *   <li>description: description for the router. Optional for the definition.
+ * </ul>
+ */
+public class RouteDef {
+    private final Pattern matcher;
+    private final String replace;
+    @Nullable private final String description;
+
+    public RouteDef(Pattern matcher, String replace, @Nullable String description) {
+        this.matcher = matcher;
+        this.replace = replace;
+        this.description = description;
+    }
+
+    public Pattern getMatcher() {
+        return matcher;
+    }
+
+    public String getReplace() {
+        return replace;
+    }
+
+    public Optional<String> getDescription() {
+        return Optional.ofNullable(description);
+    }
+
+    @Override
+    public String toString() {
+        return "RouteDef{"
+                + "matcher="
+                + matcher
+                + ", replace="
+                + replace
+                + ", description='"
+                + description
+                + '\''
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RouteDef routeDef = (RouteDef) o;
+        return Objects.equals(matcher.pattern(), routeDef.matcher.pattern())
+                && Objects.equals(replace, routeDef.replace)
+                && Objects.equals(description, routeDef.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(matcher, replace, description);
+    }
+}

--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/SinkDef.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/SinkDef.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.composer.definition;
+
+import org.apache.flink.configuration.Configuration;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Definition of a data sink.
+ *
+ * <p>A sink definition contains:
+ *
+ * <ul>
+ *   <li>type: connector type of the sink, which will be used for discovering sink implementation.
+ *       Required in the definition.
+ *   <li>name: name of the sink. Optional in the definition.
+ *   <li>config: configuration of the sink
+ * </ul>
+ */
+public class SinkDef {
+    private final String type;
+    @Nullable private final String name;
+    private final Configuration config;
+
+    public SinkDef(String type, @Nullable String name, Configuration config) {
+        this.type = type;
+        this.name = name;
+        this.config = config;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Optional<String> getName() {
+        return Optional.ofNullable(name);
+    }
+
+    public Configuration getConfig() {
+        return config;
+    }
+
+    @Override
+    public String toString() {
+        return "SinkDef{"
+                + "type='"
+                + type
+                + '\''
+                + ", name='"
+                + name
+                + '\''
+                + ", config="
+                + config
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SinkDef sinkDef = (SinkDef) o;
+        return Objects.equals(type, sinkDef.type)
+                && Objects.equals(name, sinkDef.name)
+                && Objects.equals(config, sinkDef.config);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, name, config);
+    }
+}

--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/SourceDef.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/SourceDef.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.composer.definition;
+
+import org.apache.flink.configuration.Configuration;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Definition of a data source.
+ *
+ * <p>A source definition contains:
+ *
+ * <ul>
+ *   <li>type: connector type of the source, which will be used for discovering source
+ *       implementation. Required in the definition.
+ *   <li>name: name of the source. Optional in the definition.
+ *   <li>config: configuration of the source
+ * </ul>
+ */
+public class SourceDef {
+    private final String type;
+    @Nullable private final String name;
+    private final Configuration config;
+
+    public SourceDef(String type, @Nullable String name, Configuration config) {
+        this.type = type;
+        this.name = name;
+        this.config = config;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Optional<String> getName() {
+        return Optional.ofNullable(name);
+    }
+
+    public Configuration getConfig() {
+        return config;
+    }
+
+    @Override
+    public String toString() {
+        return "SourceDef{"
+                + "type='"
+                + type
+                + '\''
+                + ", name='"
+                + name
+                + '\''
+                + ", config="
+                + config
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SourceDef sourceDef = (SourceDef) o;
+        return Objects.equals(type, sourceDef.type)
+                && Objects.equals(name, sourceDef.name)
+                && Objects.equals(config, sourceDef.config);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, name, config);
+    }
+}

--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/TransformDef.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/TransformDef.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.composer.definition;
+
+/**
+ * Definition of transformation.
+ *
+ * <p>Transformation will be implemented later, therefore we left the class blank.
+ */
+public class TransformDef {}

--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/flink/FlinkPipelineComposer.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/flink/FlinkPipelineComposer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.composer.flink;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import com.ververica.cdc.composer.PipelineComposer;
+import com.ververica.cdc.composer.PipelineExecution;
+import com.ververica.cdc.composer.definition.PipelineDef;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/** Composer for translating data pipeline to a Flink DataStream job. */
+public class FlinkPipelineComposer implements PipelineComposer {
+
+    private final StreamExecutionEnvironment env;
+    private final boolean isBlocking;
+
+    public static FlinkPipelineComposer ofRemoteCluster(
+            String host, int port, List<Path> additionalJars) {
+        String[] jarPaths = additionalJars.stream().map(Path::toString).toArray(String[]::new);
+        return new FlinkPipelineComposer(
+                StreamExecutionEnvironment.createRemoteEnvironment(host, port, jarPaths), false);
+    }
+
+    public static FlinkPipelineComposer ofMiniCluster() {
+        return new FlinkPipelineComposer(StreamExecutionEnvironment.createLocalEnvironment(), true);
+    }
+
+    private FlinkPipelineComposer(StreamExecutionEnvironment env, boolean isBlocking) {
+        this.env = env;
+        this.isBlocking = isBlocking;
+    }
+
+    @Override
+    public PipelineExecution compose(PipelineDef pipelineDef) {
+        return new FlinkPipelineExecution(env, "CDC Job", isBlocking);
+    }
+}

--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/flink/FlinkPipelineExecution.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/flink/FlinkPipelineExecution.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.composer.flink;
+
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import com.ververica.cdc.composer.PipelineExecution;
+
+/**
+ * A pipeline execution that run the defined pipeline via Flink's {@link
+ * StreamExecutionEnvironment}.
+ */
+public class FlinkPipelineExecution implements PipelineExecution {
+
+    private final StreamExecutionEnvironment env;
+    private final String jobName;
+    private final boolean isBlocking;
+
+    public FlinkPipelineExecution(
+            StreamExecutionEnvironment env, String jobName, boolean isBlocking) {
+        this.env = env;
+        this.jobName = jobName;
+        this.isBlocking = isBlocking;
+    }
+
+    @Override
+    public ExecutionInfo execute() throws Exception {
+        JobClient jobClient = env.executeAsync(jobName);
+        if (isBlocking) {
+            jobClient.getJobExecutionResult().get();
+        }
+        return new ExecutionInfo(jobClient.getJobID().toString(), jobName);
+    }
+}


### PR DESCRIPTION
This pull request implements #2608, which introduces base interfaces exposed to upper-level CLI, including:

- `PipelineComposer`: interface for composer
- `PipelineDef`: Java object abstracting a pipeline definition
- `PipelineExecution`: Abstraction for an execution of the pipeline

And a Flink implementation (just a framework without solid composing logic) is made as a proof of concept. 