### PR TITLE
[cdc-runtime] Improve partitioning logics and add tests for PrePartitioner

### DIFF
--- a/flink-cdc-runtime/src/main/java/com/ververica/cdc/runtime/partitioning/PartitioningEvent.java
+++ b/flink-cdc-runtime/src/main/java/com/ververica/cdc/runtime/partitioning/PartitioningEvent.java
@@ -59,4 +59,14 @@ public class PartitioningEvent implements Event {
     public int hashCode() {
         return Objects.hash(payload, targetPartition);
     }
+
+    @Override
+    public String toString() {
+        return "PartitioningEvent{"
+                + "payload="
+                + payload
+                + ", targetPartition="
+                + targetPartition
+                + '}';
+    }
 }

--- a/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/partitioning/PrePartitionOperatorTest.java
+++ b/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/partitioning/PrePartitionOperatorTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.runtime.partitioning;
+
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import com.ververica.cdc.common.data.binary.BinaryStringData;
+import com.ververica.cdc.common.event.CreateTableEvent;
+import com.ververica.cdc.common.event.DataChangeEvent;
+import com.ververica.cdc.common.event.FlushEvent;
+import com.ververica.cdc.common.event.TableId;
+import com.ververica.cdc.common.schema.Schema;
+import com.ververica.cdc.common.types.DataTypes;
+import com.ververica.cdc.common.types.RowType;
+import com.ververica.cdc.runtime.testutils.operators.EventOperatorTestHarness;
+import com.ververica.cdc.runtime.testutils.schema.TestingSchemaRegistryGateway;
+import com.ververica.cdc.runtime.typeutils.BinaryRecordDataGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit test for {@link PrePartitionOperator}. */
+class PrePartitionOperatorTest {
+    private static final TableId CUSTOMERS =
+            TableId.tableId("my_company", "my_branch", "customers");
+    private static final Schema CUSTOMERS_SCHEMA =
+            Schema.newBuilder()
+                    .physicalColumn("id", DataTypes.INT())
+                    .physicalColumn("name", DataTypes.STRING())
+                    .physicalColumn("phone", DataTypes.BIGINT())
+                    .primaryKey("id")
+                    .build();
+    private static final int DOWNSTREAM_PARALLELISM = 5;
+
+    @Test
+    void testBroadcastingSchemaChangeEvent() throws Exception {
+        try (EventOperatorTestHarness<PrePartitionOperator, PartitioningEvent> testHarness =
+                createTestHarness()) {
+            // Initialization
+            testHarness.open();
+            testHarness.registerTableSchema(CUSTOMERS, CUSTOMERS_SCHEMA);
+
+            // CreateTableEvent
+            PrePartitionOperator operator = testHarness.getOperator();
+            CreateTableEvent createTableEvent = new CreateTableEvent(CUSTOMERS, CUSTOMERS_SCHEMA);
+            operator.processElement(new StreamRecord<>(createTableEvent));
+            assertThat(testHarness.getOutputRecords()).hasSize(DOWNSTREAM_PARALLELISM);
+            for (int i = 0; i < DOWNSTREAM_PARALLELISM; i++) {
+                assertThat(testHarness.getOutputRecords().poll())
+                        .isEqualTo(new StreamRecord<>(new PartitioningEvent(createTableEvent, i)));
+            }
+        }
+    }
+
+    @Test
+    void testBroadcastingFlushEvent() throws Exception {
+        try (EventOperatorTestHarness<PrePartitionOperator, PartitioningEvent> testHarness =
+                createTestHarness()) {
+            // Initialization
+            testHarness.open();
+            testHarness.registerTableSchema(CUSTOMERS, CUSTOMERS_SCHEMA);
+
+            // FlushEvent
+            PrePartitionOperator operator = testHarness.getOperator();
+            FlushEvent flushEvent = new FlushEvent(CUSTOMERS);
+            operator.processElement(new StreamRecord<>(flushEvent));
+            assertThat(testHarness.getOutputRecords()).hasSize(DOWNSTREAM_PARALLELISM);
+            for (int i = 0; i < DOWNSTREAM_PARALLELISM; i++) {
+                assertThat(testHarness.getOutputRecords().poll())
+                        .isEqualTo(new StreamRecord<>(new PartitioningEvent(flushEvent, i)));
+            }
+        }
+    }
+
+    @Test
+    void testPartitioningDataChangeEvent() throws Exception {
+        try (EventOperatorTestHarness<PrePartitionOperator, PartitioningEvent> testHarness =
+                createTestHarness()) {
+            // Initialization
+            testHarness.open();
+            testHarness.registerTableSchema(CUSTOMERS, CUSTOMERS_SCHEMA);
+
+            // DataChangeEvent
+            PrePartitionOperator operator = testHarness.getOperator();
+            BinaryRecordDataGenerator recordDataGenerator =
+                    new BinaryRecordDataGenerator(((RowType) CUSTOMERS_SCHEMA.toRowDataType()));
+            DataChangeEvent eventA =
+                    DataChangeEvent.insertEvent(
+                            CUSTOMERS,
+                            recordDataGenerator.generate(
+                                    new Object[] {1, new BinaryStringData("Alice"), 12345678L}));
+            DataChangeEvent eventB =
+                    DataChangeEvent.insertEvent(
+                            CUSTOMERS,
+                            recordDataGenerator.generate(
+                                    new Object[] {2, new BinaryStringData("Bob"), 12345689L}));
+            operator.processElement(new StreamRecord<>(eventA));
+            operator.processElement(new StreamRecord<>(eventB));
+            assertThat(testHarness.getOutputRecords().poll())
+                    .isEqualTo(
+                            new StreamRecord<>(
+                                    new PartitioningEvent(
+                                            eventA,
+                                            getPartitioningTarget(CUSTOMERS_SCHEMA, eventA))));
+            assertThat(testHarness.getOutputRecords().poll())
+                    .isEqualTo(
+                            new StreamRecord<>(
+                                    new PartitioningEvent(
+                                            eventB,
+                                            getPartitioningTarget(CUSTOMERS_SCHEMA, eventB))));
+        }
+    }
+
+    private int getPartitioningTarget(Schema schema, DataChangeEvent dataChangeEvent) {
+        return new PrePartitionOperator.HashFunction(schema).apply(dataChangeEvent)
+                % DOWNSTREAM_PARALLELISM;
+    }
+
+    private EventOperatorTestHarness<PrePartitionOperator, PartitioningEvent> createTestHarness() {
+        PrePartitionOperator operator =
+                new PrePartitionOperator(
+                        TestingSchemaRegistryGateway.SCHEMA_OPERATOR_ID, DOWNSTREAM_PARALLELISM);
+        return new EventOperatorTestHarness<>(operator, DOWNSTREAM_PARALLELISM);
+    }
+}

--- a/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/testutils/operators/EventOperatorTestHarness.java
+++ b/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/testutils/operators/EventOperatorTestHarness.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.runtime.testutils.operators;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.tasks.TaskOperatorEventGateway;
+import org.apache.flink.runtime.operators.coordination.MockOperatorCoordinatorContext;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
+import org.apache.flink.streaming.util.MockStreamConfig;
+import org.apache.flink.util.OutputTag;
+
+import com.ververica.cdc.common.event.CreateTableEvent;
+import com.ververica.cdc.common.event.Event;
+import com.ververica.cdc.common.event.TableId;
+import com.ververica.cdc.common.schema.Schema;
+import com.ververica.cdc.runtime.operators.schema.coordinator.SchemaRegistry;
+import com.ververica.cdc.runtime.operators.schema.event.SchemaChangeRequest;
+import com.ververica.cdc.runtime.testutils.schema.CollectingMetadataApplier;
+import com.ververica.cdc.runtime.testutils.schema.TestingSchemaRegistryGateway;
+
+import java.util.LinkedList;
+
+/**
+ * Harness for testing customized operators handling {@link Event}s in CDC pipeline.
+ *
+ * <p>In addition to regular operator context and lifecycle management, this test harness also wraps
+ * {@link TestingSchemaRegistryGateway} into the context of tested operator, in order to support
+ * testing operators that have interaction with {@link
+ * com.ververica.cdc.runtime.operators.schema.coordinator.SchemaRegistry} via {@link
+ * com.ververica.cdc.runtime.operators.sink.SchemaEvolutionClient}.
+ *
+ * @param <OP> Type of the operator
+ * @param <E> Type of the event emitted by the operator
+ */
+public class EventOperatorTestHarness<OP extends AbstractStreamOperator<E>, E extends Event>
+        implements AutoCloseable {
+    public static final OperatorID SCHEMA_OPERATOR_ID = new OperatorID(15213L, 15513L);
+
+    private final OP operator;
+    private final int numOutputs;
+    private final SchemaRegistry schemaRegistry;
+    private final TestingSchemaRegistryGateway schemaRegistryGateway;
+    private final LinkedList<StreamRecord<E>> outputRecords = new LinkedList<>();
+
+    public EventOperatorTestHarness(OP operator, int numOutputs) {
+        this.operator = operator;
+        this.numOutputs = numOutputs;
+        schemaRegistry =
+                new SchemaRegistry(
+                        "SchemaOperator",
+                        new MockOperatorCoordinatorContext(
+                                SCHEMA_OPERATOR_ID, Thread.currentThread().getContextClassLoader()),
+                        new CollectingMetadataApplier());
+        schemaRegistryGateway = new TestingSchemaRegistryGateway(schemaRegistry);
+    }
+
+    public void open() throws Exception {
+        initializeOperator();
+        operator.open();
+    }
+
+    public LinkedList<StreamRecord<E>> getOutputRecords() {
+        return outputRecords;
+    }
+
+    public OP getOperator() {
+        return operator;
+    }
+
+    public void registerTableSchema(TableId tableId, Schema schema) {
+        schemaRegistry.handleCoordinationRequest(
+                new SchemaChangeRequest(tableId, new CreateTableEvent(tableId, schema)));
+    }
+
+    @Override
+    public void close() throws Exception {
+        operator.close();
+    }
+
+    // -------------------------------------- Helper functions -------------------------------
+
+    private void initializeOperator() throws Exception {
+        operator.setup(
+                new MockStreamTask(schemaRegistryGateway),
+                new MockStreamConfig(new Configuration(), numOutputs),
+                new EventCollectingOutput<>(outputRecords));
+    }
+
+    // ---------------------------------------- Helper classes ---------------------------------
+
+    private static class EventCollectingOutput<E extends Event> implements Output<StreamRecord<E>> {
+        private final LinkedList<StreamRecord<E>> outputRecords;
+
+        public EventCollectingOutput(LinkedList<StreamRecord<E>> outputRecords) {
+            this.outputRecords = outputRecords;
+        }
+
+        @Override
+        public void collect(StreamRecord<E> record) {
+            outputRecords.add(record);
+        }
+
+        @Override
+        public void emitWatermark(Watermark mark) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void emitWatermarkStatus(WatermarkStatus watermarkStatus) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void emitLatencyMarker(LatencyMarker latencyMarker) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class MockStreamTask extends StreamTask<Event, AbstractStreamOperator<Event>> {
+        protected MockStreamTask(TestingSchemaRegistryGateway schemaRegistryGateway)
+                throws Exception {
+            super(new SchemaRegistryCoordinatingEnvironment(schemaRegistryGateway));
+        }
+
+        @Override
+        protected void init() {}
+    }
+
+    private static class SchemaRegistryCoordinatingEnvironment extends DummyEnvironment {
+        private final TestingSchemaRegistryGateway schemaRegistryGateway;
+
+        public SchemaRegistryCoordinatingEnvironment(
+                TestingSchemaRegistryGateway schemaRegistryGateway) {
+            this.schemaRegistryGateway = schemaRegistryGateway;
+        }
+
+        @Override
+        public TaskOperatorEventGateway getOperatorCoordinatorEventGateway() {
+            return schemaRegistryGateway;
+        }
+    }
+}

--- a/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/testutils/schema/CollectingMetadataApplier.java
+++ b/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/testutils/schema/CollectingMetadataApplier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.runtime.testutils.schema;
+
+import com.ververica.cdc.common.event.SchemaChangeEvent;
+import com.ververica.cdc.common.sink.MetadataApplier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A {@link MetadataApplier} for testing that holds all schema change events in a list for further
+ * examination.
+ */
+public class CollectingMetadataApplier implements MetadataApplier {
+    private final List<SchemaChangeEvent> schemaChangeEvents = new ArrayList<>();
+
+    @Override
+    public void applySchemaChange(SchemaChangeEvent schemaChangeEvent) {
+        schemaChangeEvents.add(schemaChangeEvent);
+    }
+
+    public List<SchemaChangeEvent> getSchemaChangeEvents() {
+        return schemaChangeEvents;
+    }
+}

--- a/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/testutils/schema/TestingSchemaRegistryGateway.java
+++ b/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/testutils/schema/TestingSchemaRegistryGateway.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.runtime.testutils.schema;
+
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.tasks.TaskOperatorEventGateway;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.util.SerializedValue;
+
+import com.ververica.cdc.runtime.operators.schema.coordinator.SchemaRegistry;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A {@link TaskOperatorEventGateway} for testing that deliver all gateway events and requests to
+ * {@link SchemaRegistry}.
+ */
+public class TestingSchemaRegistryGateway implements TaskOperatorEventGateway, AutoCloseable {
+    public static final OperatorID SCHEMA_OPERATOR_ID = new OperatorID(15213L, 15513L);
+    private final SchemaRegistry schemaRegistry;
+
+    public TestingSchemaRegistryGateway(SchemaRegistry schemaRegistry) {
+        this.schemaRegistry = schemaRegistry;
+    }
+
+    public void open() throws Exception {
+        schemaRegistry.start();
+    }
+
+    @Override
+    public void close() throws Exception {
+        schemaRegistry.close();
+    }
+
+    @Override
+    public void sendOperatorEventToCoordinator(
+            OperatorID operator, SerializedValue<OperatorEvent> event) {
+        try {
+            schemaRegistry.handleEventFromOperator(
+                    0, 0, event.deserializeValue(Thread.currentThread().getContextClassLoader()));
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to deliver OperatorEvent to SchemaRegistry", e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<CoordinationResponse> sendRequestToCoordinator(
+            OperatorID operator, SerializedValue<CoordinationRequest> request) {
+        try {
+            return schemaRegistry.handleCoordinationRequest(
+                    request.deserializeValue(Thread.currentThread().getContextClassLoader()));
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Unable to deliver CoordinationRequest to SchemaRegistry", e);
+        }
+    }
+}


### PR DESCRIPTION
This pull request is a follow-up of #2609, that improves some logic in `PrePartitionOpeartor`:
- Use Guava cache for caching hash function
- Always try to load schema from registry if there's cache miss
- Improve hashing function to use Objects.hash * 31 & 0x7FFFFFF to avoid clash and negative value.

This pull requests also introduces some test utilities for operators, and add test for `PrePartitionOperator`.