### PR TITLE
[tidb] Add support for 'scan.startup.mode' option 'timestamp'

### DIFF
--- a/docs/content/connectors/tidb-cdc.md
+++ b/docs/content/connectors/tidb-cdc.md
@@ -97,7 +97,15 @@ Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">initial</td>
       <td>String</td>
-      <td>Optional startup mode for TiDB CDC consumer, valid enumerations are "initial" and "latest-offset".</td>
+      <td>Optional startup mode for TiDB CDC consumer, valid enumerations are 
+          <code>'initial'</code>,<code>'latest-offset'</code> or <code>'timestamp'</code>.</td>
+    </tr>
+    <tr>
+        <td>scan.startup.timestamp</td>
+        <td>optional</td>
+        <td style="word-wrap: break-word;">0</td>
+        <td>Long</td>
+        <td>Timestamp in seconds of the start point, only used for <code>'timestamp'</code> startup mode.</td>
     </tr>
     <tr>
       <td>pd-addresses</td>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/TDBSourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/TDBSourceOptions.java
@@ -48,7 +48,15 @@ public class TDBSourceOptions {
                     .defaultValue("initial")
                     .withDescription(
                             "Optional startup mode for TiDB CDC consumer, valid enumerations are "
-                                    + "\"initial\", \"latest-offset\"");
+                                    + "\"initial\", \"latest-offset\" or \"timestamp\"");
+
+    public static final ConfigOption<Long> SCAN_STARTUP_TIMESTAMP =
+            ConfigOptions.key("scan.startup.timestamp")
+                    .longType()
+                    .defaultValue(0L)
+                    .withDescription(
+                            "Timestamp in seconds of the start point, only used for 'timestamp' startup mode."
+                                    + "eg: 1699891200000");
 
     public static final ConfigOption<String> PD_ADDRESSES =
             ConfigOptions.key("pd-addresses")

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/TiDBSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/TiDBSource.java
@@ -83,6 +83,7 @@ public class TiDBSource {
                     changeEventDeserializationSchema,
                     tiConf,
                     startupOptions.startupMode,
+                    startupOptions.startupTimestamp,
                     database,
                     tableName);
         }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/table/StartupMode.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/table/StartupMode.java
@@ -24,4 +24,6 @@ package com.ververica.cdc.connectors.tidb.table;
 public enum StartupMode {
     INITIAL,
     LATEST_OFFSET,
+
+    TIMESTAMP
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/table/StartupOptions.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/table/StartupOptions.java
@@ -23,12 +23,15 @@ public final class StartupOptions {
 
     public final StartupMode startupMode;
 
+    /** Timestamp in seconds of the start point, only used for 'timestamp' startup mode. */
+    public final Long startupTimestamp;
+
     /**
      * Performs an initial snapshot on the monitored database tables upon first startup, and
      * continue to read the latest CDC events.
      */
     public static StartupOptions initial() {
-        return new StartupOptions(StartupMode.INITIAL);
+        return new StartupOptions(StartupMode.INITIAL, null);
     }
 
     /**
@@ -36,16 +39,23 @@ public final class StartupOptions {
      * the latest CDC events which means only have the changes since the connector was started.
      */
     public static StartupOptions latest() {
-        return new StartupOptions(StartupMode.LATEST_OFFSET);
+        return new StartupOptions(StartupMode.LATEST_OFFSET, null);
     }
 
-    private StartupOptions(StartupMode startupMode) {
+    public static StartupOptions timestamp(Long startupTimestamp) {
+        return new StartupOptions(StartupMode.TIMESTAMP, startupTimestamp);
+    }
+
+    private StartupOptions(StartupMode startupMode, Long startupTimestamp) {
         this.startupMode = startupMode;
+        this.startupTimestamp = startupTimestamp;
 
         switch (startupMode) {
             case INITIAL:
 
             case LATEST_OFFSET:
+
+            case TIMESTAMP:
                 break;
 
             default:

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/table/TiDBTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/table/TiDBTableSourceFactory.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import static com.ververica.cdc.connectors.tidb.TDBSourceOptions.DATABASE_NAME;
 import static com.ververica.cdc.connectors.tidb.TDBSourceOptions.PD_ADDRESSES;
 import static com.ververica.cdc.connectors.tidb.TDBSourceOptions.SCAN_STARTUP_MODE;
+import static com.ververica.cdc.connectors.tidb.TDBSourceOptions.SCAN_STARTUP_TIMESTAMP;
 import static com.ververica.cdc.connectors.tidb.TDBSourceOptions.TABLE_NAME;
 import static com.ververica.cdc.connectors.tidb.TDBSourceOptions.TIKV_BATCH_GET_CONCURRENCY;
 import static com.ververica.cdc.connectors.tidb.TDBSourceOptions.TIKV_BATCH_SCAN_CONCURRENCY;
@@ -98,6 +99,7 @@ public class TiDBTableSourceFactory implements DynamicTableSourceFactory {
 
     private static final String SCAN_STARTUP_MODE_VALUE_INITIAL = "initial";
     private static final String SCAN_STARTUP_MODE_VALUE_LATEST = "latest-offset";
+    private static final String SCAN_STARTUP_MODE_VALUE_TIMESTAMP = "timestamp";
 
     private static StartupOptions getStartupOptions(ReadableConfig config) {
         String modeString = config.get(SCAN_STARTUP_MODE);
@@ -108,6 +110,9 @@ public class TiDBTableSourceFactory implements DynamicTableSourceFactory {
 
             case SCAN_STARTUP_MODE_VALUE_LATEST:
                 return StartupOptions.latest();
+
+            case SCAN_STARTUP_MODE_VALUE_TIMESTAMP:
+                return StartupOptions.timestamp(config.get(SCAN_STARTUP_TIMESTAMP));
 
             default:
                 throw new ValidationException(


### PR DESCRIPTION
[tidb] Add support for 'scan.startup.mode' option 'timestamp', same as oceanbase.