### PR TITLE
[Bug][mongo] Fix MongoDB's rewriteOutputBuffer to emit +I rather than +U(or -U)

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/reader/fetch/MongoDBFetchTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/reader/fetch/MongoDBFetchTaskContext.java
@@ -162,6 +162,8 @@ public class MongoDBFetchTaskContext implements FetchTask.Context {
                 case INSERT:
                 case UPDATE:
                 case REPLACE:
+                    value.put(
+                            MongoDBEnvelope.OPERATION_TYPE_FIELD, OperationType.INSERT.getValue());
                     outputBuffer.put(key, changeRecord);
                     break;
                 case DELETE:


### PR DESCRIPTION
Fix [#2759](https://github.com/ververica/flink-cdc-connectors/issues/2759)