### PR TITLE
[common] Introduce Configuration and related utilities

### DIFF
--- a/flink-cdc-cli/pom.xml
+++ b/flink-cdc-cli/pom.xml
@@ -33,13 +33,13 @@ under the License.
         <dependency>
             <groupId>com.ververica</groupId>
             <artifactId>flink-cdc-common</artifactId>
-            <version>${project.version}</version>
+            <version>${revision}</version>
         </dependency>
 
         <dependency>
             <groupId>com.ververica</groupId>
             <artifactId>flink-cdc-composer</artifactId>
-            <version>${project.version}</version>
+            <version>${revision}</version>
         </dependency>
 
         <dependency>

--- a/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/CliExecutor.java
+++ b/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/CliExecutor.java
@@ -16,12 +16,11 @@
 
 package com.ververica.cdc.cli;
 
-import org.apache.flink.configuration.Configuration;
-
 import com.ververica.cdc.cli.parser.PipelineDefinitionParser;
 import com.ververica.cdc.cli.parser.YamlPipelineDefinitionParser;
 import com.ververica.cdc.cli.utils.FlinkEnvironmentUtils;
 import com.ververica.cdc.common.annotation.VisibleForTesting;
+import com.ververica.cdc.common.configuration.Configuration;
 import com.ververica.cdc.composer.PipelineComposer;
 import com.ververica.cdc.composer.PipelineExecution;
 import com.ververica.cdc.composer.definition.PipelineDef;

--- a/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/CliFrontend.java
+++ b/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/CliFrontend.java
@@ -16,11 +16,10 @@
 
 package com.ververica.cdc.cli;
 
-import org.apache.flink.configuration.Configuration;
-
 import com.ververica.cdc.cli.utils.ConfigurationUtils;
 import com.ververica.cdc.cli.utils.FlinkEnvironmentUtils;
 import com.ververica.cdc.common.annotation.VisibleForTesting;
+import com.ververica.cdc.common.configuration.Configuration;
 import com.ververica.cdc.composer.PipelineExecution;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;

--- a/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/parser/PipelineDefinitionParser.java
+++ b/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/parser/PipelineDefinitionParser.java
@@ -16,8 +16,7 @@
 
 package com.ververica.cdc.cli.parser;
 
-import org.apache.flink.configuration.Configuration;
-
+import com.ververica.cdc.common.configuration.Configuration;
 import com.ververica.cdc.composer.definition.PipelineDef;
 
 import java.nio.file.Path;

--- a/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/parser/YamlPipelineDefinitionParser.java
+++ b/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/parser/YamlPipelineDefinitionParser.java
@@ -16,13 +16,12 @@
 
 package com.ververica.cdc.cli.parser;
 
-import org.apache.flink.configuration.Configuration;
-
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
+import com.ververica.cdc.common.configuration.Configuration;
 import com.ververica.cdc.composer.definition.PipelineDef;
 import com.ververica.cdc.composer.definition.RouteDef;
 import com.ververica.cdc.composer.definition.SinkDef;
@@ -35,7 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import static org.apache.flink.shaded.guava31.com.google.common.base.Preconditions.checkNotNull;
+import static com.ververica.cdc.common.utils.Preconditions.checkNotNull;
 
 /** Parser for converting YAML formatted pipeline definition to {@link PipelineDef}. */
 public class YamlPipelineDefinitionParser implements PipelineDefinitionParser {

--- a/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/utils/ConfigurationUtils.java
+++ b/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/utils/ConfigurationUtils.java
@@ -16,18 +16,18 @@
 
 package com.ververica.cdc.cli.utils;
 
-import org.apache.flink.configuration.Configuration;
-
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import com.ververica.cdc.common.configuration.Configuration;
 
 import java.io.FileNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
-/** Utilities for handling {@link Configuration} in Flink. */
+/** Utilities for handling {@link Configuration}. */
 public class ConfigurationUtils {
     public static Configuration loadMapFormattedConfig(Path configPath) throws Exception {
         if (!Files.exists(configPath)) {

--- a/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/utils/FlinkEnvironmentUtils.java
+++ b/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/utils/FlinkEnvironmentUtils.java
@@ -16,10 +16,9 @@
 
 package com.ververica.cdc.cli.utils;
 
-import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.ConfigOptions;
-import org.apache.flink.configuration.Configuration;
-
+import com.ververica.cdc.common.configuration.ConfigOption;
+import com.ververica.cdc.common.configuration.ConfigOptions;
+import com.ververica.cdc.common.configuration.Configuration;
 import com.ververica.cdc.composer.flink.FlinkPipelineComposer;
 
 import java.nio.file.Path;

--- a/flink-cdc-cli/src/test/java/com/ververica/cdc/cli/parser/YamlPipelineDefinitionParserTest.java
+++ b/flink-cdc-cli/src/test/java/com/ververica/cdc/cli/parser/YamlPipelineDefinitionParserTest.java
@@ -16,11 +16,10 @@
 
 package com.ververica.cdc.cli.parser;
 
-import org.apache.flink.configuration.Configuration;
-
 import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
 import org.apache.flink.shaded.guava31.com.google.common.io.Resources;
 
+import com.ververica.cdc.common.configuration.Configuration;
 import com.ververica.cdc.composer.definition.PipelineDef;
 import com.ververica.cdc.composer.definition.RouteDef;
 import com.ververica.cdc.composer.definition.SinkDef;

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigOption.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigOption.java
@@ -16,8 +16,7 @@
 
 package com.ververica.cdc.common.configuration;
 
-import org.apache.flink.annotation.PublicEvolving;
-
+import com.ververica.cdc.common.annotation.PublicEvolving;
 import com.ververica.cdc.common.configuration.description.Description;
 
 import java.util.Arrays;

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigOption.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigOption.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import com.ververica.cdc.common.configuration.description.Description;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import static com.ververica.cdc.common.utils.Preconditions.checkNotNull;
+
+/**
+ * A {@code ConfigOption} describes a configuration parameter. It encapsulates the configuration
+ * key, deprecated older versions of the key, and an optional default value for the configuration
+ * parameter.
+ *
+ * <p>{@code ConfigOptions} are built via the {@link ConfigOptions} class. Once created, a config
+ * option is immutable.
+ *
+ * @param <T> The type of value associated with the configuration option.
+ */
+@PublicEvolving
+public class ConfigOption<T> {
+
+    private static final FallbackKey[] EMPTY = new FallbackKey[0];
+
+    static final Description EMPTY_DESCRIPTION = Description.builder().text("").build();
+
+    // ------------------------------------------------------------------------
+
+    /** The current key for that config option. */
+    private final String key;
+
+    /** The list of deprecated keys, in the order to be checked. */
+    private final FallbackKey[] fallbackKeys;
+
+    /** The default value for this option. */
+    private final T defaultValue;
+
+    /** The description for this option. */
+    private final Description description;
+
+    /**
+     * Type of the value that this ConfigOption describes.
+     *
+     * <ul>
+     *   <li>typeClass == atomic class (e.g. {@code Integer.class}) -> {@code ConfigOption<Integer>}
+     *   <li>typeClass == {@code Map.class} -> {@code ConfigOption<Map<String, String>>}
+     *   <li>typeClass == atomic class and isList == true for {@code ConfigOption<List<Integer>>}
+     * </ul>
+     */
+    private final Class<?> clazz;
+
+    private final boolean isList;
+
+    // ------------------------------------------------------------------------
+
+    Class<?> getClazz() {
+        return clazz;
+    }
+
+    boolean isList() {
+        return isList;
+    }
+
+    /**
+     * Creates a new config option with fallback keys.
+     *
+     * @param key The current key for that config option
+     * @param clazz describes type of the ConfigOption, see description of the clazz field
+     * @param description Description for that option
+     * @param defaultValue The default value for this option
+     * @param isList tells if the ConfigOption describes a list option, see description of the clazz
+     *     field
+     * @param fallbackKeys The list of fallback keys, in the order to be checked
+     */
+    ConfigOption(
+            String key,
+            Class<?> clazz,
+            Description description,
+            T defaultValue,
+            boolean isList,
+            FallbackKey... fallbackKeys) {
+        this.key = checkNotNull(key);
+        this.description = description;
+        this.defaultValue = defaultValue;
+        this.fallbackKeys = fallbackKeys == null || fallbackKeys.length == 0 ? EMPTY : fallbackKeys;
+        this.clazz = checkNotNull(clazz);
+        this.isList = isList;
+    }
+
+    // ------------------------------------------------------------------------
+
+    /**
+     * Creates a new config option, using this option's key and default value, and adding the given
+     * fallback keys.
+     *
+     * <p>When obtaining a value from the configuration via {@link Configuration#get(ConfigOption)},
+     * the fallback keys will be checked in the order provided to this method. The first key for
+     * which a value is found will be used - that value will be returned.
+     *
+     * @param fallbackKeys The fallback keys, in the order in which they should be checked.
+     * @return A new config options, with the given fallback keys.
+     */
+    public ConfigOption<T> withFallbackKeys(String... fallbackKeys) {
+        final Stream<FallbackKey> newFallbackKeys =
+                Arrays.stream(fallbackKeys).map(FallbackKey::createFallbackKey);
+        final Stream<FallbackKey> currentAlternativeKeys = Arrays.stream(this.fallbackKeys);
+
+        // put fallback keys first so that they are prioritized
+        final FallbackKey[] mergedAlternativeKeys =
+                Stream.concat(newFallbackKeys, currentAlternativeKeys).toArray(FallbackKey[]::new);
+        return new ConfigOption<>(
+                key, clazz, description, defaultValue, isList, mergedAlternativeKeys);
+    }
+
+    /**
+     * Creates a new config option, using this option's key and default value, and adding the given
+     * deprecated keys.
+     *
+     * <p>When obtaining a value from the configuration via {@link Configuration#get(ConfigOption)},
+     * the deprecated keys will be checked in the order provided to this method. The first key for
+     * which a value is found will be used - that value will be returned.
+     *
+     * @param deprecatedKeys The deprecated keys, in the order in which they should be checked.
+     * @return A new config options, with the given deprecated keys.
+     */
+    public ConfigOption<T> withDeprecatedKeys(String... deprecatedKeys) {
+        final Stream<FallbackKey> newDeprecatedKeys =
+                Arrays.stream(deprecatedKeys).map(FallbackKey::createDeprecatedKey);
+        final Stream<FallbackKey> currentAlternativeKeys = Arrays.stream(this.fallbackKeys);
+
+        // put deprecated keys last so that they are de-prioritized
+        final FallbackKey[] mergedAlternativeKeys =
+                Stream.concat(currentAlternativeKeys, newDeprecatedKeys)
+                        .toArray(FallbackKey[]::new);
+        return new ConfigOption<>(
+                key, clazz, description, defaultValue, isList, mergedAlternativeKeys);
+    }
+
+    /**
+     * Creates a new config option, using this option's key and default value, and adding the given
+     * description. The given description is used when generation the configuration documentation.
+     *
+     * @param description The description for this option.
+     * @return A new config option, with given description.
+     */
+    public ConfigOption<T> withDescription(final String description) {
+        return withDescription(Description.builder().text(description).build());
+    }
+
+    /**
+     * Creates a new config option, using this option's key and default value, and adding the given
+     * description. The given description is used when generation the configuration documentation.
+     *
+     * @param description The description for this option.
+     * @return A new config option, with given description.
+     */
+    public ConfigOption<T> withDescription(final Description description) {
+        return new ConfigOption<>(key, clazz, description, defaultValue, isList, fallbackKeys);
+    }
+
+    // ------------------------------------------------------------------------
+
+    /**
+     * Gets the configuration key.
+     *
+     * @return The configuration key
+     */
+    public String key() {
+        return key;
+    }
+
+    /**
+     * Checks if this option has a default value.
+     *
+     * @return True if it has a default value, false if not.
+     */
+    public boolean hasDefaultValue() {
+        return defaultValue != null;
+    }
+
+    /**
+     * Returns the default value, or null, if there is no default value.
+     *
+     * @return The default value, or null.
+     */
+    public T defaultValue() {
+        return defaultValue;
+    }
+
+    /**
+     * Checks whether this option has fallback keys.
+     *
+     * @return True if the option has fallback keys, false if not.
+     */
+    public boolean hasFallbackKeys() {
+        return fallbackKeys != EMPTY;
+    }
+
+    /**
+     * Gets the fallback keys, in the order to be checked.
+     *
+     * @return The option's fallback keys.
+     */
+    public Iterable<FallbackKey> fallbackKeys() {
+        return (fallbackKeys == EMPTY) ? Collections.emptyList() : Arrays.asList(fallbackKeys);
+    }
+
+    /**
+     * Returns the description of this option.
+     *
+     * @return The option's description.
+     */
+    public Description description() {
+        return description;
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o != null && o.getClass() == ConfigOption.class) {
+            ConfigOption<?> that = (ConfigOption<?>) o;
+            return this.key.equals(that.key)
+                    && Arrays.equals(this.fallbackKeys, that.fallbackKeys)
+                    && (this.defaultValue == null
+                            ? that.defaultValue == null
+                            : (that.defaultValue != null
+                                    && this.defaultValue.equals(that.defaultValue)));
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * key.hashCode()
+                + 17 * Arrays.hashCode(fallbackKeys)
+                + (defaultValue != null ? defaultValue.hashCode() : 0);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "Key: '%s' , default: %s (fallback keys: %s)",
+                key, defaultValue, Arrays.toString(fallbackKeys));
+    }
+}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigOption.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigOption.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigOptions.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigOptions.java
@@ -16,8 +16,7 @@
 
 package com.ververica.cdc.common.configuration;
 
-import org.apache.flink.annotation.PublicEvolving;
-
+import com.ververica.cdc.common.annotation.PublicEvolving;
 import com.ververica.cdc.common.configuration.description.Description;
 
 import java.time.Duration;

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigOptions.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigOptions.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import com.ververica.cdc.common.configuration.description.Description;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static com.ververica.cdc.common.utils.Preconditions.checkNotNull;
+
+/**
+ * {@code ConfigOptions} are used to build a {@link ConfigOption}. The option is typically built in
+ * one of the following pattern:
+ *
+ * <pre>{@code
+ * // simple string-valued option with a default value
+ * ConfigOption<String> tempDirs = ConfigOptions
+ *     .key("tmp.dir")
+ *     .stringType()
+ *     .defaultValue("/tmp");
+ *
+ * // simple integer-valued option with a default value
+ * ConfigOption<Integer> parallelism = ConfigOptions
+ *     .key("application.parallelism")
+ *     .intType()
+ *     .defaultValue(100);
+ *
+ * // option of list of integers with a default value
+ * ConfigOption<Integer> parallelism = ConfigOptions
+ *     .key("application.ports")
+ *     .intType()
+ *     .asList()
+ *     .defaultValue(8000, 8001, 8002);
+ *
+ * // option with no default value
+ * ConfigOption<String> userName = ConfigOptions
+ *     .key("user.name")
+ *     .stringType()
+ *     .noDefaultValue();
+ *
+ * // option with deprecated keys to check
+ * ConfigOption<Double> threshold = ConfigOptions
+ *     .key("cpu.utilization.threshold")
+ *     .doubleType()
+ *     .defaultValue(0.9)
+ *     .withDeprecatedKeys("cpu.threshold");
+ * }</pre>
+ */
+@PublicEvolving
+public class ConfigOptions {
+
+    /**
+     * Starts building a new {@link ConfigOption}.
+     *
+     * @param key The key for the config option.
+     * @return The builder for the config option with the given key.
+     */
+    public static OptionBuilder key(String key) {
+        checkNotNull(key);
+        return new OptionBuilder(key);
+    }
+
+    // ------------------------------------------------------------------------
+
+    /**
+     * The option builder is used to create a {@link ConfigOption}. It is instantiated via {@link
+     * ConfigOptions#key(String)}.
+     */
+    public static final class OptionBuilder {
+        /**
+         * Workaround to reuse the {@link TypedConfigOptionBuilder} for a {@link Map Map&lt;String,
+         * String&gt;}.
+         */
+        @SuppressWarnings("unchecked")
+        private static final Class<Map<String, String>> PROPERTIES_MAP_CLASS =
+                (Class<Map<String, String>>) (Class<?>) Map.class;
+
+        /** The key for the config option. */
+        private final String key;
+
+        /**
+         * Creates a new OptionBuilder.
+         *
+         * @param key The key for the config option
+         */
+        OptionBuilder(String key) {
+            this.key = key;
+        }
+
+        /** Defines that the value of the option should be of {@link Boolean} type. */
+        public TypedConfigOptionBuilder<Boolean> booleanType() {
+            return new TypedConfigOptionBuilder<>(key, Boolean.class);
+        }
+
+        /** Defines that the value of the option should be of {@link Integer} type. */
+        public TypedConfigOptionBuilder<Integer> intType() {
+            return new TypedConfigOptionBuilder<>(key, Integer.class);
+        }
+
+        /** Defines that the value of the option should be of {@link Long} type. */
+        public TypedConfigOptionBuilder<Long> longType() {
+            return new TypedConfigOptionBuilder<>(key, Long.class);
+        }
+
+        /** Defines that the value of the option should be of {@link Float} type. */
+        public TypedConfigOptionBuilder<Float> floatType() {
+            return new TypedConfigOptionBuilder<>(key, Float.class);
+        }
+
+        /** Defines that the value of the option should be of {@link Double} type. */
+        public TypedConfigOptionBuilder<Double> doubleType() {
+            return new TypedConfigOptionBuilder<>(key, Double.class);
+        }
+
+        /** Defines that the value of the option should be of {@link String} type. */
+        public TypedConfigOptionBuilder<String> stringType() {
+            return new TypedConfigOptionBuilder<>(key, String.class);
+        }
+
+        /** Defines that the value of the option should be of {@link Duration} type. */
+        public TypedConfigOptionBuilder<Duration> durationType() {
+            return new TypedConfigOptionBuilder<>(key, Duration.class);
+        }
+
+        /**
+         * Defines that the value of the option should be of {@link Enum} type.
+         *
+         * @param enumClass Concrete type of the expected enum.
+         */
+        public <T extends Enum<T>> TypedConfigOptionBuilder<T> enumType(Class<T> enumClass) {
+            return new TypedConfigOptionBuilder<>(key, enumClass);
+        }
+
+        /**
+         * Defines that the value of the option should be a set of properties, which can be
+         * represented as {@code Map<String, String>}.
+         */
+        public TypedConfigOptionBuilder<Map<String, String>> mapType() {
+            return new TypedConfigOptionBuilder<>(key, PROPERTIES_MAP_CLASS);
+        }
+    }
+
+    /**
+     * Builder for {@link ConfigOption} with a defined atomic type.
+     *
+     * @param <T> atomic type of the option
+     */
+    public static class TypedConfigOptionBuilder<T> {
+        private final String key;
+        private final Class<T> clazz;
+
+        TypedConfigOptionBuilder(String key, Class<T> clazz) {
+            this.key = key;
+            this.clazz = clazz;
+        }
+
+        /** Defines that the option's type should be a list of previously defined atomic type. */
+        public ListConfigOptionBuilder<T> asList() {
+            return new ListConfigOptionBuilder<>(key, clazz);
+        }
+
+        /**
+         * Creates a ConfigOption with the given default value.
+         *
+         * @param value The default value for the config option
+         * @return The config option with the default value.
+         */
+        public ConfigOption<T> defaultValue(T value) {
+            return new ConfigOption<>(key, clazz, ConfigOption.EMPTY_DESCRIPTION, value, false);
+        }
+
+        /**
+         * Creates a ConfigOption without a default value.
+         *
+         * @return The config option without a default value.
+         */
+        public ConfigOption<T> noDefaultValue() {
+            return new ConfigOption<>(
+                    key, clazz, Description.builder().text("").build(), null, false);
+        }
+    }
+
+    /**
+     * Builder for {@link ConfigOption} of list of type {@link E}.
+     *
+     * @param <E> list element type of the option
+     */
+    public static class ListConfigOptionBuilder<E> {
+        private final String key;
+        private final Class<E> clazz;
+
+        ListConfigOptionBuilder(String key, Class<E> clazz) {
+            this.key = key;
+            this.clazz = clazz;
+        }
+
+        /**
+         * Creates a ConfigOption with the given default value.
+         *
+         * @param values The list of default values for the config option
+         * @return The config option with the default value.
+         */
+        @SafeVarargs
+        public final ConfigOption<List<E>> defaultValues(E... values) {
+            return new ConfigOption<>(
+                    key, clazz, ConfigOption.EMPTY_DESCRIPTION, Arrays.asList(values), true);
+        }
+
+        /**
+         * Creates a ConfigOption without a default value.
+         *
+         * @return The config option without a default value.
+         */
+        public ConfigOption<List<E>> noDefaultValue() {
+            return new ConfigOption<>(key, clazz, ConfigOption.EMPTY_DESCRIPTION, null, true);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    /** Not intended to be instantiated. */
+    private ConfigOptions() {}
+}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigOptions.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigOptions.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/Configuration.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/Configuration.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import static com.ververica.cdc.common.configuration.ConfigurationUtils.canBePrefixMap;
+import static com.ververica.cdc.common.configuration.ConfigurationUtils.containsPrefixMap;
+import static com.ververica.cdc.common.configuration.ConfigurationUtils.convertToPropertiesPrefixed;
+import static com.ververica.cdc.common.configuration.ConfigurationUtils.removePrefixMap;
+
+/** Lightweight configuration object which stores key/value pairs. */
+public class Configuration implements java.io.Serializable, Cloneable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The log object used for debugging. */
+    private static final Logger LOG = LoggerFactory.getLogger(Configuration.class);
+
+    /** Stores the concrete key/value pairs of this configuration object. */
+    protected final HashMap<String, Object> confData;
+
+    // --------------------------------------------------------------------------------------------
+
+    /** Creates a new empty configuration. */
+    public Configuration() {
+        this.confData = new HashMap<>();
+    }
+
+    /**
+     * Creates a new configuration with the copy of the given configuration.
+     *
+     * @param other The configuration to copy the entries from.
+     */
+    public Configuration(Configuration other) {
+        this.confData = new HashMap<>(other.confData);
+    }
+
+    /** Creates a new configuration that is initialized with the options of the given map. */
+    public static Configuration fromMap(Map<String, String> map) {
+        final Configuration configuration = new Configuration();
+        configuration.confData.putAll(map);
+        return configuration;
+    }
+
+    public void addAll(Configuration other) {
+        synchronized (this.confData) {
+            synchronized (other.confData) {
+                this.confData.putAll(other.confData);
+            }
+        }
+    }
+
+    @Override
+    public Configuration clone() {
+        Configuration config = new Configuration();
+        config.addAll(this);
+
+        return config;
+    }
+
+    /**
+     * Checks whether there is an entry for the given config option.
+     *
+     * @param configOption The configuration option
+     * @return <tt>true</tt> if a valid (current or deprecated) key of the config option is stored,
+     *     <tt>false</tt> otherwise
+     */
+    public boolean contains(ConfigOption<?> configOption) {
+        synchronized (this.confData) {
+            final BiFunction<String, Boolean, Optional<Boolean>> applier =
+                    (key, canBePrefixMap) -> {
+                        if (canBePrefixMap && containsPrefixMap(this.confData, key)
+                                || this.confData.containsKey(key)) {
+                            return Optional.of(true);
+                        }
+                        return Optional.empty();
+                    };
+            return applyWithOption(configOption, applier).orElse(false);
+        }
+    }
+
+    public <T> T get(ConfigOption<T> option) {
+        return getOptional(option).orElseGet(option::defaultValue);
+    }
+
+    public <T> Optional<T> getOptional(ConfigOption<T> option) {
+        Optional<Object> rawValue = getRawValueFromOption(option);
+        Class<?> clazz = option.getClazz();
+
+        try {
+            if (option.isList()) {
+                return rawValue.map(v -> ConfigurationUtils.convertToList(v, clazz));
+            } else {
+                return rawValue.map(v -> ConfigurationUtils.convertValue(v, clazz));
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Could not parse value '%s' for key '%s'.",
+                            rawValue.map(Object::toString).orElse(""), option.key()),
+                    e);
+        }
+    }
+
+    public <T> Configuration set(ConfigOption<T> option, T value) {
+        final boolean canBePrefixMap = canBePrefixMap(option);
+        setValueInternal(option.key(), value, canBePrefixMap);
+        return this;
+    }
+
+    public Map<String, String> toMap() {
+        synchronized (this.confData) {
+            Map<String, String> ret = new HashMap<>(this.confData.size());
+            for (Map.Entry<String, Object> entry : confData.entrySet()) {
+                ret.put(entry.getKey(), ConfigurationUtils.convertToString(entry.getValue()));
+            }
+            return ret;
+        }
+    }
+
+    /**
+     * Removes given config option from the configuration.
+     *
+     * @param configOption config option to remove
+     * @param <T> Type of the config option
+     * @return true is config has been removed, false otherwise
+     */
+    public <T> boolean remove(ConfigOption<T> configOption) {
+        synchronized (this.confData) {
+            final BiFunction<String, Boolean, Optional<Boolean>> applier =
+                    (key, canBePrefixMap) -> {
+                        if (canBePrefixMap && removePrefixMap(this.confData, key)
+                                || this.confData.remove(key) != null) {
+                            return Optional.of(true);
+                        }
+                        return Optional.empty();
+                    };
+            return applyWithOption(configOption, applier).orElse(false);
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    private <T> void setValueInternal(String key, T value, boolean canBePrefixMap) {
+        if (key == null) {
+            throw new NullPointerException("Key must not be null.");
+        }
+        if (value == null) {
+            throw new NullPointerException("Value must not be null.");
+        }
+
+        synchronized (this.confData) {
+            if (canBePrefixMap) {
+                removePrefixMap(this.confData, key);
+            }
+            this.confData.put(key, value);
+        }
+    }
+
+    private Optional<Object> getRawValue(String key, boolean canBePrefixMap) {
+        if (key == null) {
+            throw new NullPointerException("Key must not be null.");
+        }
+
+        synchronized (this.confData) {
+            final Object valueFromExactKey = this.confData.get(key);
+            if (!canBePrefixMap || valueFromExactKey != null) {
+                return Optional.ofNullable(valueFromExactKey);
+            }
+            final Map<String, String> valueFromPrefixMap =
+                    convertToPropertiesPrefixed(confData, key);
+            if (valueFromPrefixMap.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(valueFromPrefixMap);
+        }
+    }
+
+    /**
+     * This method will do the following steps to get the value of a config option:
+     *
+     * <p>1. get the value from {@link Configuration}. <br>
+     * 2. if key is not found, try to get the value with fallback keys from {@link Configuration}
+     * <br>
+     * 3. if no fallback keys are found, return {@link Optional#empty()}. <br>
+     *
+     * @return the value of the configuration or {@link Optional#empty()}.
+     */
+    private Optional<Object> getRawValueFromOption(ConfigOption<?> configOption) {
+        return applyWithOption(configOption, this::getRawValue);
+    }
+
+    private void loggingFallback(FallbackKey fallbackKey, ConfigOption<?> configOption) {
+        if (fallbackKey.isDeprecated()) {
+            LOG.warn(
+                    "Config uses deprecated configuration key '{}' instead of proper key '{}'",
+                    fallbackKey.getKey(),
+                    configOption.key());
+        } else {
+            LOG.info(
+                    "Config uses fallback configuration key '{}' instead of key '{}'",
+                    fallbackKey.getKey(),
+                    configOption.key());
+        }
+    }
+
+    private <T> Optional<T> applyWithOption(
+            ConfigOption<?> option, BiFunction<String, Boolean, Optional<T>> applier) {
+        final boolean canBePrefixMap = canBePrefixMap(option);
+        final Optional<T> valueFromExactKey = applier.apply(option.key(), canBePrefixMap);
+        if (valueFromExactKey.isPresent()) {
+            return valueFromExactKey;
+        } else if (option.hasFallbackKeys()) {
+            // try the fallback keys
+            for (FallbackKey fallbackKey : option.fallbackKeys()) {
+                final Optional<T> valueFromFallbackKey =
+                        applier.apply(fallbackKey.getKey(), canBePrefixMap);
+                if (valueFromFallbackKey.isPresent()) {
+                    loggingFallback(fallbackKey, option);
+                    return valueFromFallbackKey;
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 0;
+        for (String s : this.confData.keySet()) {
+            hash ^= s.hashCode();
+        }
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj instanceof Configuration) {
+            Map<String, Object> otherConf = ((Configuration) obj).confData;
+
+            for (Map.Entry<String, Object> e : this.confData.entrySet()) {
+                Object thisVal = e.getValue();
+                Object otherVal = otherConf.get(e.getKey());
+
+                if (!thisVal.getClass().equals(byte[].class)) {
+                    if (!thisVal.equals(otherVal)) {
+                        return false;
+                    }
+                } else if (otherVal.getClass().equals(byte[].class)) {
+                    if (!Arrays.equals((byte[]) thisVal, (byte[]) otherVal)) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            }
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return this.confData.toString();
+    }
+}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/Configuration.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/Configuration.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigurationUtils.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigurationUtils.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration;
+
+import com.ververica.cdc.common.utils.TimeUtils;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.ververica.cdc.common.configuration.StructuredOptionsSplitter.escapeWithSingleQuote;
+
+/** Utility class for {@link Configuration} related helper functions. */
+public class ConfigurationUtils {
+
+    // --------------------------------------------------------------------------------------------
+    //  Type conversion
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Tries to convert the raw value into the provided type.
+     *
+     * @param rawValue rawValue to convert into the provided type clazz
+     * @param clazz clazz specifying the target type
+     * @param <T> type of the result
+     * @return the converted value if rawValue is of type clazz
+     * @throws IllegalArgumentException if the rawValue cannot be converted in the specified target
+     *     type clazz
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T convertValue(Object rawValue, Class<?> clazz) {
+        if (Integer.class.equals(clazz)) {
+            return (T) convertToInt(rawValue);
+        } else if (Long.class.equals(clazz)) {
+            return (T) convertToLong(rawValue);
+        } else if (Boolean.class.equals(clazz)) {
+            return (T) convertToBoolean(rawValue);
+        } else if (Float.class.equals(clazz)) {
+            return (T) convertToFloat(rawValue);
+        } else if (Double.class.equals(clazz)) {
+            return (T) convertToDouble(rawValue);
+        } else if (String.class.equals(clazz)) {
+            return (T) convertToString(rawValue);
+        } else if (clazz.isEnum()) {
+            return (T) convertToEnum(rawValue, (Class<? extends Enum<?>>) clazz);
+        } else if (clazz == Duration.class) {
+            return (T) convertToDuration(rawValue);
+        } else if (clazz == Map.class) {
+            return (T) convertToProperties(rawValue);
+        }
+
+        throw new IllegalArgumentException("Unsupported type: " + clazz);
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> T convertToList(Object rawValue, Class<?> atomicClass) {
+        if (rawValue instanceof List) {
+            return (T) rawValue;
+        } else {
+            return (T)
+                    StructuredOptionsSplitter.splitEscaped(rawValue.toString(), ';').stream()
+                            .map(s -> convertValue(s, atomicClass))
+                            .collect(Collectors.toList());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    static Map<String, String> convertToProperties(Object o) {
+        if (o instanceof Map) {
+            return (Map<String, String>) o;
+        } else {
+            List<String> listOfRawProperties =
+                    StructuredOptionsSplitter.splitEscaped(o.toString(), ',');
+            return listOfRawProperties.stream()
+                    .map(s -> StructuredOptionsSplitter.splitEscaped(s, ':'))
+                    .peek(
+                            pair -> {
+                                if (pair.size() != 2) {
+                                    throw new IllegalArgumentException(
+                                            "Map item is not a key-value pair (missing ':'?)");
+                                }
+                            })
+                    .collect(Collectors.toMap(a -> a.get(0), a -> a.get(1)));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E extends Enum<?>> E convertToEnum(Object o, Class<E> clazz) {
+        if (o.getClass().equals(clazz)) {
+            return (E) o;
+        }
+
+        return Arrays.stream(clazz.getEnumConstants())
+                .filter(
+                        e ->
+                                e.toString()
+                                        .toUpperCase(Locale.ROOT)
+                                        .equals(o.toString().toUpperCase(Locale.ROOT)))
+                .findAny()
+                .orElseThrow(
+                        () ->
+                                new IllegalArgumentException(
+                                        String.format(
+                                                "Could not parse value for enum %s. Expected one of: [%s]",
+                                                clazz, Arrays.toString(clazz.getEnumConstants()))));
+    }
+
+    static Duration convertToDuration(Object o) {
+        if (o.getClass() == Duration.class) {
+            return (Duration) o;
+        }
+
+        return TimeUtils.parseDuration(o.toString());
+    }
+
+    static String convertToString(Object o) {
+        if (o.getClass() == String.class) {
+            return (String) o;
+        } else if (o.getClass() == Duration.class) {
+            Duration duration = (Duration) o;
+            return TimeUtils.formatWithHighestUnit(duration);
+        } else if (o instanceof List) {
+            return ((List<?>) o)
+                    .stream()
+                            .map(e -> escapeWithSingleQuote(convertToString(e), ";"))
+                            .collect(Collectors.joining(";"));
+        } else if (o instanceof Map) {
+            return ((Map<?, ?>) o)
+                    .entrySet().stream()
+                            .map(
+                                    e -> {
+                                        String escapedKey =
+                                                escapeWithSingleQuote(e.getKey().toString(), ":");
+                                        String escapedValue =
+                                                escapeWithSingleQuote(e.getValue().toString(), ":");
+
+                                        return escapeWithSingleQuote(
+                                                escapedKey + ":" + escapedValue, ",");
+                                    })
+                            .collect(Collectors.joining(","));
+        }
+
+        return o.toString();
+    }
+
+    static Integer convertToInt(Object o) {
+        if (o.getClass() == Integer.class) {
+            return (Integer) o;
+        } else if (o.getClass() == Long.class) {
+            long value = (Long) o;
+            if (value <= Integer.MAX_VALUE && value >= Integer.MIN_VALUE) {
+                return (int) value;
+            } else {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Configuration value %s overflows/underflows the integer type.",
+                                value));
+            }
+        }
+
+        return Integer.parseInt(o.toString());
+    }
+
+    static Long convertToLong(Object o) {
+        if (o.getClass() == Long.class) {
+            return (Long) o;
+        } else if (o.getClass() == Integer.class) {
+            return ((Integer) o).longValue();
+        }
+
+        return Long.parseLong(o.toString());
+    }
+
+    static Boolean convertToBoolean(Object o) {
+        if (o.getClass() == Boolean.class) {
+            return (Boolean) o;
+        }
+
+        switch (o.toString().toUpperCase()) {
+            case "TRUE":
+                return true;
+            case "FALSE":
+                return false;
+            default:
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Unrecognized option for boolean: %s. Expected either true or false(case insensitive)",
+                                o));
+        }
+    }
+
+    static Float convertToFloat(Object o) {
+        if (o.getClass() == Float.class) {
+            return (Float) o;
+        } else if (o.getClass() == Double.class) {
+            double value = ((Double) o);
+            if (value == 0.0
+                    || (value >= Float.MIN_VALUE && value <= Float.MAX_VALUE)
+                    || (value >= -Float.MAX_VALUE && value <= -Float.MIN_VALUE)) {
+                return (float) value;
+            } else {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Configuration value %s overflows/underflows the float type.",
+                                value));
+            }
+        }
+
+        return Float.parseFloat(o.toString());
+    }
+
+    static Double convertToDouble(Object o) {
+        if (o.getClass() == Double.class) {
+            return (Double) o;
+        } else if (o.getClass() == Float.class) {
+            return ((Float) o).doubleValue();
+        }
+
+        return Double.parseDouble(o.toString());
+    }
+
+    // --------------------------------------------------------------------------------------------
+    //  Prefix map handling
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Maps can be represented in two ways.
+     *
+     * <p>With constant key space:
+     *
+     * <pre>
+     *     avro-confluent.properties = schema: 1, other-prop: 2
+     * </pre>
+     *
+     * <p>Or with variable key space (i.e. prefix notation):
+     *
+     * <pre>
+     *     avro-confluent.properties.schema = 1
+     *     avro-confluent.properties.other-prop = 2
+     * </pre>
+     */
+    public static boolean canBePrefixMap(ConfigOption<?> configOption) {
+        return configOption.getClazz() == Map.class && !configOption.isList();
+    }
+
+    /** Filter condition for prefix map keys. */
+    public static boolean filterPrefixMapKey(String key, String candidate) {
+        final String prefixKey = key + ".";
+        return candidate.startsWith(prefixKey);
+    }
+
+    static Map<String, String> convertToPropertiesPrefixed(
+            Map<String, Object> confData, String key) {
+        final String prefixKey = key + ".";
+        return confData.keySet().stream()
+                .filter(k -> k.startsWith(prefixKey))
+                .collect(
+                        Collectors.toMap(
+                                k -> k.substring(prefixKey.length()),
+                                k -> convertToString(confData.get(k))));
+    }
+
+    static boolean containsPrefixMap(Map<String, Object> confData, String key) {
+        return confData.keySet().stream().anyMatch(candidate -> filterPrefixMapKey(key, candidate));
+    }
+
+    static boolean removePrefixMap(Map<String, Object> confData, String key) {
+        final List<String> prefixKeys =
+                confData.keySet().stream()
+                        .filter(candidate -> filterPrefixMapKey(key, candidate))
+                        .collect(Collectors.toList());
+        prefixKeys.forEach(confData::remove);
+        return !prefixKeys.isEmpty();
+    }
+
+    // Make sure that we cannot instantiate this class
+    private ConfigurationUtils() {}
+}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigurationUtils.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/ConfigurationUtils.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/FallbackKey.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/FallbackKey.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration;
+
+/** A key with FallbackKeys will fall back to the FallbackKeys if it itself is not configured. */
+public class FallbackKey {
+
+    // -------------------------
+    //  Factory methods
+    // -------------------------
+
+    static FallbackKey createFallbackKey(String key) {
+        return new FallbackKey(key, false);
+    }
+
+    static FallbackKey createDeprecatedKey(String key) {
+        return new FallbackKey(key, true);
+    }
+
+    // ------------------------------------------------------------------------
+
+    private final String key;
+
+    private final boolean isDeprecated;
+
+    public String getKey() {
+        return key;
+    }
+
+    public boolean isDeprecated() {
+        return isDeprecated;
+    }
+
+    private FallbackKey(String key, boolean isDeprecated) {
+        this.key = key;
+        this.isDeprecated = isDeprecated;
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o != null && o.getClass() == FallbackKey.class) {
+            FallbackKey that = (FallbackKey) o;
+            return this.key.equals(that.key) && (this.isDeprecated == that.isDeprecated);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * key.hashCode() + (isDeprecated ? 1 : 0);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("{key=%s, isDeprecated=%s}", key, isDeprecated);
+    }
+}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/FallbackKey.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/FallbackKey.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/StructuredOptionsSplitter.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/StructuredOptionsSplitter.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.ververica.cdc.common.utils.Preconditions.checkNotNull;
+
+/** Helper class for splitting a string on a given delimiter with quoting logic. */
+@Internal
+class StructuredOptionsSplitter {
+
+    /**
+     * Splits the given string on the given delimiter. It supports quoting parts of the string with
+     * either single (') or double quotes ("). Quotes can be escaped by doubling the quotes.
+     *
+     * <p>Examples:
+     *
+     * <ul>
+     *   <li>'A;B';C => [A;B], [C]
+     *   <li>"AB'D";B;C => [AB'D], [B], [C]
+     *   <li>"AB'""D;B";C => [AB'\"D;B], [C]
+     * </ul>
+     *
+     * <p>For more examples check the tests.
+     *
+     * @param string a string to split
+     * @param delimiter delimiter to split on
+     * @return a list of splits
+     */
+    static List<String> splitEscaped(String string, char delimiter) {
+        List<Token> tokens = tokenize(checkNotNull(string), delimiter);
+        return processTokens(tokens);
+    }
+
+    /**
+     * Escapes the given string with single quotes, if the input string contains a double quote or
+     * any of the given {@code charsToEscape}. Any single quotes in the input string will be escaped
+     * by doubling.
+     *
+     * <p>Given that the escapeChar is (;)
+     *
+     * <p>Examples:
+     *
+     * <ul>
+     *   <li>A,B,C,D => A,B,C,D
+     *   <li>A'B'C'D => 'A''B''C''D'
+     *   <li>A;BCD => 'A;BCD'
+     *   <li>AB"C"D => 'AB"C"D'
+     *   <li>AB'"D:B => 'AB''"D:B'
+     * </ul>
+     *
+     * @param string a string which needs to be escaped
+     * @param charsToEscape escape chars for the escape conditions
+     * @return escaped string by single quote
+     */
+    static String escapeWithSingleQuote(String string, String... charsToEscape) {
+        boolean escape =
+                Arrays.stream(charsToEscape).anyMatch(string::contains)
+                        || string.contains("\"")
+                        || string.contains("'");
+
+        if (escape) {
+            return "'" + string.replaceAll("'", "''") + "'";
+        }
+
+        return string;
+    }
+
+    private static List<String> processTokens(List<Token> tokens) {
+        final List<String> splits = new ArrayList<>();
+        for (int i = 0; i < tokens.size(); i++) {
+            Token token = tokens.get(i);
+            switch (token.getTokenType()) {
+                case DOUBLE_QUOTED:
+                case SINGLE_QUOTED:
+                    if (i + 1 < tokens.size()
+                            && tokens.get(i + 1).getTokenType() != TokenType.DELIMITER) {
+                        int illegalPosition = tokens.get(i + 1).getPosition() - 1;
+                        throw new IllegalArgumentException(
+                                "Could not split string. Illegal quoting at position: "
+                                        + illegalPosition);
+                    }
+                    splits.add(token.getString());
+                    break;
+                case UNQUOTED:
+                    splits.add(token.getString());
+                    break;
+                case DELIMITER:
+                    if (i + 1 < tokens.size()
+                            && tokens.get(i + 1).getTokenType() == TokenType.DELIMITER) {
+                        splits.add("");
+                    }
+                    break;
+            }
+        }
+
+        return splits;
+    }
+
+    private static List<Token> tokenize(String string, char delimiter) {
+        final List<Token> tokens = new ArrayList<>();
+        final StringBuilder builder = new StringBuilder();
+        for (int cursor = 0; cursor < string.length(); ) {
+            final char c = string.charAt(cursor);
+
+            int nextChar = cursor + 1;
+            if (c == '\'') {
+                nextChar = consumeInQuotes(string, '\'', cursor, builder);
+                tokens.add(new Token(TokenType.SINGLE_QUOTED, builder.toString(), cursor));
+            } else if (c == '"') {
+                nextChar = consumeInQuotes(string, '"', cursor, builder);
+                tokens.add(new Token(TokenType.DOUBLE_QUOTED, builder.toString(), cursor));
+            } else if (c == delimiter) {
+                tokens.add(new Token(TokenType.DELIMITER, String.valueOf(c), cursor));
+            } else if (!Character.isWhitespace(c)) {
+                nextChar = consumeUnquoted(string, delimiter, cursor, builder);
+                tokens.add(new Token(TokenType.UNQUOTED, builder.toString().trim(), cursor));
+            }
+            builder.setLength(0);
+            cursor = nextChar;
+        }
+
+        return tokens;
+    }
+
+    private static int consumeInQuotes(
+            String string, char quote, int cursor, StringBuilder builder) {
+        for (int i = cursor + 1; i < string.length(); i++) {
+            char c = string.charAt(i);
+            if (c == quote) {
+                if (i + 1 < string.length() && string.charAt(i + 1) == quote) {
+                    builder.append(c);
+                    i += 1;
+                } else {
+                    return i + 1;
+                }
+            } else {
+                builder.append(c);
+            }
+        }
+
+        throw new IllegalArgumentException(
+                "Could not split string. Quoting was not closed properly.");
+    }
+
+    private static int consumeUnquoted(
+            String string, char delimiter, int cursor, StringBuilder builder) {
+        int i;
+        for (i = cursor; i < string.length(); i++) {
+            char c = string.charAt(i);
+            if (c == delimiter) {
+                return i;
+            }
+
+            builder.append(c);
+        }
+
+        return i;
+    }
+
+    private enum TokenType {
+        DOUBLE_QUOTED,
+        SINGLE_QUOTED,
+        UNQUOTED,
+        DELIMITER
+    }
+
+    private static class Token {
+        private final TokenType tokenType;
+        private final String string;
+        private final int position;
+
+        private Token(TokenType tokenType, String string, int position) {
+            this.tokenType = tokenType;
+            this.string = string;
+            this.position = position;
+        }
+
+        public TokenType getTokenType() {
+            return tokenType;
+        }
+
+        public String getString() {
+            return string;
+        }
+
+        public int getPosition() {
+            return position;
+        }
+    }
+
+    private StructuredOptionsSplitter() {}
+}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/StructuredOptionsSplitter.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/StructuredOptionsSplitter.java
@@ -16,7 +16,7 @@
 
 package com.ververica.cdc.common.configuration;
 
-import org.apache.flink.annotation.Internal;
+import com.ververica.cdc.common.annotation.Internal;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/StructuredOptionsSplitter.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/StructuredOptionsSplitter.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/BlockElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/BlockElement.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration.description;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/** Part of description that represents a block e.g. some text, linebreak or a list. */
+@PublicEvolving
+public interface BlockElement extends DescriptionElement {}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/BlockElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/BlockElement.java
@@ -16,7 +16,7 @@
 
 package com.ververica.cdc.common.configuration.description;
 
-import org.apache.flink.annotation.PublicEvolving;
+import com.ververica.cdc.common.annotation.PublicEvolving;
 
 /** Part of description that represents a block e.g. some text, linebreak or a list. */
 @PublicEvolving

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/BlockElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/BlockElement.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/Description.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/Description.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration.description;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Description for {@link com.ververica.cdc.common.configuration.ConfigOption}. Allows providing
+ * multiple rich formats.
+ */
+@PublicEvolving
+public class Description {
+
+    private final List<BlockElement> blocks;
+
+    public static DescriptionBuilder builder() {
+        return new DescriptionBuilder();
+    }
+
+    public List<BlockElement> getBlocks() {
+        return blocks;
+    }
+
+    /**
+     * Builder for {@link Description}. Allows adding a rich formatting like lists, links,
+     * linebreaks etc. For example:
+     *
+     * <pre>{@code
+     * Description description = Description.builder()
+     * 	.text("This is some list: ")
+     * 	.list(
+     * 		text("this is first element of list"),
+     * 		text("this is second element of list with a %s", link("https://link")))
+     * 	.build();
+     * }</pre>
+     */
+    @PublicEvolving
+    public static class DescriptionBuilder {
+
+        private final List<BlockElement> blocks = new ArrayList<>();
+
+        /**
+         * Adds a block of text with placeholders ("%s") that will be replaced with proper string
+         * representation of given {@link InlineElement}. For example:
+         *
+         * <p>{@code text("This is a text with a link %s", link("https://somepage", "to here"))}
+         *
+         * @param format text with placeholders for elements
+         * @param elements elements to be put in the text
+         * @return description with added block of text
+         */
+        public DescriptionBuilder text(String format, InlineElement... elements) {
+            blocks.add(TextElement.text(format, elements));
+            return this;
+        }
+
+        /**
+         * Creates a simple block of text.
+         *
+         * @param text a simple block of text
+         * @return block of text
+         */
+        public DescriptionBuilder text(String text) {
+            blocks.add(TextElement.text(text));
+            return this;
+        }
+
+        /**
+         * Block of description add.
+         *
+         * @param block block of description to add
+         * @return block of description
+         */
+        public DescriptionBuilder add(BlockElement block) {
+            blocks.add(block);
+            return this;
+        }
+
+        /** Creates a line break in the description. */
+        public DescriptionBuilder linebreak() {
+            blocks.add(LineBreakElement.linebreak());
+            return this;
+        }
+
+        /** Adds a bulleted list to the description. */
+        public DescriptionBuilder list(InlineElement... elements) {
+            blocks.add(ListElement.list(elements));
+            return this;
+        }
+
+        /** Creates description representation. */
+        public Description build() {
+            return new Description(blocks);
+        }
+    }
+
+    private Description(List<BlockElement> blocks) {
+        this.blocks = blocks;
+    }
+}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/Description.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/Description.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/Description.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/Description.java
@@ -16,7 +16,7 @@
 
 package com.ververica.cdc.common.configuration.description;
 
-import org.apache.flink.annotation.PublicEvolving;
+import com.ververica.cdc.common.annotation.PublicEvolving;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/DescriptionElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/DescriptionElement.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration.description;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/** Part of a {@link Description} that can be converted into String representation. */
+@PublicEvolving
+interface DescriptionElement {
+    /**
+     * Transforms itself into String representation using given format.
+     *
+     * @param formatter formatter to use.
+     */
+    void format(Formatter formatter);
+}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/DescriptionElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/DescriptionElement.java
@@ -16,7 +16,7 @@
 
 package com.ververica.cdc.common.configuration.description;
 
-import org.apache.flink.annotation.PublicEvolving;
+import com.ververica.cdc.common.annotation.PublicEvolving;
 
 /** Part of a {@link Description} that can be converted into String representation. */
 @PublicEvolving

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/DescriptionElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/DescriptionElement.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/Formatter.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/Formatter.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration.description;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.EnumSet;
+
+/**
+ * Allows providing multiple formatters for the description. E.g. Html formatter, Markdown formatter
+ * etc.
+ */
+@PublicEvolving
+public abstract class Formatter {
+
+    private final StringBuilder state = new StringBuilder();
+
+    /**
+     * Formats the description into a String using format specific tags.
+     *
+     * @param description description to be formatted
+     * @return string representation of the description
+     */
+    public String format(Description description) {
+        for (BlockElement blockElement : description.getBlocks()) {
+            blockElement.format(this);
+        }
+        return finalizeFormatting();
+    }
+
+    public void format(LinkElement element) {
+        formatLink(state, element.getLink(), element.getText());
+    }
+
+    public void format(TextElement element) {
+        String[] inlineElements =
+                element.getElements().stream()
+                        .map(
+                                el -> {
+                                    Formatter formatter = newInstance();
+                                    el.format(formatter);
+                                    return formatter.finalizeFormatting();
+                                })
+                        .toArray(String[]::new);
+        formatText(
+                state,
+                escapeFormatPlaceholder(element.getFormat()),
+                inlineElements,
+                element.getStyles());
+    }
+
+    public void format(LineBreakElement element) {
+        formatLineBreak(state);
+    }
+
+    public void format(ListElement element) {
+        String[] inlineElements =
+                element.getEntries().stream()
+                        .map(
+                                el -> {
+                                    Formatter formatter = newInstance();
+                                    el.format(formatter);
+                                    return formatter.finalizeFormatting();
+                                })
+                        .toArray(String[]::new);
+        formatList(state, inlineElements);
+    }
+
+    private String finalizeFormatting() {
+        String result = state.toString();
+        state.setLength(0);
+        return result.replaceAll("%%", "%");
+    }
+
+    protected abstract void formatLink(StringBuilder state, String link, String description);
+
+    protected abstract void formatLineBreak(StringBuilder state);
+
+    protected abstract void formatText(
+            StringBuilder state,
+            String format,
+            String[] elements,
+            EnumSet<TextElement.TextStyle> styles);
+
+    protected abstract void formatList(StringBuilder state, String[] entries);
+
+    protected abstract Formatter newInstance();
+
+    private static final String TEMPORARY_PLACEHOLDER = "randomPlaceholderForStringFormat";
+
+    private static String escapeFormatPlaceholder(String value) {
+        return value.replaceAll("%s", TEMPORARY_PLACEHOLDER)
+                .replaceAll("%", "%%")
+                .replaceAll(TEMPORARY_PLACEHOLDER, "%s");
+    }
+}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/Formatter.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/Formatter.java
@@ -16,7 +16,7 @@
 
 package com.ververica.cdc.common.configuration.description;
 
-import org.apache.flink.annotation.PublicEvolving;
+import com.ververica.cdc.common.annotation.PublicEvolving;
 
 import java.util.EnumSet;
 

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/Formatter.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/Formatter.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/HtmlFormatter.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/HtmlFormatter.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration.description;
+
+import java.util.EnumSet;
+
+/** Formatter that transforms {@link Description} into Html representation. */
+public class HtmlFormatter extends Formatter {
+
+    @Override
+    protected void formatLink(StringBuilder state, String link, String description) {
+        state.append(String.format("<a href=\"%s\">%s</a>", link, description));
+    }
+
+    @Override
+    protected void formatLineBreak(StringBuilder state) {
+        state.append("<br />");
+    }
+
+    @Override
+    protected void formatText(
+            StringBuilder state,
+            String format,
+            String[] elements,
+            EnumSet<TextElement.TextStyle> styles) {
+        String escapedFormat = escapeCharacters(format);
+
+        String prefix = "";
+        String suffix = "";
+        if (styles.contains(TextElement.TextStyle.CODE)) {
+            prefix = "<code class=\"highlighter-rouge\">";
+            suffix = "</code>";
+        }
+        state.append(prefix);
+        state.append(String.format(escapedFormat, elements));
+        state.append(suffix);
+    }
+
+    @Override
+    protected void formatList(StringBuilder state, String[] entries) {
+        state.append("<ul>");
+        for (String entry : entries) {
+            state.append(String.format("<li>%s</li>", entry));
+        }
+        state.append("</ul>");
+    }
+
+    @Override
+    protected Formatter newInstance() {
+        return new HtmlFormatter();
+    }
+
+    private static String escapeCharacters(String value) {
+        return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+    }
+}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/HtmlFormatter.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/HtmlFormatter.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/InlineElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/InlineElement.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration.description;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/** Part of description that represents an element inside a block e.g. a link. */
+@PublicEvolving
+public interface InlineElement extends DescriptionElement {}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/InlineElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/InlineElement.java
@@ -16,7 +16,7 @@
 
 package com.ververica.cdc.common.configuration.description;
 
-import org.apache.flink.annotation.PublicEvolving;
+import com.ververica.cdc.common.annotation.PublicEvolving;
 
 /** Part of description that represents an element inside a block e.g. a link. */
 @PublicEvolving

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/InlineElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/InlineElement.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/LineBreakElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/LineBreakElement.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration.description;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/** Represents a line break in the {@link Description}. */
+@PublicEvolving
+public class LineBreakElement implements InlineElement, BlockElement {
+
+    /** Creates a line break in the description. */
+    public static LineBreakElement linebreak() {
+        return new LineBreakElement();
+    }
+
+    private LineBreakElement() {}
+
+    @Override
+    public void format(Formatter formatter) {
+        formatter.format(this);
+    }
+}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/LineBreakElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/LineBreakElement.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/LineBreakElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/LineBreakElement.java
@@ -16,7 +16,7 @@
 
 package com.ververica.cdc.common.configuration.description;
 
-import org.apache.flink.annotation.PublicEvolving;
+import com.ververica.cdc.common.annotation.PublicEvolving;
 
 /** Represents a line break in the {@link Description}. */
 @PublicEvolving

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/LinkElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/LinkElement.java
@@ -16,7 +16,7 @@
 
 package com.ververica.cdc.common.configuration.description;
 
-import org.apache.flink.annotation.PublicEvolving;
+import com.ververica.cdc.common.annotation.PublicEvolving;
 
 /** Element that represents a link in the {@link Description}. */
 @PublicEvolving

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/LinkElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/LinkElement.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration.description;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/** Element that represents a link in the {@link Description}. */
+@PublicEvolving
+public class LinkElement implements InlineElement {
+    private final String link;
+    private final String text;
+
+    /**
+     * Creates a link with a given url and description.
+     *
+     * @param link address that this link should point to
+     * @param text a description for that link, that should be used in text
+     * @return link representation
+     */
+    public static LinkElement link(String link, String text) {
+        return new LinkElement(link, text);
+    }
+
+    /**
+     * Creates a link with a given url. This url will be used as a description for that link.
+     *
+     * @param link address that this link should point to
+     * @return link representation
+     */
+    public static LinkElement link(String link) {
+        return new LinkElement(link, link);
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    private LinkElement(String link, String text) {
+        this.link = link;
+        this.text = text;
+    }
+
+    @Override
+    public void format(Formatter formatter) {
+        formatter.format(this);
+    }
+}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/LinkElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/LinkElement.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/ListElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/ListElement.java
@@ -16,7 +16,7 @@
 
 package com.ververica.cdc.common.configuration.description;
 
-import org.apache.flink.annotation.PublicEvolving;
+import com.ververica.cdc.common.annotation.PublicEvolving;
 
 import java.util.Arrays;
 import java.util.List;

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/ListElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/ListElement.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/ListElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/ListElement.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration.description;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Arrays;
+import java.util.List;
+
+/** Represents a list in the {@link Description}. */
+@PublicEvolving
+public class ListElement implements BlockElement {
+
+    private final List<InlineElement> entries;
+
+    /**
+     * Creates a list with blocks of text. For example:
+     *
+     * <pre>{@code
+     * .list(
+     * 	text("this is first element of list"),
+     * 	text("this is second element of list with a %s", link("https://link"))
+     * )
+     * }</pre>
+     *
+     * @param elements list of this list entries
+     * @return list representation
+     */
+    public static ListElement list(InlineElement... elements) {
+        return new ListElement(Arrays.asList(elements));
+    }
+
+    public List<InlineElement> getEntries() {
+        return entries;
+    }
+
+    private ListElement(List<InlineElement> entries) {
+        this.entries = entries;
+    }
+
+    @Override
+    public void format(Formatter formatter) {
+        formatter.format(this);
+    }
+}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/TextElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/TextElement.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.configuration.description;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import org.apache.flink.shaded.guava30.com.google.common.base.Strings;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+
+/** Represents a text block in the {@link Description}. */
+@PublicEvolving
+public class TextElement implements BlockElement, InlineElement {
+    private final String format;
+    private final List<InlineElement> elements;
+    private final EnumSet<TextStyle> textStyles = EnumSet.noneOf(TextStyle.class);
+
+    /**
+     * Creates a block of text with placeholders ("%s") that will be replaced with proper string
+     * representation of given {@link InlineElement}. For example:
+     *
+     * <p>{@code text("This is a text with a link %s", link("https://somepage", "to here"))}
+     *
+     * @param format text with placeholders for elements
+     * @param elements elements to be put in the text
+     * @return block of text
+     */
+    public static TextElement text(String format, InlineElement... elements) {
+        return new TextElement(format, Arrays.asList(elements));
+    }
+
+    /**
+     * Creates a simple block of text.
+     *
+     * @param text a simple block of text
+     * @return block of text
+     */
+    public static TextElement text(String text) {
+        return new TextElement(text, Collections.emptyList());
+    }
+
+    /** Wraps a list of {@link InlineElement}s into a single {@link TextElement}. */
+    public static InlineElement wrap(InlineElement... elements) {
+        return text(Strings.repeat("%s", elements.length), elements);
+    }
+
+    /**
+     * Creates a block of text formatted as code.
+     *
+     * @param text a block of text that will be formatted as code
+     * @return block of text formatted as code
+     */
+    public static TextElement code(String text) {
+        TextElement element = text(text);
+        element.textStyles.add(TextStyle.CODE);
+        return element;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public List<InlineElement> getElements() {
+        return elements;
+    }
+
+    public EnumSet<TextStyle> getStyles() {
+        return textStyles;
+    }
+
+    private TextElement(String format, List<InlineElement> elements) {
+        this.format = format;
+        this.elements = elements;
+    }
+
+    @Override
+    public void format(Formatter formatter) {
+        formatter.format(this);
+    }
+
+    /** Styles that can be applied to {@link TextElement} e.g. code, bold etc. */
+    @PublicEvolving
+    public enum TextStyle {
+        CODE
+    }
+}

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/TextElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/TextElement.java
@@ -18,7 +18,7 @@ package com.ververica.cdc.common.configuration.description;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import org.apache.flink.shaded.guava30.com.google.common.base.Strings;
+import org.apache.flink.shaded.guava31.com.google.common.base.Strings;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/TextElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/TextElement.java
@@ -16,9 +16,9 @@
 
 package com.ververica.cdc.common.configuration.description;
 
-import org.apache.flink.annotation.PublicEvolving;
-
 import org.apache.flink.shaded.guava31.com.google.common.base.Strings;
+
+import com.ververica.cdc.common.annotation.PublicEvolving;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/TextElement.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/configuration/description/TextElement.java
@@ -1,11 +1,9 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/utils/TimeUtils.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/utils/TimeUtils.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.utils;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.ververica.cdc.common.utils.Preconditions.checkArgument;
+import static com.ververica.cdc.common.utils.Preconditions.checkNotNull;
+
+/** Collection of utilities about time intervals. */
+public class TimeUtils {
+
+    private static final Map<String, ChronoUnit> LABEL_TO_UNIT_MAP =
+            Collections.unmodifiableMap(initMap());
+
+    /**
+     * Parse the given string to a java {@link Duration}. The string is in format "{length
+     * value}{time unit label}", e.g. "123ms", "321 s". If no time unit label is specified, it will
+     * be considered as milliseconds.
+     *
+     * <p>Supported time unit labels are:
+     *
+     * <ul>
+     *   <li>DAYS： "d", "day"
+     *   <li>HOURS： "h", "hour"
+     *   <li>MINUTES： "m", "min", "minute"
+     *   <li>SECONDS： "s", "sec", "second"
+     *   <li>MILLISECONDS： "ms", "milli", "millisecond"
+     *   <li>MICROSECONDS： "µs", "micro", "microsecond"
+     *   <li>NANOSECONDS： "ns", "nano", "nanosecond"
+     * </ul>
+     *
+     * @param text string to parse.
+     */
+    public static Duration parseDuration(String text) {
+        checkNotNull(text);
+
+        final String trimmed = text.trim();
+        checkArgument(!trimmed.isEmpty(), "argument is an empty- or whitespace-only string");
+
+        final int len = trimmed.length();
+        int pos = 0;
+
+        char current;
+        while (pos < len && (current = trimmed.charAt(pos)) >= '0' && current <= '9') {
+            pos++;
+        }
+
+        final String number = trimmed.substring(0, pos);
+        final String unitLabel = trimmed.substring(pos).trim().toLowerCase(Locale.US);
+
+        if (number.isEmpty()) {
+            throw new NumberFormatException("text does not start with a number");
+        }
+
+        final long value;
+        try {
+            value = Long.parseLong(number); // this throws a NumberFormatException on overflow
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "The value '"
+                            + number
+                            + "' cannot be re represented as 64bit number (numeric overflow).");
+        }
+
+        if (unitLabel.isEmpty()) {
+            return Duration.of(value, ChronoUnit.MILLIS);
+        }
+
+        ChronoUnit unit = LABEL_TO_UNIT_MAP.get(unitLabel);
+        if (unit != null) {
+            return Duration.of(value, unit);
+        } else {
+            throw new IllegalArgumentException(
+                    "Time interval unit label '"
+                            + unitLabel
+                            + "' does not match any of the recognized units: "
+                            + TimeUnit.getAllUnits());
+        }
+    }
+
+    private static Map<String, ChronoUnit> initMap() {
+        Map<String, ChronoUnit> labelToUnit = new HashMap<>();
+        for (TimeUnit timeUnit : TimeUnit.values()) {
+            for (String label : timeUnit.getLabels()) {
+                labelToUnit.put(label, timeUnit.getUnit());
+            }
+        }
+        return labelToUnit;
+    }
+
+    /**
+     * @param duration to convert to string
+     * @return duration string in millis
+     */
+    public static String getStringInMillis(final Duration duration) {
+        return duration.toMillis() + TimeUnit.MILLISECONDS.labels.get(0);
+    }
+
+    /**
+     * Pretty prints the duration as a lowest granularity unit that does not lose precision.
+     *
+     * <p>Examples:
+     *
+     * <pre>{@code
+     * Duration.ofMilliseconds(60000) will be printed as 1 min
+     * Duration.ofHours(1).plusSeconds(1) will be printed as 3601 s
+     * }</pre>
+     *
+     * <b>NOTE:</b> It supports only durations that fit into long.
+     */
+    public static String formatWithHighestUnit(Duration duration) {
+        long nanos = duration.toNanos();
+
+        List<TimeUnit> orderedUnits =
+                Arrays.asList(
+                        TimeUnit.NANOSECONDS,
+                        TimeUnit.MICROSECONDS,
+                        TimeUnit.MILLISECONDS,
+                        TimeUnit.SECONDS,
+                        TimeUnit.MINUTES,
+                        TimeUnit.HOURS,
+                        TimeUnit.DAYS);
+
+        TimeUnit highestIntegerUnit =
+                IntStream.range(0, orderedUnits.size())
+                        .sequential()
+                        .filter(
+                                idx ->
+                                        nanos % orderedUnits.get(idx).unit.getDuration().toNanos()
+                                                != 0)
+                        .boxed()
+                        .findFirst()
+                        .map(
+                                idx -> {
+                                    if (idx == 0) {
+                                        return orderedUnits.get(0);
+                                    } else {
+                                        return orderedUnits.get(idx - 1);
+                                    }
+                                })
+                        .orElse(TimeUnit.MILLISECONDS);
+
+        return String.format(
+                "%d %s",
+                nanos / highestIntegerUnit.unit.getDuration().toNanos(),
+                highestIntegerUnit.getLabels().get(0));
+    }
+
+    /** Enum which defines time unit, mostly used to parse value from configuration file. */
+    private enum TimeUnit {
+        DAYS(ChronoUnit.DAYS, singular("d"), plural("day")),
+        HOURS(ChronoUnit.HOURS, singular("h"), plural("hour")),
+        MINUTES(ChronoUnit.MINUTES, singular("min"), singular("m"), plural("minute")),
+        SECONDS(ChronoUnit.SECONDS, singular("s"), plural("sec"), plural("second")),
+        MILLISECONDS(ChronoUnit.MILLIS, singular("ms"), plural("milli"), plural("millisecond")),
+        MICROSECONDS(ChronoUnit.MICROS, singular("µs"), plural("micro"), plural("microsecond")),
+        NANOSECONDS(ChronoUnit.NANOS, singular("ns"), plural("nano"), plural("nanosecond"));
+
+        private static final String PLURAL_SUFFIX = "s";
+
+        private final List<String> labels;
+
+        private final ChronoUnit unit;
+
+        TimeUnit(ChronoUnit unit, String[]... labels) {
+            this.unit = unit;
+            this.labels =
+                    Arrays.stream(labels)
+                            .flatMap(ls -> Arrays.stream(ls))
+                            .collect(Collectors.toList());
+        }
+
+        /**
+         * @param label the original label
+         * @return the singular format of the original label
+         */
+        private static String[] singular(String label) {
+            return new String[] {label};
+        }
+
+        /**
+         * @param label the original label
+         * @return both the singular format and plural format of the original label
+         */
+        private static String[] plural(String label) {
+            return new String[] {label, label + PLURAL_SUFFIX};
+        }
+
+        public List<String> getLabels() {
+            return labels;
+        }
+
+        public ChronoUnit getUnit() {
+            return unit;
+        }
+
+        public static String getAllUnits() {
+            return Arrays.stream(TimeUnit.values())
+                    .map(TimeUnit::createTimeUnitString)
+                    .collect(Collectors.joining(", "));
+        }
+
+        private static String createTimeUnitString(TimeUnit timeUnit) {
+            return timeUnit.name() + ": (" + String.join(" | ", timeUnit.getLabels()) + ")";
+        }
+    }
+}

--- a/flink-cdc-composer/pom.xml
+++ b/flink-cdc-composer/pom.xml
@@ -29,7 +29,7 @@ under the License.
         <dependency>
             <groupId>com.ververica</groupId>
             <artifactId>flink-cdc-common</artifactId>
-            <version>${project.version}</version>
+            <version>${revision}</version>
         </dependency>
     </dependencies>
 

--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/PipelineDef.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/PipelineDef.java
@@ -16,7 +16,7 @@
 
 package com.ververica.cdc.composer.definition;
 
-import org.apache.flink.configuration.Configuration;
+import com.ververica.cdc.common.configuration.Configuration;
 
 import java.util.List;
 import java.util.Objects;

--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/SinkDef.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/SinkDef.java
@@ -16,7 +16,7 @@
 
 package com.ververica.cdc.composer.definition;
 
-import org.apache.flink.configuration.Configuration;
+import com.ververica.cdc.common.configuration.Configuration;
 
 import javax.annotation.Nullable;
 

--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/SourceDef.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/SourceDef.java
@@ -16,7 +16,7 @@
 
 package com.ververica.cdc.composer.definition;
 
-import org.apache.flink.configuration.Configuration;
+import com.ververica.cdc.common.configuration.Configuration;
 
 import javax.annotation.Nullable;
 


### PR DESCRIPTION
This pull request introduces `Configuration` and its related utilities such as `ConfigOption`, and migrate current usage of Flink `Configuration` to CDC's own one in `flink-cdc-composer` and `flink-cdc-cli`.

Please note that most code blocks are borrowed from Flink, and some deprecated and redundant methods are dropped. 