### PR TITLE
[3.0][cdc-common] Use 'ConfigOption' of cdc-common.

### DIFF
--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/factories/Factory.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/factories/Factory.java
@@ -16,9 +16,8 @@
 
 package com.ververica.cdc.common.factories;
 
-import org.apache.flink.configuration.ConfigOption;
-
 import com.ververica.cdc.common.annotation.PublicEvolving;
+import com.ververica.cdc.common.configuration.ConfigOption;
 import com.ververica.cdc.common.configuration.Configuration;
 
 import java.util.Collections;

--- a/flink-cdc-composer/pom.xml
+++ b/flink-cdc-composer/pom.xml
@@ -29,7 +29,7 @@ under the License.
         <dependency>
             <groupId>com.ververica</groupId>
             <artifactId>flink-cdc-common</artifactId>
-            <version>${revision}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/flink-cdc-composer/src/test/java/com/ververica/cdc/composer/utils/factory/DataSinkFactory1.java
+++ b/flink-cdc-composer/src/test/java/com/ververica/cdc/composer/utils/factory/DataSinkFactory1.java
@@ -16,8 +16,7 @@
 
 package com.ververica.cdc.composer.utils.factory;
 
-import org.apache.flink.configuration.ConfigOption;
-
+import com.ververica.cdc.common.configuration.ConfigOption;
 import com.ververica.cdc.common.factories.DataSinkFactory;
 import com.ververica.cdc.common.sink.DataSink;
 import com.ververica.cdc.common.sink.EventSinkProvider;

--- a/flink-cdc-composer/src/test/java/com/ververica/cdc/composer/utils/factory/DataSinkFactory2.java
+++ b/flink-cdc-composer/src/test/java/com/ververica/cdc/composer/utils/factory/DataSinkFactory2.java
@@ -16,8 +16,7 @@
 
 package com.ververica.cdc.composer.utils.factory;
 
-import org.apache.flink.configuration.ConfigOption;
-
+import com.ververica.cdc.common.configuration.ConfigOption;
 import com.ververica.cdc.common.factories.DataSinkFactory;
 import com.ververica.cdc.common.sink.DataSink;
 import com.ververica.cdc.common.sink.EventSinkProvider;

--- a/flink-cdc-composer/src/test/java/com/ververica/cdc/composer/utils/factory/DataSourceFactory1.java
+++ b/flink-cdc-composer/src/test/java/com/ververica/cdc/composer/utils/factory/DataSourceFactory1.java
@@ -16,8 +16,7 @@
 
 package com.ververica.cdc.composer.utils.factory;
 
-import org.apache.flink.configuration.ConfigOption;
-
+import com.ververica.cdc.common.configuration.ConfigOption;
 import com.ververica.cdc.common.factories.DataSourceFactory;
 import com.ververica.cdc.common.source.DataSource;
 import com.ververica.cdc.common.source.EventSourceProvider;

--- a/flink-cdc-composer/src/test/java/com/ververica/cdc/composer/utils/factory/DataSourceFactory2.java
+++ b/flink-cdc-composer/src/test/java/com/ververica/cdc/composer/utils/factory/DataSourceFactory2.java
@@ -16,8 +16,7 @@
 
 package com.ververica.cdc.composer.utils.factory;
 
-import org.apache.flink.configuration.ConfigOption;
-
+import com.ververica.cdc.common.configuration.ConfigOption;
 import com.ververica.cdc.common.factories.DataSourceFactory;
 import com.ververica.cdc.common.source.DataSource;
 import com.ververica.cdc.common.source.EventSourceProvider;


### PR DESCRIPTION
As we have own ConfigOption, we should use 'ConfigOption' of cdc-common in Factory.

cc @lvyanquan @GOODBOY008 