### PR TITLE
[cdc-base] Support ability to skip backfill in CDC

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/BaseSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/BaseSourceConfig.java
@@ -34,6 +34,7 @@ public abstract class BaseSourceConfig implements SourceConfig {
     protected final double distributionFactorLower;
     protected final boolean includeSchemaChanges;
     protected final boolean closeIdleReaders;
+    protected final boolean skipSnapshotBackfill;
 
     // --------------------------------------------------------------------------------------------
     // Debezium Configurations
@@ -49,6 +50,7 @@ public abstract class BaseSourceConfig implements SourceConfig {
             double distributionFactorLower,
             boolean includeSchemaChanges,
             boolean closeIdleReaders,
+            boolean skipSnapshotBackfill,
             Properties dbzProperties,
             Configuration dbzConfiguration) {
         this.startupOptions = startupOptions;
@@ -58,6 +60,7 @@ public abstract class BaseSourceConfig implements SourceConfig {
         this.distributionFactorLower = distributionFactorLower;
         this.includeSchemaChanges = includeSchemaChanges;
         this.closeIdleReaders = closeIdleReaders;
+        this.skipSnapshotBackfill = skipSnapshotBackfill;
         this.dbzProperties = dbzProperties;
         this.dbzConfiguration = dbzConfiguration;
     }
@@ -101,5 +104,10 @@ public abstract class BaseSourceConfig implements SourceConfig {
 
     public Configuration getDbzConfiguration() {
         return Configuration.from(dbzProperties);
+    }
+
+    @Override
+    public boolean isSkipSnapshotBackfill() {
+        return skipSnapshotBackfill;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfig.java
@@ -68,7 +68,8 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
             Duration connectTimeout,
             int connectMaxRetries,
             int connectionPoolSize,
-            String chunkKeyColumn) {
+            String chunkKeyColumn,
+            boolean skipSnapshotBackfill) {
         super(
                 startupOptions,
                 splitSize,
@@ -77,6 +78,7 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
                 distributionFactorLower,
                 includeSchemaChanges,
                 closeIdleReaders,
+                skipSnapshotBackfill,
                 dbzProperties,
                 dbzConfiguration);
         this.driverClassName = driverClassName;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfigFactory.java
@@ -55,6 +55,7 @@ public abstract class JdbcSourceConfigFactory implements Factory<JdbcSourceConfi
     protected int connectionPoolSize = JdbcSourceOptions.CONNECTION_POOL_SIZE.defaultValue();
     protected Properties dbzProperties;
     protected String chunkKeyColumn;
+    protected boolean skipSnapshotBackfill;
 
     /** Integer port number of the database server. */
     public JdbcSourceConfigFactory hostname(String hostname) {
@@ -222,6 +223,10 @@ public abstract class JdbcSourceConfigFactory implements Factory<JdbcSourceConfi
     public JdbcSourceConfigFactory closeIdleReaders(boolean closeIdleReaders) {
         this.closeIdleReaders = closeIdleReaders;
         return this;
+    }
+
+    public void skipSnapshotBackfill(boolean skipSnapshotBackfill) {
+        this.skipSnapshotBackfill = skipSnapshotBackfill;
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfigFactory.java
@@ -225,6 +225,17 @@ public abstract class JdbcSourceConfigFactory implements Factory<JdbcSourceConfi
         return this;
     }
 
+    /**
+     * Whether to skip backfill in snapshot reading phase.
+     *
+     * <p>If backfill is skipped, changes on captured tables during snapshot phase will be consumed
+     * later in binlog reading phase instead of being merged into the snapshot.
+     *
+     * <p>WARNING: Skipping backfill might lead to data inconsistency because some binlog events
+     * happened within the snapshot phase might be replayed (only at-least-once semantic is
+     * promised). For example updating an already updated value in snapshot, or deleting an already
+     * deleted entry in snapshot. These replayed binlog events should be handled specially.
+     */
     public void skipSnapshotBackfill(boolean skipSnapshotBackfill) {
         this.skipSnapshotBackfill = skipSnapshotBackfill;
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfigFactory.java
@@ -55,7 +55,8 @@ public abstract class JdbcSourceConfigFactory implements Factory<JdbcSourceConfi
     protected int connectionPoolSize = JdbcSourceOptions.CONNECTION_POOL_SIZE.defaultValue();
     protected Properties dbzProperties;
     protected String chunkKeyColumn;
-    protected boolean skipSnapshotBackfill;
+    protected boolean skipSnapshotBackfill =
+            JdbcSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue();
 
     /** Integer port number of the database server. */
     public JdbcSourceConfigFactory hostname(String hostname) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/SourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/SourceConfig.java
@@ -35,6 +35,8 @@ public interface SourceConfig extends Serializable {
 
     boolean isCloseIdleReaders();
 
+    boolean isSkipSnapshotBackfill();
+
     /** Factory for the {@code SourceConfig}. */
     @FunctionalInterface
     interface Factory<C extends SourceConfig> extends Serializable {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/options/SourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/options/SourceOptions.java
@@ -121,4 +121,12 @@ public class SourceOptions {
                             "Whether to close idle readers at the end of the snapshot phase. This feature depends on "
                                     + "FLIP-147: Support Checkpoints After Tasks Finished. The flink version is required to be "
                                     + "greater than or equal to 1.14 when enabling this feature.");
+
+    @Experimental
+    public static final ConfigOption<Boolean> SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP =
+            ConfigOptions.key("scan.incremental.snapshot.backfill.skip")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to skip backfill in snapshot reading phase. If backfill is skipped, changes on captured tables during snapshot phase will be consumed later in binlog reading phase instead of being merged into the snapshot.WARNING: Skipping backfill might lead to data inconsistency because some binlog events happened within the snapshot phase might be replayed (only at-least-once semantic is promised). For example updating an already updated value in snapshot, or deleting an already deleted entry in snapshot. These replayed binlog events should be handled specially.");
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/IncrementalSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/IncrementalSource.java
@@ -217,6 +217,11 @@ public class IncrementalSource<T, C extends SourceConfig>
                 offsetFactory);
     }
 
+    /**
+     * Set snapshot hooks only for test. The SnapshotPhaseHook should be serializable。
+     *
+     * @param snapshotHooks
+     */
     @VisibleForTesting
     public void setSnapshotHooks(SnapshotPhaseHooks snapshotHooks) {
         this.snapshotHooks = snapshotHooks;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/IncrementalSourceSplitReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/IncrementalSourceSplitReader.java
@@ -28,10 +28,12 @@ import com.ververica.cdc.connectors.base.dialect.DataSourceDialect;
 import com.ververica.cdc.connectors.base.source.meta.split.ChangeEventRecords;
 import com.ververica.cdc.connectors.base.source.meta.split.SourceRecords;
 import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import com.ververica.cdc.connectors.base.source.reader.external.AbstractScanFetchTask;
 import com.ververica.cdc.connectors.base.source.reader.external.FetchTask;
 import com.ververica.cdc.connectors.base.source.reader.external.Fetcher;
 import com.ververica.cdc.connectors.base.source.reader.external.IncrementalSourceScanFetcher;
 import com.ververica.cdc.connectors.base.source.reader.external.IncrementalSourceStreamFetcher;
+import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHooks;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,12 +59,18 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
     private final DataSourceDialect<C> dataSourceDialect;
     private final C sourceConfig;
 
+    private final SnapshotPhaseHooks snapshotHooks;
+
     public IncrementalSourceSplitReader(
-            int subtaskId, DataSourceDialect<C> dataSourceDialect, C sourceConfig) {
+            int subtaskId,
+            DataSourceDialect<C> dataSourceDialect,
+            C sourceConfig,
+            SnapshotPhaseHooks snapshotHooks) {
         this.subtaskId = subtaskId;
         this.splits = new ArrayDeque<>();
         this.dataSourceDialect = dataSourceDialect;
         this.sourceConfig = sourceConfig;
+        this.snapshotHooks = snapshotHooks;
     }
 
     @Override
@@ -113,16 +121,18 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
 
         if (canAssignNextSplit()) {
             final SourceSplitBase nextSplit = splits.poll();
+
             if (nextSplit == null) {
                 throw new IOException("Cannot fetch from another split - no split remaining.");
             }
             currentSplitId = nextSplit.splitId();
-
+            FetchTask fetchTask = dataSourceDialect.createFetchTask(nextSplit);
             if (nextSplit.isSnapshotSplit()) {
                 if (currentFetcher == null) {
                     final FetchTask.Context taskContext =
                             dataSourceDialect.createFetchTaskContext(nextSplit, sourceConfig);
                     currentFetcher = new IncrementalSourceScanFetcher(taskContext, subtaskId);
+                    ((AbstractScanFetchTask) fetchTask).setSnapshotPhaseHooks(snapshotHooks);
                 }
             } else {
                 // point from snapshot split to stream split
@@ -135,7 +145,7 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
                 currentFetcher = new IncrementalSourceStreamFetcher(taskContext, subtaskId);
                 LOG.info("Stream fetcher is created.");
             }
-            currentFetcher.submitTask(dataSourceDialect.createFetchTask(nextSplit));
+            currentFetcher.submitTask(fetchTask);
         }
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/utils/hooks/SnapshotPhaseHook.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/utils/hooks/SnapshotPhaseHook.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.base.source.utils.hooks;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.util.function.BiConsumerWithException;
+
+import com.ververica.cdc.connectors.base.config.SourceConfig;
+
+import java.io.Serializable;
+import java.sql.SQLException;
+
+/**
+ * Hook to be invoked during different stages in the snapshot phase.
+ *
+ * <p>Please note that implementations should be serializable in order to be used in integration
+ * tests, as the hook need to be serialized together with the source on job submission.
+ */
+@Internal
+@FunctionalInterface
+public interface SnapshotPhaseHook
+        extends BiConsumerWithException<SourceConfig, SourceSplit, SQLException>, Serializable {}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/utils/hooks/SnapshotPhaseHooks.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/utils/hooks/SnapshotPhaseHooks.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.base.source.utils.hooks;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * A container class for hooks applied in the snapshot phase, including:
+ *
+ * <ul>
+ *   <li>{@link #preHighWatermarkAction}: Hook to run before emitting high watermark, which is for
+ *       testing whether binlog events created within snapshot phase are backfilled correctly.
+ *   <li>{@link #postHighWatermarkAction}: Hook to run after emitting high watermark, which is for
+ *       testing actions handling binlog events between snapshot splits.
+ * </ul>
+ */
+public class SnapshotPhaseHooks implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private SnapshotPhaseHook preLowWatermarkAction;
+    private SnapshotPhaseHook postLowWatermarkAction;
+    private SnapshotPhaseHook preHighWatermarkAction;
+    private SnapshotPhaseHook postHighWatermarkAction;
+
+    public void setPreHighWatermarkAction(SnapshotPhaseHook preHighWatermarkAction) {
+        this.preHighWatermarkAction = preHighWatermarkAction;
+    }
+
+    public void setPostHighWatermarkAction(SnapshotPhaseHook postHighWatermarkAction) {
+        this.postHighWatermarkAction = postHighWatermarkAction;
+    }
+
+    public void setPreLowWatermarkAction(SnapshotPhaseHook preLowWatermarkAction) {
+        this.preLowWatermarkAction = preLowWatermarkAction;
+    }
+
+    public void setPostLowWatermarkAction(SnapshotPhaseHook postLowWatermarkAction) {
+        this.postLowWatermarkAction = postLowWatermarkAction;
+    }
+
+    @Nullable
+    public SnapshotPhaseHook getPreHighWatermarkAction() {
+        return preHighWatermarkAction;
+    }
+
+    @Nullable
+    public SnapshotPhaseHook getPostHighWatermarkAction() {
+        return postHighWatermarkAction;
+    }
+
+    @Nullable
+    public SnapshotPhaseHook getPreLowWatermarkAction() {
+        return preLowWatermarkAction;
+    }
+
+    @Nullable
+    public SnapshotPhaseHook getPostLowWatermarkAction() {
+        return postLowWatermarkAction;
+    }
+
+    public static SnapshotPhaseHooks empty() {
+        return new SnapshotPhaseHooks();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/MySqlDialect.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/MySqlDialect.java
@@ -23,7 +23,6 @@ import com.ververica.cdc.common.annotation.Experimental;
 import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
 import com.ververica.cdc.connectors.base.dialect.JdbcDataSourceDialect;
 import com.ververica.cdc.connectors.base.experimental.config.MySqlSourceConfig;
-import com.ververica.cdc.connectors.base.experimental.config.MySqlSourceConfigFactory;
 import com.ververica.cdc.connectors.base.experimental.fetch.MySqlScanFetchTask;
 import com.ververica.cdc.connectors.base.experimental.fetch.MySqlSourceFetchTaskContext;
 import com.ververica.cdc.connectors.base.experimental.fetch.MySqlStreamFetchTask;
@@ -59,13 +58,11 @@ public class MySqlDialect implements JdbcDataSourceDialect {
     private static final String QUOTED_CHARACTER = "`";
 
     private static final long serialVersionUID = 1L;
-    private final MySqlSourceConfigFactory configFactory;
     private final MySqlSourceConfig sourceConfig;
     private transient MySqlSchema mySqlSchema;
 
-    public MySqlDialect(MySqlSourceConfigFactory configFactory) {
-        this.configFactory = configFactory;
-        this.sourceConfig = configFactory.create(0);
+    public MySqlDialect(MySqlSourceConfig sourceConfig) {
+        this.sourceConfig = sourceConfig;
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/MySqlSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/MySqlSourceBuilder.java
@@ -235,7 +235,7 @@ public class MySqlSourceBuilder<T> {
      */
     public MySqlIncrementalSource<T> build() {
         this.offsetFactory = new BinlogOffsetFactory();
-        this.dialect = new MySqlDialect(configFactory);
+        this.dialect = new MySqlDialect(configFactory.create(0));
         return new MySqlIncrementalSource<>(
                 configFactory, checkNotNull(deserializer), offsetFactory, dialect);
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/config/MySqlSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/config/MySqlSourceConfig.java
@@ -81,7 +81,8 @@ public class MySqlSourceConfig extends JdbcSourceConfig {
                 connectTimeout,
                 connectMaxRetries,
                 connectionPoolSize,
-                null);
+                null,
+                true);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/MongoDBSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/MongoDBSourceBuilder.java
@@ -243,6 +243,22 @@ public class MongoDBSourceBuilder<T> {
     }
 
     /**
+     * Whether to skip backfill in snapshot reading phase.
+     *
+     * <p>If backfill is skipped, changes on captured tables during snapshot phase will be consumed
+     * later in binlog reading phase instead of being merged into the snapshot.
+     *
+     * <p>WARNING: Skipping backfill might lead to data inconsistency because some binlog events
+     * happened within the snapshot phase might be replayed (only at-least-once semantic is
+     * promised). For example updating an already updated value in snapshot, or deleting an already
+     * deleted entry in snapshot. These replayed binlog events should be handled specially.
+     */
+    public MongoDBSourceBuilder<T> skipSnapshotBackfill(boolean skipSnapshotBackfill) {
+        this.configFactory.skipSnapshotBackfill(skipSnapshotBackfill);
+        return this;
+    }
+
+    /**
      * Build the {@link MongoDBSource}.
      *
      * @return a MongoDBParallelSource with the settings made for this builder.

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfig.java
@@ -52,6 +52,7 @@ public class MongoDBSourceConfig implements SourceConfig {
     private final boolean closeIdleReaders;
     private final boolean enableFullDocPrePostImage;
     private final boolean disableCursorTimeout;
+    private final boolean skipSnapshotBackfill;
 
     MongoDBSourceConfig(
             String scheme,
@@ -72,7 +73,8 @@ public class MongoDBSourceConfig implements SourceConfig {
             int samplesPerChunk,
             boolean closeIdleReaders,
             boolean enableFullDocPrePostImage,
-            boolean disableCursorTimeout) {
+            boolean disableCursorTimeout,
+            boolean skipSnapshotBackfill) {
         this.scheme = checkNotNull(scheme);
         this.hosts = checkNotNull(hosts);
         this.username = username;
@@ -93,6 +95,7 @@ public class MongoDBSourceConfig implements SourceConfig {
         this.closeIdleReaders = closeIdleReaders;
         this.enableFullDocPrePostImage = enableFullDocPrePostImage;
         this.disableCursorTimeout = disableCursorTimeout;
+        this.skipSnapshotBackfill = skipSnapshotBackfill;
     }
 
     public String getScheme() {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfig.java
@@ -185,6 +185,11 @@ public class MongoDBSourceConfig implements SourceConfig {
     }
 
     @Override
+    public boolean isSkipSnapshotBackfill() {
+        return skipSnapshotBackfill;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfigFactory.java
@@ -62,6 +62,7 @@ public class MongoDBSourceConfigFactory implements Factory<MongoDBSourceConfig> 
     private boolean closeIdleReaders = false;
     private boolean enableFullDocPrePostImage = false;
     private boolean disableCursorTimeout = true;
+    protected boolean skipSnapshotBackfill = false;
 
     /** The protocol connected to MongoDB. For example mongodb or mongodb+srv. */
     public MongoDBSourceConfigFactory scheme(String scheme) {
@@ -253,6 +254,16 @@ public class MongoDBSourceConfigFactory implements Factory<MongoDBSourceConfig> 
         return this;
     }
 
+    /**
+     * Whether to backfill the log for each snapshot split in the snapshot phase. Enabling backfill
+     * log can provide exactly once semantics, otherwise only provides at-least once semantics. The
+     * default action is to backfill log in snapshot phase.");
+     */
+    public MongoDBSourceConfigFactory skipSnapshotBackfill(boolean skipSnapshotBackfill) {
+        this.skipSnapshotBackfill = skipSnapshotBackfill;
+        return this;
+    }
+
     /** Creates a new {@link MongoDBSourceConfig} for the given subtask {@code subtaskId}. */
     @Override
     public MongoDBSourceConfig create(int subtaskId) {
@@ -276,6 +287,7 @@ public class MongoDBSourceConfigFactory implements Factory<MongoDBSourceConfig> 
                 samplesPerChunk,
                 closeIdleReaders,
                 enableFullDocPrePostImage,
-                disableCursorTimeout);
+                disableCursorTimeout,
+                skipSnapshotBackfill);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSource.java
@@ -83,6 +83,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
     private final boolean closeIdlerReaders;
     private final boolean enableFullDocPrePostImage;
     private final boolean noCursorTimeout;
+    private final boolean skipSnapshotBackfill;
 
     // --------------------------------------------------------------------------------------------
     // Mutable attributes
@@ -116,7 +117,8 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
             @Nullable Integer samplesPerChunk,
             boolean closeIdlerReaders,
             boolean enableFullDocPrePostImage,
-            boolean noCursorTimeout) {
+            boolean noCursorTimeout,
+            boolean skipSnapshotBackfill) {
         this.physicalSchema = physicalSchema;
         this.scheme = checkNotNull(scheme);
         this.hosts = checkNotNull(hosts);
@@ -141,6 +143,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
         this.closeIdlerReaders = closeIdlerReaders;
         this.enableFullDocPrePostImage = enableFullDocPrePostImage;
         this.noCursorTimeout = noCursorTimeout;
+        this.skipSnapshotBackfill = skipSnapshotBackfill;
     }
 
     @Override
@@ -197,6 +200,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                             .closeIdleReaders(closeIdlerReaders)
                             .scanFullChangelog(enableFullDocPrePostImage)
                             .startupOptions(startupOptions)
+                            .skipSnapshotBackfill(skipSnapshotBackfill)
                             .deserializer(deserializer)
                             .disableCursorTimeout(noCursorTimeout);
 
@@ -296,7 +300,8 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                         samplesPerChunk,
                         closeIdlerReaders,
                         enableFullDocPrePostImage,
-                        noCursorTimeout);
+                        noCursorTimeout,
+                        skipSnapshotBackfill);
         source.metadataKeys = metadataKeys;
         source.producedDataType = producedDataType;
         return source;
@@ -334,7 +339,8 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                 && Objects.equals(metadataKeys, that.metadataKeys)
                 && Objects.equals(closeIdlerReaders, that.closeIdlerReaders)
                 && Objects.equals(enableFullDocPrePostImage, that.enableFullDocPrePostImage)
-                && Objects.equals(noCursorTimeout, that.noCursorTimeout);
+                && Objects.equals(noCursorTimeout, that.noCursorTimeout)
+                && Objects.equals(skipSnapshotBackfill, that.skipSnapshotBackfill);
     }
 
     @Override
@@ -363,7 +369,8 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                 metadataKeys,
                 closeIdlerReaders,
                 enableFullDocPrePostImage,
-                noCursorTimeout);
+                noCursorTimeout,
+                skipSnapshotBackfill);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
@@ -36,6 +36,7 @@ import java.util.Set;
 
 import static com.ververica.cdc.connectors.base.options.SourceOptions.CHUNK_META_GROUP_SIZE;
 import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED;
+import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP;
 import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_STARTUP_MODE;
 import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_STARTUP_TIMESTAMP_MILLIS;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.BATCH_SIZE;
@@ -102,6 +103,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
 
         boolean enableParallelRead = config.get(SCAN_INCREMENTAL_SNAPSHOT_ENABLED);
         boolean enableCloseIdleReaders = config.get(SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED);
+        boolean skipSnapshotBackfill = config.get(SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
 
         int splitSizeMB = config.get(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB);
         int splitMetaGroupSize = config.get(CHUNK_META_GROUP_SIZE);
@@ -140,7 +142,8 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
                 samplesPerChunk,
                 enableCloseIdleReaders,
                 enableFullDocumentPrePostImage,
-                noCursorTimeout);
+                noCursorTimeout,
+                skipSnapshotBackfill);
     }
 
     private void checkPrimaryKey(UniqueConstraint pk, String message) {
@@ -215,6 +218,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
         options.add(SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED);
         options.add(FULL_DOCUMENT_PRE_POST_IMAGE);
         options.add(SCAN_NO_CURSOR_TIMEOUT);
+        options.add(SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
         return options;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/MongoDBFullChangelogITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/MongoDBFullChangelogITCase.java
@@ -17,21 +17,30 @@
 package com.ververica.cdc.connectors.mongodb.source;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Updates;
+import com.ververica.cdc.connectors.base.options.StartupOptions;
+import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHook;
+import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHooks;
 import com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceConfig;
 import com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceConfigFactory;
 import com.ververica.cdc.connectors.mongodb.source.utils.MongoUtils;
 import com.ververica.cdc.connectors.mongodb.utils.MongoDBTestUtils;
+import com.ververica.cdc.connectors.mongodb.utils.TestTable;
 import org.bson.Document;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,6 +50,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -48,14 +58,21 @@ import java.util.stream.Collectors;
 import static com.ververica.cdc.connectors.mongodb.utils.MongoDBAssertUtils.assertEqualsInAnyOrder;
 import static com.ververica.cdc.connectors.mongodb.utils.MongoDBContainer.FLINK_USER;
 import static com.ververica.cdc.connectors.mongodb.utils.MongoDBContainer.FLINK_USER_PASSWORD;
+import static com.ververica.cdc.connectors.mongodb.utils.MongoDBTestUtils.fetchRowData;
 import static com.ververica.cdc.connectors.mongodb.utils.MongoDBTestUtils.fetchRows;
 import static com.ververica.cdc.connectors.mongodb.utils.MongoDBTestUtils.triggerFailover;
+import static org.apache.flink.table.api.DataTypes.BIGINT;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.catalog.Column.physical;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.junit.Assert.assertEquals;
 
 /** Integration tests for MongoDB full document before change info. */
 @RunWith(Parameterized.class)
 public class MongoDBFullChangelogITCase extends MongoDBSourceTestBase {
+
+    private static final int USE_POST_LOWWATERMARK_HOOK = 1;
+    private static final int USE_PRE_HIGHWATERMARK_HOOK = 2;
 
     @Rule public final Timeout timeoutPerTest = Timeout.seconds(300);
 
@@ -188,6 +205,261 @@ public class MongoDBFullChangelogITCase extends MongoDBSourceTestBase {
                 new String[] {"customers"});
     }
 
+    @Test
+    public void testReadSingleTableWithSingleParallelismAndSkipBackfill() throws Exception {
+        if (!parallelismSnapshot) {
+            return;
+        }
+        testMongoDBParallelSource(
+                DEFAULT_PARALLELISM,
+                MongoDBTestUtils.FailoverType.TM,
+                MongoDBTestUtils.FailoverPhase.SNAPSHOT,
+                new String[] {"customers"},
+                true);
+    }
+
+    @Test
+    public void testEnableBackfillWithDMLPreHighWaterMark() throws Exception {
+        if (!parallelismSnapshot) {
+            return;
+        }
+
+        List<String> records =
+                testBackfillWhenWritingEvents(false, 21, USE_PRE_HIGHWATERMARK_HOOK, true);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Pittsburgh, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]");
+        // when enable backfill, the wal log between (snapshot, high_watermark) will be
+        // applied as snapshot image
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    @Test
+    public void testEnableBackfillWithDMLPostLowWaterMark() throws Exception {
+        if (!parallelismSnapshot) {
+            return;
+        }
+
+        List<String> records =
+                testBackfillWhenWritingEvents(false, 21, USE_POST_LOWWATERMARK_HOOK, true);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Pittsburgh, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]");
+        // when enable backfill, the wal log between (low_watermark, snapshot) will be applied
+        // as snapshot image
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    @Test
+    public void testSkipBackfillWithDMLPreHighWaterMark() throws Exception {
+        if (!parallelismSnapshot) {
+            return;
+        }
+
+        List<String> records =
+                testBackfillWhenWritingEvents(true, 25, USE_PRE_HIGHWATERMARK_HOOK, true);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[1019, user_20, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Shanghai, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]",
+                        "-U[2000, user_21, Shanghai, 123567891234]",
+                        "+U[2000, user_21, Pittsburgh, 123567891234]",
+                        "-D[1019, user_20, Shanghai, 123567891234]");
+        // when skip backfill, the wal log between (snapshot, high_watermark) will be seen as
+        // stream event.
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    @Test
+    public void testSkipBackfillWithDMLPostLowWaterMark() throws Exception {
+        if (!parallelismSnapshot) {
+            return;
+        }
+
+        List<String> records =
+                testBackfillWhenWritingEvents(true, 25, USE_POST_LOWWATERMARK_HOOK, true);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Pittsburgh, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]",
+                        "-U[2000, user_21, Shanghai, 123567891234]",
+                        "+U[2000, user_21, Pittsburgh, 123567891234]",
+                        "-D[1019, user_20, Shanghai, 123567891234]");
+        // when skip backfill, the wal log between (snapshot,  high_watermark) will still be
+        // seen as stream event. This will occur data duplicate. For example, user_20 will be
+        // deleted twice, and user_15213 will be inserted twice.
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    private List<String> testBackfillWhenWritingEvents(
+            boolean skipBackFill, int fetchSize, int hookType, boolean enableFullDocPrePostImage)
+            throws Exception {
+
+        String customerDatabase =
+                "customer_" + Integer.toUnsignedString(new Random().nextInt(), 36);
+
+        // A - enable system-level fulldoc pre & post image feature
+        CONTAINER.executeCommand(
+                "use admin; db.runCommand({ setClusterParameter: { changeStreamOptions: { preAndPostImages: { expireAfterSeconds: 'off' } } } })");
+
+        // B - enable collection-level fulldoc pre & post image for change capture collection
+        CONTAINER.executeCommandInDatabase(
+                String.format(
+                        "db.createCollection('%s'); db.runCommand({ collMod: '%s', changeStreamPreAndPostImages: { enabled: true } })",
+                        "customers", "customers"),
+                customerDatabase);
+        CONTAINER.executeCommandFileInDatabase("customer", customerDatabase);
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(1000);
+        env.setParallelism(1);
+
+        ResolvedSchema customersSchame =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                physical("cid", BIGINT().notNull()),
+                                physical("name", STRING()),
+                                physical("address", STRING()),
+                                physical("phone_number", STRING())),
+                        new ArrayList<>(),
+                        UniqueConstraint.primaryKey("pk", Collections.singletonList("cid")));
+        TestTable customerTable = new TestTable(customerDatabase, "customers", customersSchame);
+        MongoDBSource source =
+                new MongoDBSourceBuilder()
+                        .hosts(CONTAINER.getHostAndPort())
+                        .databaseList(customerDatabase)
+                        .username(FLINK_USER)
+                        .password(FLINK_USER_PASSWORD)
+                        .startupOptions(StartupOptions.initial())
+                        .scanFullChangelog(enableFullDocPrePostImage)
+                        .collectionList(
+                                getCollectionNameRegex(
+                                        customerDatabase, new String[] {"customers"}))
+                        .deserializer(customerTable.getDeserializer(enableFullDocPrePostImage))
+                        .skipSnapshotBackfill(skipBackFill)
+                        .build();
+
+        // Do some database operations during hook in snapshot phase.
+        SnapshotPhaseHooks hooks = new SnapshotPhaseHooks();
+        SnapshotPhaseHook snapshotPhaseHook =
+                (sourceConfig, split) -> {
+                    MongoDBSourceConfig mongoDBSourceConfig = (MongoDBSourceConfig) sourceConfig;
+                    MongoClient mongoClient = MongoUtils.clientFor(mongoDBSourceConfig);
+                    MongoDatabase database =
+                            mongoClient.getDatabase(mongoDBSourceConfig.getDatabaseList().get(0));
+                    MongoCollection<Document> mongoCollection = database.getCollection("customers");
+                    Document document = new Document();
+                    document.put("cid", 15213L);
+                    document.put("name", "user_15213");
+                    document.put("address", "Shanghai");
+                    document.put("phone_number", "123567891234");
+                    mongoCollection.insertOne(document);
+                    mongoCollection.updateOne(
+                            Filters.eq("cid", 2000L), Updates.set("address", "Pittsburgh"));
+                    mongoCollection.deleteOne(Filters.eq("cid", 1019L));
+                };
+
+        if (hookType == USE_POST_LOWWATERMARK_HOOK) {
+            hooks.setPostLowWatermarkAction(snapshotPhaseHook);
+        } else if (hookType == USE_PRE_HIGHWATERMARK_HOOK) {
+            hooks.setPreHighWatermarkAction(snapshotPhaseHook);
+        }
+        source.setSnapshotHooks(hooks);
+
+        List<String> records = new ArrayList<>();
+        try (CloseableIterator<RowData> iterator =
+                env.fromSource(source, WatermarkStrategy.noWatermarks(), "Backfill Skipped Source")
+                        .executeAndCollect()) {
+            records = fetchRowData(iterator, fetchSize, customerTable::stringify);
+            env.close();
+        }
+        return records;
+    }
+
     private void testMongoDBParallelSource(
             MongoDBTestUtils.FailoverType failoverType,
             MongoDBTestUtils.FailoverPhase failoverPhase,
@@ -202,6 +474,17 @@ public class MongoDBFullChangelogITCase extends MongoDBSourceTestBase {
             MongoDBTestUtils.FailoverType failoverType,
             MongoDBTestUtils.FailoverPhase failoverPhase,
             String[] captureCustomerCollections)
+            throws Exception {
+        testMongoDBParallelSource(
+                parallelism, failoverType, failoverPhase, captureCustomerCollections, false);
+    }
+
+    private void testMongoDBParallelSource(
+            int parallelism,
+            MongoDBTestUtils.FailoverType failoverType,
+            MongoDBTestUtils.FailoverPhase failoverPhase,
+            String[] captureCustomerCollections,
+            boolean skipSnapshotBackfill)
             throws Exception {
 
         String customerDatabase =
@@ -245,14 +528,16 @@ public class MongoDBFullChangelogITCase extends MongoDBSourceTestBase {
                                 + " 'database' = '%s',"
                                 + " 'collection' = '%s',"
                                 + " 'heartbeat.interval.ms' = '500',"
-                                + " 'scan.full-changelog' = 'true'"
+                                + " 'scan.full-changelog' = 'true',"
+                                + " 'scan.incremental.snapshot.backfill.skip' = '%s'"
                                 + ")",
                         parallelismSnapshot ? "true" : "false",
                         CONTAINER.getHostAndPort(),
                         FLINK_USER,
                         FLINK_USER_PASSWORD,
                         customerDatabase,
-                        getCollectionNameRegex(customerDatabase, captureCustomerCollections));
+                        getCollectionNameRegex(customerDatabase, captureCustomerCollections),
+                        skipSnapshotBackfill);
 
         CONTAINER.executeCommandFileInDatabase("customer", customerDatabase);
 
@@ -340,7 +625,7 @@ public class MongoDBFullChangelogITCase extends MongoDBSourceTestBase {
     private String getCollectionNameRegex(String database, String[] captureCustomerCollections) {
         checkState(captureCustomerCollections.length > 0);
         if (captureCustomerCollections.length == 1) {
-            return captureCustomerCollections[0];
+            return database + "." + captureCustomerCollections[0];
         } else {
             // pattern that matches multiple collections
             return Arrays.stream(captureCustomerCollections)

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/MongoDBParallelSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/MongoDBParallelSourceITCase.java
@@ -17,19 +17,30 @@
 package com.ververica.cdc.connectors.mongodb.source;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Updates;
+import com.ververica.cdc.connectors.base.options.StartupOptions;
+import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHook;
+import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHooks;
+import com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceConfig;
+import com.ververica.cdc.connectors.mongodb.source.utils.MongoUtils;
 import com.ververica.cdc.connectors.mongodb.utils.MongoDBTestUtils.FailoverPhase;
 import com.ververica.cdc.connectors.mongodb.utils.MongoDBTestUtils.FailoverType;
+import com.ververica.cdc.connectors.mongodb.utils.TestTable;
 import org.bson.Document;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,18 +48,25 @@ import org.junit.rules.Timeout;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.ververica.cdc.connectors.mongodb.utils.MongoDBAssertUtils.assertEqualsInAnyOrder;
 import static com.ververica.cdc.connectors.mongodb.utils.MongoDBContainer.FLINK_USER;
 import static com.ververica.cdc.connectors.mongodb.utils.MongoDBContainer.FLINK_USER_PASSWORD;
+import static com.ververica.cdc.connectors.mongodb.utils.MongoDBTestUtils.fetchRowData;
 import static com.ververica.cdc.connectors.mongodb.utils.MongoDBTestUtils.fetchRows;
 import static com.ververica.cdc.connectors.mongodb.utils.MongoDBTestUtils.triggerFailover;
+import static org.apache.flink.table.api.DataTypes.BIGINT;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.catalog.Column.physical;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /** IT tests for {@link MongoDBSource}. */
 public class MongoDBParallelSourceITCase extends MongoDBSourceTestBase {
+    private static final int USE_POST_LOWWATERMARK_HOOK = 1;
+    private static final int USE_PRE_HIGHWATERMARK_HOOK = 2;
 
     @Rule public final Timeout timeoutPerTest = Timeout.seconds(300);
 
@@ -119,6 +137,238 @@ public class MongoDBParallelSourceITCase extends MongoDBSourceTestBase {
                 1, FailoverType.JM, FailoverPhase.SNAPSHOT, new String[] {"customers"});
     }
 
+    @Test
+    public void testReadSingleTableWithSingleParallelismAndSkipBackfill() throws Exception {
+        testMongoDBParallelSource(
+                DEFAULT_PARALLELISM,
+                FailoverType.TM,
+                FailoverPhase.SNAPSHOT,
+                new String[] {"customers"},
+                true);
+    }
+
+    @Test
+    public void testEnableBackfillWithDMLPreHighWaterMark() throws Exception {
+
+        List<String> records =
+                testBackfillWhenWritingEvents(false, 21, USE_PRE_HIGHWATERMARK_HOOK, false);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Pittsburgh, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]");
+        // when enable backfill, the wal log between (snapshot, high_watermark) will be
+        // applied as snapshot image
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    @Test
+    public void testEnableBackfillWithDMLPostLowWaterMark() throws Exception {
+
+        List<String> records =
+                testBackfillWhenWritingEvents(false, 21, USE_POST_LOWWATERMARK_HOOK, false);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Pittsburgh, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]");
+        // when enable backfill, the wal log between (low_watermark, snapshot) will be applied
+        // as snapshot image
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    @Test
+    public void testSkipBackfillWithDMLPreHighWaterMark() throws Exception {
+
+        List<String> records =
+                testBackfillWhenWritingEvents(true, 24, USE_PRE_HIGHWATERMARK_HOOK, false);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[1019, user_20, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Shanghai, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]",
+                        "+U[2000, user_21, Pittsburgh, 123567891234]",
+                        // delete message only contains _id, sql job contain value because of
+                        // changelog normalization
+                        "-D[0, null, null, null]");
+        // when skip backfill, the wal log between (snapshot, high_watermark) will be seen as
+        // stream event.
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    @Test
+    public void testSkipBackfillWithDMLPostLowWaterMark() throws Exception {
+
+        List<String> records =
+                testBackfillWhenWritingEvents(true, 24, USE_POST_LOWWATERMARK_HOOK, false);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Pittsburgh, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]",
+                        "+U[2000, user_21, Pittsburgh, 123567891234]",
+                        // delete message only contains _id, sql job contain value because of
+                        // changelog normalization
+                        "-D[0, null, null, null]");
+        // when skip backfill, the wal log between (snapshot, high_watermark) will still be
+        // seen as stream event. This will occur data duplicate. For example, user_20 will be
+        // deleted twice, and user_15213 will be inserted twice.
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    private List<String> testBackfillWhenWritingEvents(
+            boolean skipBackFill, int fetchSize, int hookType, boolean enableFullDocPrePostImage)
+            throws Exception {
+        String customerDatabase = CONTAINER.executeCommandFileInSeparateDatabase("customer");
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(1000);
+        env.setParallelism(1);
+
+        ResolvedSchema customersSchame =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                physical("cid", BIGINT().notNull()),
+                                physical("name", STRING()),
+                                physical("address", STRING()),
+                                physical("phone_number", STRING())),
+                        new ArrayList<>(),
+                        UniqueConstraint.primaryKey("pk", Collections.singletonList("cid")));
+        TestTable customerTable = new TestTable(customerDatabase, "customers", customersSchame);
+        MongoDBSource source =
+                new MongoDBSourceBuilder()
+                        .hosts(CONTAINER.getHostAndPort())
+                        .databaseList(customerDatabase)
+                        .username(FLINK_USER)
+                        .password(FLINK_USER_PASSWORD)
+                        .startupOptions(StartupOptions.initial())
+                        .scanFullChangelog(enableFullDocPrePostImage)
+                        .collectionList(
+                                getCollectionNameRegex(
+                                        customerDatabase, new String[] {"customers"}))
+                        .deserializer(customerTable.getDeserializer(enableFullDocPrePostImage))
+                        .skipSnapshotBackfill(skipBackFill)
+                        .build();
+
+        // Do some database operations during hook in snapshot phase.
+        SnapshotPhaseHooks hooks = new SnapshotPhaseHooks();
+        SnapshotPhaseHook snapshotPhaseHook =
+                (sourceConfig, split) -> {
+                    MongoDBSourceConfig mongoDBSourceConfig = (MongoDBSourceConfig) sourceConfig;
+                    MongoClient mongoClient = MongoUtils.clientFor(mongoDBSourceConfig);
+                    MongoDatabase database =
+                            mongoClient.getDatabase(mongoDBSourceConfig.getDatabaseList().get(0));
+                    MongoCollection<Document> mongoCollection = database.getCollection("customers");
+                    Document document = new Document();
+                    document.put("cid", 15213L);
+                    document.put("name", "user_15213");
+                    document.put("address", "Shanghai");
+                    document.put("phone_number", "123567891234");
+                    mongoCollection.insertOne(document);
+                    mongoCollection.updateOne(
+                            Filters.eq("cid", 2000L), Updates.set("address", "Pittsburgh"));
+                    mongoCollection.deleteOne(Filters.eq("cid", 1019L));
+                    try {
+                        Thread.sleep(500L);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                };
+
+        if (hookType == USE_POST_LOWWATERMARK_HOOK) {
+            hooks.setPostLowWatermarkAction(snapshotPhaseHook);
+        } else if (hookType == USE_PRE_HIGHWATERMARK_HOOK) {
+            hooks.setPreHighWatermarkAction(snapshotPhaseHook);
+        }
+        source.setSnapshotHooks(hooks);
+
+        List<String> records = new ArrayList<>();
+        try (CloseableIterator<RowData> iterator =
+                env.fromSource(source, WatermarkStrategy.noWatermarks(), "Backfill Skipped Source")
+                        .executeAndCollect()) {
+            records = fetchRowData(iterator, fetchSize, customerTable::stringify);
+            env.close();
+        }
+        return records;
+    }
+
     private void testMongoDBParallelSource(
             FailoverType failoverType,
             FailoverPhase failoverPhase,
@@ -133,6 +383,17 @@ public class MongoDBParallelSourceITCase extends MongoDBSourceTestBase {
             FailoverType failoverType,
             FailoverPhase failoverPhase,
             String[] captureCustomerCollections)
+            throws Exception {
+        testMongoDBParallelSource(
+                parallelism, failoverType, failoverPhase, captureCustomerCollections, false);
+    }
+
+    private void testMongoDBParallelSource(
+            int parallelism,
+            FailoverType failoverType,
+            FailoverPhase failoverPhase,
+            String[] captureCustomerCollections,
+            boolean skipSnapshotBackfill)
             throws Exception {
 
         String customerDatabase = CONTAINER.executeCommandFileInSeparateDatabase("customer");
@@ -160,13 +421,15 @@ public class MongoDBParallelSourceITCase extends MongoDBSourceTestBase {
                                 + " 'password' = '%s',"
                                 + " 'database' = '%s',"
                                 + " 'collection' = '%s',"
-                                + " 'heartbeat.interval.ms' = '500'"
+                                + " 'heartbeat.interval.ms' = '500',"
+                                + " 'scan.incremental.snapshot.backfill.skip' = '%s'"
                                 + ")",
                         CONTAINER.getHostAndPort(),
                         FLINK_USER,
                         FLINK_USER_PASSWORD,
                         customerDatabase,
-                        getCollectionNameRegex(customerDatabase, captureCustomerCollections));
+                        getCollectionNameRegex(customerDatabase, captureCustomerCollections),
+                        skipSnapshotBackfill);
         // first step: check the snapshot data
         String[] snapshotForSingleTable =
                 new String[] {
@@ -251,7 +514,7 @@ public class MongoDBParallelSourceITCase extends MongoDBSourceTestBase {
     private String getCollectionNameRegex(String database, String[] captureCustomerCollections) {
         checkState(captureCustomerCollections.length > 0);
         if (captureCustomerCollections.length == 1) {
-            return captureCustomerCollections[0];
+            return database + "." + captureCustomerCollections[0];
         } else {
             // pattern that matches multiple collections
             return Arrays.stream(captureCustomerCollections)

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBSnapshotSplitReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBSnapshotSplitReaderTest.java
@@ -22,6 +22,7 @@ import com.ververica.cdc.connectors.base.source.meta.split.ChangeEventRecords;
 import com.ververica.cdc.connectors.base.source.meta.split.SnapshotSplit;
 import com.ververica.cdc.connectors.base.source.meta.split.SourceRecords;
 import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceSplitReader;
+import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHooks;
 import com.ververica.cdc.connectors.mongodb.source.MongoDBSourceTestBase;
 import com.ververica.cdc.connectors.mongodb.source.assigners.splitters.SampleBucketSplitStrategy;
 import com.ververica.cdc.connectors.mongodb.source.assigners.splitters.ShardedSplitStrategy;
@@ -114,7 +115,8 @@ public class MongoDBSnapshotSplitReaderTest extends MongoDBSourceTestBase {
         assertTrue(snapshotSplits.size() > 0);
 
         IncrementalSourceSplitReader<MongoDBSourceConfig> snapshotSplitReader =
-                new IncrementalSourceSplitReader<>(0, dialect, sourceConfig);
+                new IncrementalSourceSplitReader<>(
+                        0, dialect, sourceConfig, SnapshotPhaseHooks.empty());
 
         int retry = 0;
         long actualCount = 0;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBStreamSplitReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBStreamSplitReaderTest.java
@@ -24,6 +24,7 @@ import com.ververica.cdc.connectors.base.source.meta.split.ChangeEventRecords;
 import com.ververica.cdc.connectors.base.source.meta.split.SourceRecords;
 import com.ververica.cdc.connectors.base.source.meta.split.StreamSplit;
 import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceSplitReader;
+import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHooks;
 import com.ververica.cdc.connectors.mongodb.source.MongoDBSourceTestBase;
 import com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceConfig;
 import com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceConfigFactory;
@@ -118,7 +119,8 @@ public class MongoDBStreamSplitReaderTest extends MongoDBSourceTestBase {
     @Test
     public void testStreamSplitReader() throws Exception {
         IncrementalSourceSplitReader<MongoDBSourceConfig> streamSplitReader =
-                new IncrementalSourceSplitReader<>(0, dialect, sourceConfig);
+                new IncrementalSourceSplitReader<>(
+                        0, dialect, sourceConfig, SnapshotPhaseHooks.empty());
 
         try {
             ChangeStreamOffset startOffset = new ChangeStreamOffset(startupResumeToken);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
@@ -47,6 +47,7 @@ import java.util.Map;
 
 import static com.ververica.cdc.connectors.base.options.SourceOptions.CHUNK_META_GROUP_SIZE;
 import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED;
+import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP;
 import static com.ververica.cdc.connectors.mongodb.internal.MongoDBEnvelope.MONGODB_SRV_SCHEME;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.BATCH_SIZE;
 import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.FULL_DOCUMENT_PRE_POST_IMAGE;
@@ -116,6 +117,8 @@ public class MongoDBTableFactoryTest {
 
     private static final boolean SCAN_NO_CURSOR_TIMEOUT_DEFAULT =
             SCAN_NO_CURSOR_TIMEOUT.defaultValue();
+    private static final boolean SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP_DEFAULT =
+            SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue();
 
     @Test
     public void testCommonProperties() {
@@ -146,7 +149,8 @@ public class MongoDBTableFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES_DEFAULT,
                         SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT,
                         FULL_DOCUMENT_PRE_POST_IMAGE_ENABLED_DEFAULT,
-                        SCAN_NO_CURSOR_TIMEOUT_DEFAULT);
+                        SCAN_NO_CURSOR_TIMEOUT_DEFAULT,
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP_DEFAULT);
         assertEquals(expectedSource, actualSource);
     }
 
@@ -167,6 +171,7 @@ public class MongoDBTableFactoryTest {
         options.put("scan.incremental.snapshot.chunk.size.mb", "10");
         options.put("scan.incremental.snapshot.chunk.samples", "10");
         options.put("scan.incremental.close-idle-reader.enabled", "true");
+        options.put("scan.incremental.snapshot.backfill.skip", "true");
         options.put("scan.full-changelog", "true");
         options.put("scan.cursor.no-timeout", "false");
         DynamicTableSource actualSource = createTableSource(SCHEMA, options);
@@ -194,7 +199,8 @@ public class MongoDBTableFactoryTest {
                         10,
                         true,
                         true,
-                        false);
+                        false,
+                        true);
         assertEquals(expectedSource, actualSource);
     }
 
@@ -233,7 +239,8 @@ public class MongoDBTableFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES_DEFAULT,
                         SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT,
                         FULL_DOCUMENT_PRE_POST_IMAGE_ENABLED_DEFAULT,
-                        SCAN_NO_CURSOR_TIMEOUT_DEFAULT);
+                        SCAN_NO_CURSOR_TIMEOUT_DEFAULT,
+                        false);
 
         expectedSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
         expectedSource.metadataKeys = Arrays.asList("op_ts", "database_name");

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/utils/MongoDBTestUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/utils/MongoDBTestUtils.java
@@ -19,6 +19,7 @@ package com.ververica.cdc.connectors.mongodb.utils;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.highavailability.nonha.embedded.HaLeadershipControl;
 import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.types.Row;
 
@@ -26,6 +27,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.fail;
 
@@ -67,6 +70,17 @@ public class MongoDBTestUtils {
                 return 0;
             }
         }
+    }
+
+    public static List<String> fetchRowData(
+            Iterator<RowData> iter, int size, Function<RowData, String> stringifier) {
+        List<RowData> rows = new ArrayList<>(size);
+        while (size > 0 && iter.hasNext()) {
+            RowData row = iter.next();
+            rows.add(row);
+            size--;
+        }
+        return rows.stream().map(stringifier).collect(Collectors.toList());
     }
 
     public static List<String> fetchRows(Iterator<Row> iter, int size) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/utils/RecordsFormatter.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/utils/RecordsFormatter.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mongodb.utils;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.conversion.RowRowConverter;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Collector;
+
+import com.ververica.cdc.connectors.base.utils.SourceRecordUtils;
+import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import com.ververica.cdc.debezium.table.RowDataDebeziumDeserializeSchema;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Formatter that formats the {@link org.apache.kafka.connect.source.SourceRecord} to String. */
+public class RecordsFormatter {
+
+    private final DataType dataType;
+    private final ZoneId zoneId;
+
+    private TypeInformation<RowData> typeInfo;
+    private DebeziumDeserializationSchema<RowData> deserializationSchema;
+    private SimpleCollector collector;
+    private RowRowConverter rowRowConverter;
+
+    public RecordsFormatter(DataType dataType) {
+        this(dataType, ZoneId.of("UTC"));
+    }
+
+    public RecordsFormatter(DataType dataType, ZoneId zoneId) {
+        this.dataType = dataType;
+        this.zoneId = zoneId;
+        this.typeInfo =
+                (TypeInformation<RowData>) TypeConversions.fromDataTypeToLegacyInfo(dataType);
+        this.deserializationSchema =
+                RowDataDebeziumDeserializeSchema.newBuilder()
+                        .setPhysicalRowType((RowType) dataType.getLogicalType())
+                        .setResultTypeInfo(typeInfo)
+                        .build();
+        this.collector = new SimpleCollector();
+        this.rowRowConverter = RowRowConverter.create(dataType);
+        rowRowConverter.open(Thread.currentThread().getContextClassLoader());
+    }
+
+    public List<String> format(List<SourceRecord> records) {
+        records.stream()
+                // Keep DataChangeEvent only
+                .filter(SourceRecordUtils::isDataChangeRecord)
+                .forEach(
+                        r -> {
+                            try {
+                                deserializationSchema.deserialize(r, collector);
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+        return collector.list.stream()
+                .map(rowRowConverter::toExternal)
+                .map(Row::toString)
+                .collect(Collectors.toList());
+    }
+
+    private static class SimpleCollector implements Collector<RowData> {
+
+        private List<RowData> list = new ArrayList<>();
+
+        @Override
+        public void collect(RowData record) {
+            list.add(record);
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/utils/TestTable.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/utils/TestTable.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mongodb.utils;
+
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.conversion.RowRowConverter;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+
+import com.ververica.cdc.connectors.mongodb.table.MongoDBConnectorDeserializationSchema;
+import com.ververica.cdc.connectors.mongodb.table.MongoDBConnectorFullChangelogDeserializationSchema;
+import com.ververica.cdc.debezium.table.MetadataConverter;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.time.ZoneId;
+import java.util.List;
+
+/**
+ * Test utility for creating converter, formatter and deserializer of a table in the test database.
+ */
+public class TestTable {
+
+    private final String databaseName;
+    private final String tableName;
+    private final ResolvedSchema schema;
+
+    // Lazily initialized components
+    private RowRowConverter rowRowConverter;
+    private MongoDBConnectorDeserializationSchema deserializer;
+    private RecordsFormatter recordsFormatter;
+
+    private String serverTimeZone;
+
+    public TestTable(String databaseName, String tableName, ResolvedSchema schema) {
+        this.databaseName = databaseName;
+        this.tableName = tableName;
+        this.schema = schema;
+    }
+
+    public RowType getRowType() {
+        return (RowType) schema.toPhysicalRowDataType().getLogicalType();
+    }
+
+    public MongoDBConnectorDeserializationSchema getDeserializer(
+            boolean enableFullDocPrePostImage) {
+
+        if (deserializer == null) {
+            deserializer =
+                    enableFullDocPrePostImage
+                            ? new MongoDBConnectorFullChangelogDeserializationSchema(
+                                    getRowType(),
+                                    new MetadataConverter[0],
+                                    InternalTypeInfo.of(getRowType()),
+                                    ZoneId.of("UTC"))
+                            : new MongoDBConnectorDeserializationSchema(
+                                    getRowType(),
+                                    new MetadataConverter[0],
+                                    InternalTypeInfo.of(getRowType()),
+                                    ZoneId.of("UTC"));
+        }
+        return deserializer;
+    }
+
+    public RowRowConverter getRowRowConverter() {
+        if (rowRowConverter == null) {
+            rowRowConverter = RowRowConverter.create(schema.toPhysicalRowDataType());
+        }
+        return rowRowConverter;
+    }
+
+    public RecordsFormatter getRecordsFormatter() {
+        if (recordsFormatter == null) {
+            recordsFormatter = new RecordsFormatter(schema.toPhysicalRowDataType());
+        }
+        return recordsFormatter;
+    }
+
+    public String stringify(RowData rowData) {
+        return getRowRowConverter().toExternal(rowData).toString();
+    }
+
+    public List<String> stringify(List<SourceRecord> sourceRecord) {
+        return getRecordsFormatter().format(sourceRecord);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
@@ -22,6 +22,7 @@ import com.ververica.cdc.connectors.mysql.debezium.reader.SnapshotSplitReader;
 import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSnapshotSplit;
 import com.ververica.cdc.connectors.mysql.source.utils.StatementUtils;
+import com.ververica.cdc.connectors.mysql.source.utils.hooks.SnapshotPhaseHooks;
 import io.debezium.DebeziumException;
 import io.debezium.connector.mysql.MySqlConnection;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
@@ -78,6 +79,8 @@ public class MySqlSnapshotSplitReadTask
     private final EventDispatcher.SnapshotReceiver<MySqlPartition> snapshotReceiver;
     private final SnapshotChangeEventSourceMetrics<MySqlPartition> snapshotChangeEventSourceMetrics;
 
+    private final SnapshotPhaseHooks hooks;
+
     public MySqlSnapshotSplitReadTask(
             MySqlConnectorConfig connectorConfig,
             SnapshotChangeEventSourceMetrics<MySqlPartition> snapshotChangeEventSourceMetrics,
@@ -87,7 +90,8 @@ public class MySqlSnapshotSplitReadTask
             TopicSelector<TableId> topicSelector,
             EventDispatcher.SnapshotReceiver<MySqlPartition> snapshotReceiver,
             Clock clock,
-            MySqlSnapshotSplit snapshotSplit) {
+            MySqlSnapshotSplit snapshotSplit,
+            SnapshotPhaseHooks hooks) {
         super(connectorConfig, snapshotChangeEventSourceMetrics);
         this.connectorConfig = connectorConfig;
         this.databaseSchema = databaseSchema;
@@ -98,6 +102,7 @@ public class MySqlSnapshotSplitReadTask
         this.topicSelector = topicSelector;
         this.snapshotReceiver = snapshotReceiver;
         this.snapshotChangeEventSourceMetrics = snapshotChangeEventSourceMetrics;
+        this.hooks = hooks;
     }
 
     @Override
@@ -139,6 +144,9 @@ public class MySqlSnapshotSplitReadTask
                         topicSelector.topicNameFor(snapshotSplit.getTableId()),
                         dispatcher.getQueue());
 
+        if (hooks.getPreLowWatermarkAction() != null) {
+            hooks.getPreLowWatermarkAction().accept(jdbcConnection, snapshotSplit);
+        }
         final BinlogOffset lowWatermark = currentBinlogOffset(jdbcConnection);
         LOG.info(
                 "Snapshot step 1 - Determining low watermark {} for split {}",
@@ -149,8 +157,16 @@ public class MySqlSnapshotSplitReadTask
         signalEventDispatcher.dispatchWatermarkEvent(
                 snapshotSplit, lowWatermark, SignalEventDispatcher.WatermarkKind.LOW);
 
+        if (hooks.getPostLowWatermarkAction() != null) {
+            hooks.getPostLowWatermarkAction().accept(jdbcConnection, snapshotSplit);
+        }
+
         LOG.info("Snapshot step 2 - Snapshotting data");
         createDataEvents(ctx, snapshotSplit.getTableId());
+
+        if (hooks.getPreHighWatermarkAction() != null) {
+            hooks.getPreHighWatermarkAction().accept(jdbcConnection, snapshotSplit);
+        }
 
         final BinlogOffset highWatermark = currentBinlogOffset(jdbcConnection);
         LOG.info(
@@ -162,6 +178,9 @@ public class MySqlSnapshotSplitReadTask
         ((SnapshotSplitReader.SnapshotSplitChangeEventSourceContextImpl) (context))
                 .setHighWatermark(highWatermark);
 
+        if (hooks.getPostHighWatermarkAction() != null) {
+            hooks.getPostHighWatermarkAction().accept(jdbcConnection, snapshotSplit);
+        }
         return SnapshotResult.completed(ctx.offset);
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
@@ -238,6 +238,22 @@ public class MySqlSourceBuilder<T> {
     }
 
     /**
+     * Whether to skip backfill in snapshot reading phase.
+     *
+     * <p>If backfill is skipped, changes on captured tables during snapshot phase will be consumed
+     * later in binlog reading phase instead of being merged into the snapshot.
+     *
+     * <p>WARNING: Skipping backfill might lead to data inconsistency because some binlog events
+     * happened within the snapshot phase might be replayed (only at-least-once semantic is
+     * promised). For example updating an already updated value in snapshot, or deleting an already
+     * deleted entry in snapshot. These replayed binlog events should be handled specially.
+     */
+    public MySqlSourceBuilder<T> skipSnapshotBackfill(boolean skipSnapshotBackfill) {
+        this.configFactory.skipSnapshotBackfill(skipSnapshotBackfill);
+        return this;
+    }
+
+    /**
      * Whether to close idle readers at the end of the snapshot phase. This feature depends on
      * FLIP-147: Support Checkpoints After Tasks Finished. The flink version is required to be
      * greater than or equal to 1.14, and the configuration <code>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
@@ -60,6 +60,7 @@ public class MySqlSourceConfig implements Serializable {
     private final boolean closeIdleReaders;
     private final Properties jdbcProperties;
     private final Map<ObjectPath, String> chunkKeyColumns;
+    private final boolean skipSnapshotBackfill;
 
     // --------------------------------------------------------------------------------------------
     // Debezium Configurations
@@ -91,7 +92,8 @@ public class MySqlSourceConfig implements Serializable {
             boolean closeIdleReaders,
             Properties dbzProperties,
             Properties jdbcProperties,
-            Map<ObjectPath, String> chunkKeyColumns) {
+            Map<ObjectPath, String> chunkKeyColumns,
+            boolean skipSnapshotBackfill) {
         this.hostname = checkNotNull(hostname);
         this.port = port;
         this.username = checkNotNull(username);
@@ -117,6 +119,7 @@ public class MySqlSourceConfig implements Serializable {
         this.dbzMySqlConfig = new MySqlConnectorConfig(dbzConfiguration);
         this.jdbcProperties = jdbcProperties;
         this.chunkKeyColumns = chunkKeyColumns;
+        this.skipSnapshotBackfill = skipSnapshotBackfill;
     }
 
     public String getHostname() {
@@ -222,5 +225,9 @@ public class MySqlSourceConfig implements Serializable {
 
     public Map<ObjectPath, String> getChunkKeyColumns() {
         return chunkKeyColumns;
+    }
+
+    public boolean isSkipSnapshotBackfill() {
+        return skipSnapshotBackfill;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceOptions.java
@@ -255,4 +255,12 @@ public class MySqlSourceOptions {
                             "Whether to close idle readers at the end of the snapshot phase. This feature depends on "
                                     + "FLIP-147: Support Checkpoints After Tasks Finished. The flink version is required to be "
                                     + "greater than or equal to 1.14 when enabling this feature.");
+
+    @Experimental
+    public static final ConfigOption<Boolean> SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP =
+            ConfigOptions.key("scan.incremental.snapshot.backfill.skip")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to skip backfill in snapshot reading phase. If backfill is skipped, changes on captured tables during snapshot phase will be consumed later in binlog reading phase instead of being merged into the snapshot. WARNING: Skipping backfill might lead to data inconsistency because some binlog events happened within the snapshot phase might be replayed (only at-least-once semantic is promised). For example updating an already updated value in snapshot, or deleting an already deleted entry in snapshot. These replayed binlog events should be handled specially.");
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/hooks/SnapshotPhaseHook.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/hooks/SnapshotPhaseHook.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mysql.source.utils.hooks;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.util.function.BiConsumerWithException;
+
+import io.debezium.connector.mysql.MySqlConnection;
+
+import java.io.Serializable;
+import java.sql.SQLException;
+
+/**
+ * Hook to be invoked during different stages in the snapshot phase.
+ *
+ * <p>Please note that implementations should be serializable in order to be used in integration
+ * tests, as the hook need to be serialized together with the source on job submission.
+ */
+@Internal
+@FunctionalInterface
+public interface SnapshotPhaseHook
+        extends BiConsumerWithException<MySqlConnection, SourceSplit, SQLException>, Serializable {}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/hooks/SnapshotPhaseHooks.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/hooks/SnapshotPhaseHooks.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mysql.source.utils.hooks;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * A container class for hooks applied in the snapshot phase, including:
+ *
+ * <ul>
+ *   <li>{@link #preHighWatermarkAction}: Hook to run before emitting high watermark, which is for
+ *       testing whether binlog events created within snapshot phase are backfilled correctly.
+ *   <li>{@link #postHighWatermarkAction}: Hook to run after emitting high watermark, which is for
+ *       testing actions handling binlog events between snapshot splits.
+ * </ul>
+ */
+public class SnapshotPhaseHooks implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private SnapshotPhaseHook preLowWatermarkAction;
+    private SnapshotPhaseHook postLowWatermarkAction;
+    private SnapshotPhaseHook preHighWatermarkAction;
+    private SnapshotPhaseHook postHighWatermarkAction;
+
+    public void setPreHighWatermarkAction(SnapshotPhaseHook preHighWatermarkAction) {
+        this.preHighWatermarkAction = preHighWatermarkAction;
+    }
+
+    public void setPostHighWatermarkAction(SnapshotPhaseHook postHighWatermarkAction) {
+        this.postHighWatermarkAction = postHighWatermarkAction;
+    }
+
+    public void setPreLowWatermarkAction(SnapshotPhaseHook preLowWatermarkAction) {
+        this.preLowWatermarkAction = preLowWatermarkAction;
+    }
+
+    public void setPostLowWatermarkAction(SnapshotPhaseHook postLowWatermarkAction) {
+        this.postLowWatermarkAction = postLowWatermarkAction;
+    }
+
+    @Nullable
+    public SnapshotPhaseHook getPreHighWatermarkAction() {
+        return preHighWatermarkAction;
+    }
+
+    @Nullable
+    public SnapshotPhaseHook getPostHighWatermarkAction() {
+        return postHighWatermarkAction;
+    }
+
+    @Nullable
+    public SnapshotPhaseHook getPreLowWatermarkAction() {
+        return preLowWatermarkAction;
+    }
+
+    @Nullable
+    public SnapshotPhaseHook getPostLowWatermarkAction() {
+        return postLowWatermarkAction;
+    }
+
+    public static SnapshotPhaseHooks empty() {
+        return new SnapshotPhaseHooks();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSource.java
@@ -81,6 +81,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
     private final Properties jdbcProperties;
     private final Duration heartbeatInterval;
     private final String chunkKeyColumn;
+    final boolean skipSnapshotBackFill;
 
     // --------------------------------------------------------------------------------------------
     // Mutable attributes
@@ -117,7 +118,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
             boolean closeIdleReaders,
             Properties jdbcProperties,
             Duration heartbeatInterval,
-            @Nullable String chunkKeyColumn) {
+            @Nullable String chunkKeyColumn,
+            boolean skipSnapshotBackFill) {
         this.physicalSchema = physicalSchema;
         this.port = port;
         this.hostname = checkNotNull(hostname);
@@ -146,6 +148,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
         this.metadataKeys = Collections.emptyList();
         this.heartbeatInterval = heartbeatInterval;
         this.chunkKeyColumn = chunkKeyColumn;
+        this.skipSnapshotBackFill = skipSnapshotBackFill;
     }
 
     @Override
@@ -200,6 +203,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                             .jdbcProperties(jdbcProperties)
                             .heartbeatInterval(heartbeatInterval)
                             .chunkKeyColumn(new ObjectPath(database, tableName), chunkKeyColumn)
+                            .skipSnapshotBackfill(skipSnapshotBackFill)
                             .build();
             return SourceProvider.of(parallelSource);
         } else {
@@ -280,7 +284,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                         closeIdleReaders,
                         jdbcProperties,
                         heartbeatInterval,
-                        chunkKeyColumn);
+                        chunkKeyColumn,
+                        skipSnapshotBackFill);
         source.metadataKeys = metadataKeys;
         source.producedDataType = producedDataType;
         return source;
@@ -321,7 +326,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                 && Objects.equals(metadataKeys, that.metadataKeys)
                 && Objects.equals(jdbcProperties, that.jdbcProperties)
                 && Objects.equals(heartbeatInterval, that.heartbeatInterval)
-                && Objects.equals(chunkKeyColumn, that.chunkKeyColumn);
+                && Objects.equals(chunkKeyColumn, that.chunkKeyColumn)
+                && Objects.equals(skipSnapshotBackFill, that.skipSnapshotBackFill);
     }
 
     @Override
@@ -353,7 +359,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                 closeIdleReaders,
                 jdbcProperties,
                 heartbeatInterval,
-                chunkKeyColumn);
+                chunkKeyColumn,
+                skipSnapshotBackFill);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactory.java
@@ -57,6 +57,7 @@ import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOption
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.PASSWORD;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.PORT;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED;
@@ -121,6 +122,7 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
 
         boolean enableParallelRead = config.get(SCAN_INCREMENTAL_SNAPSHOT_ENABLED);
         boolean closeIdleReaders = config.get(SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED);
+        boolean skipSnapshotBackFill = config.get(SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
 
         if (enableParallelRead) {
             validatePrimaryKeyIfEnableParallel(physicalSchema, chunkKeyColumn);
@@ -160,7 +162,8 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
                 closeIdleReaders,
                 JdbcUrlUtils.getJdbcProperties(context.getCatalogTable().getOptions()),
                 heartbeatInterval,
-                chunkKeyColumn);
+                chunkKeyColumn,
+                skipSnapshotBackFill);
     }
 
     @Override
@@ -205,6 +208,7 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
         options.add(SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED);
         options.add(HEARTBEAT_INTERVAL);
         options.add(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN);
+        options.add(SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
         return options;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
@@ -30,18 +30,12 @@ import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfig;
 import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfigFactory;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
 import com.ververica.cdc.connectors.mysql.source.split.SourceRecords;
+import com.ververica.cdc.connectors.mysql.source.utils.hooks.SnapshotPhaseHooks;
 import com.ververica.cdc.connectors.mysql.testutils.RecordsFormatter;
 import com.ververica.cdc.connectors.mysql.testutils.UniqueDatabase;
 import io.debezium.connector.mysql.MySqlConnection;
-import io.debezium.connector.mysql.MySqlPartition;
-import io.debezium.data.Envelope;
 import io.debezium.jdbc.JdbcConnection;
-import io.debezium.pipeline.EventDispatcher;
-import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.TableId;
-import io.debezium.schema.DataCollectionSchema;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -53,7 +47,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertNotNull;
@@ -304,11 +297,14 @@ public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
                 };
 
         StatefulTaskContext statefulTaskContext =
-                new MakeBinlogEventTaskContext(
-                        sourceConfig,
-                        binaryLogClient,
-                        mySqlConnection,
-                        () -> executeSql(sourceConfig, changingDataSql));
+                new StatefulTaskContext(sourceConfig, binaryLogClient, mySqlConnection);
+
+        SnapshotPhaseHooks snapshotHooks = new SnapshotPhaseHooks();
+        snapshotHooks.setPreHighWatermarkAction(
+                (mySqlConnection, split) -> {
+                    mySqlConnection.execute(changingDataSql);
+                    mySqlConnection.commit();
+                });
 
         final DataType dataType =
                 DataTypes.ROW(
@@ -334,7 +330,11 @@ public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
 
         List<String> actual =
                 readTableSnapshotSplits(
-                        mySqlSplits, statefulTaskContext, mySqlSplits.size(), dataType);
+                        mySqlSplits,
+                        statefulTaskContext,
+                        mySqlSplits.size(),
+                        dataType,
+                        snapshotHooks);
         assertEqualsInAnyOrder(Arrays.asList(expected), actual);
     }
 
@@ -357,11 +357,13 @@ public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
                 };
 
         StatefulTaskContext statefulTaskContext =
-                new MakeBinlogEventTaskContext(
-                        sourceConfig,
-                        binaryLogClient,
-                        mySqlConnection,
-                        () -> executeSql(sourceConfig, insertDataSql));
+                new StatefulTaskContext(sourceConfig, binaryLogClient, mySqlConnection);
+        SnapshotPhaseHooks snapshotHooks = new SnapshotPhaseHooks();
+        snapshotHooks.setPostLowWatermarkAction(
+                (mySqlConnection, split) -> {
+                    mySqlConnection.execute(insertDataSql);
+                    mySqlConnection.commit();
+                });
 
         final DataType dataType =
                 DataTypes.ROW(
@@ -389,7 +391,11 @@ public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
 
         List<String> actual =
                 readTableSnapshotSplits(
-                        mySqlSplits, statefulTaskContext, mySqlSplits.size(), dataType);
+                        mySqlSplits,
+                        statefulTaskContext,
+                        mySqlSplits.size(),
+                        dataType,
+                        snapshotHooks);
         assertEqualsInAnyOrder(Arrays.asList(expected), actual);
         executeSql(sourceConfig, recoveryDataSql);
     }
@@ -413,11 +419,13 @@ public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
                 };
 
         StatefulTaskContext statefulTaskContext =
-                new MakeBinlogEventTaskContext(
-                        sourceConfig,
-                        binaryLogClient,
-                        mySqlConnection,
-                        () -> executeSql(sourceConfig, deleteDataSql));
+                new StatefulTaskContext(sourceConfig, binaryLogClient, mySqlConnection);
+        SnapshotPhaseHooks snapshotHooks = new SnapshotPhaseHooks();
+        snapshotHooks.setPreHighWatermarkAction(
+                (mySqlConnection, split) -> {
+                    mySqlConnection.execute(deleteDataSql);
+                    mySqlConnection.commit();
+                });
 
         final DataType dataType =
                 DataTypes.ROW(
@@ -441,7 +449,11 @@ public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
 
         List<String> actual =
                 readTableSnapshotSplits(
-                        mySqlSplits, statefulTaskContext, mySqlSplits.size(), dataType);
+                        mySqlSplits,
+                        statefulTaskContext,
+                        mySqlSplits.size(),
+                        dataType,
+                        snapshotHooks);
         assertEqualsInAnyOrder(Arrays.asList(expected), actual);
         executeSql(sourceConfig, recoveryDataSql);
     }
@@ -450,9 +462,11 @@ public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
             List<MySqlSplit> mySqlSplits,
             StatefulTaskContext statefulTaskContext,
             int scanSplitsNum,
-            DataType dataType)
+            DataType dataType,
+            SnapshotPhaseHooks snapshotHooks)
             throws Exception {
-        SnapshotSplitReader snapshotSplitReader = new SnapshotSplitReader(statefulTaskContext, 0);
+        SnapshotSplitReader snapshotSplitReader =
+                new SnapshotSplitReader(statefulTaskContext, 0, snapshotHooks);
 
         List<SourceRecord> result = new ArrayList<>();
         for (int i = 0; i < scanSplitsNum; i++) {
@@ -475,6 +489,20 @@ public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
         assertTrue(snapshotSplitReader.getExecutorService().isTerminated());
 
         return formatResult(result, dataType);
+    }
+
+    private List<String> readTableSnapshotSplits(
+            List<MySqlSplit> mySqlSplits,
+            StatefulTaskContext statefulTaskContext,
+            int scanSplitsNum,
+            DataType dataType)
+            throws Exception {
+        return readTableSnapshotSplits(
+                mySqlSplits,
+                statefulTaskContext,
+                scanSplitsNum,
+                dataType,
+                SnapshotPhaseHooks.empty());
     }
 
     private List<String> formatResult(List<SourceRecord> records, DataType dataType) {
@@ -539,48 +567,5 @@ public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
             return false;
         }
         return true;
-    }
-
-    static class MakeBinlogEventTaskContext extends StatefulTaskContext {
-
-        private final Supplier<Boolean> makeBinlogFunction;
-
-        public MakeBinlogEventTaskContext(
-                MySqlSourceConfig sourceConfig,
-                BinaryLogClient binaryLogClient,
-                MySqlConnection connection,
-                Supplier<Boolean> makeBinlogFunction) {
-            super(sourceConfig, binaryLogClient, connection);
-            this.makeBinlogFunction = makeBinlogFunction;
-        }
-
-        @Override
-        public EventDispatcher.SnapshotReceiver<MySqlPartition> getSnapshotReceiver() {
-            EventDispatcher.SnapshotReceiver<MySqlPartition> snapshotReceiver =
-                    super.getSnapshotReceiver();
-            return new EventDispatcher.SnapshotReceiver<MySqlPartition>() {
-
-                @Override
-                public void changeRecord(
-                        MySqlPartition partition,
-                        DataCollectionSchema schema,
-                        Envelope.Operation operation,
-                        Object key,
-                        Struct value,
-                        OffsetContext offset,
-                        ConnectHeaders headers)
-                        throws InterruptedException {
-                    snapshotReceiver.changeRecord(
-                            partition, schema, operation, key, value, offset, headers);
-                }
-
-                @Override
-                public void completeSnapshot() throws InterruptedException {
-                    snapshotReceiver.completeSnapshot();
-                    // make binlog events
-                    makeBinlogFunction.get();
-                }
-            };
-        }
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
@@ -50,6 +50,7 @@ import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOption
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.CONNECT_MAX_RETRIES;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.CONNECT_TIMEOUT;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.HEARTBEAT_INTERVAL;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_SNAPSHOT_FETCH_SIZE;
@@ -124,7 +125,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -169,7 +171,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        "testCol");
+                        "testCol",
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -210,7 +213,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -249,7 +253,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -265,6 +270,7 @@ public class MySqlTableSourceFactoryTest {
         options.put("heartbeat.interval", "15213ms");
         options.put("scan.incremental.snapshot.chunk.key-column", "testCol");
         options.put("scan.incremental.close-idle-reader.enabled", "true");
+        options.put("scan.incremental.snapshot.backfill.skip", "true");
 
         DynamicTableSource actualSource = createTableSource(options);
         Properties dbzProperties = new Properties();
@@ -297,7 +303,8 @@ public class MySqlTableSourceFactoryTest {
                         true,
                         jdbcProperties,
                         Duration.ofMillis(15213),
-                        "testCol");
+                        "testCol",
+                        true);
         assertEquals(expectedSource, actualSource);
     }
 
@@ -342,7 +349,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -379,7 +387,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -417,7 +426,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -456,7 +466,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -493,7 +504,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -535,7 +547,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         expectedSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
         expectedSource.metadataKeys = Arrays.asList("op_ts", "database_name");
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OracleDialect.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OracleDialect.java
@@ -28,7 +28,6 @@ import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitBase;
 import com.ververica.cdc.connectors.base.source.reader.external.FetchTask;
 import com.ververica.cdc.connectors.oracle.source.assigner.splitter.OracleChunkSplitter;
 import com.ververica.cdc.connectors.oracle.source.config.OracleSourceConfig;
-import com.ververica.cdc.connectors.oracle.source.config.OracleSourceConfigFactory;
 import com.ververica.cdc.connectors.oracle.source.reader.fetch.OracleScanFetchTask;
 import com.ververica.cdc.connectors.oracle.source.reader.fetch.OracleSourceFetchTaskContext;
 import com.ververica.cdc.connectors.oracle.source.reader.fetch.OracleStreamFetchTask;
@@ -52,14 +51,7 @@ import static com.ververica.cdc.connectors.oracle.source.utils.OracleConnectionU
 public class OracleDialect implements JdbcDataSourceDialect {
 
     private static final long serialVersionUID = 1L;
-    private final OracleSourceConfigFactory configFactory;
-    private final OracleSourceConfig sourceConfig;
     private transient OracleSchema oracleSchema;
-
-    public OracleDialect(OracleSourceConfigFactory configFactory) {
-        this.configFactory = configFactory;
-        this.sourceConfig = configFactory.create(0);
-    }
 
     @Override
     public String getName() {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OracleSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OracleSourceBuilder.java
@@ -233,7 +233,7 @@ public class OracleSourceBuilder<T> {
      */
     public OracleIncrementalSource<T> build() {
         this.offsetFactory = new RedoLogOffsetFactory();
-        this.dialect = new OracleDialect(configFactory);
+        this.dialect = new OracleDialect();
         return new OracleIncrementalSource<T>(
                 configFactory, checkNotNull(deserializer), offsetFactory, dialect);
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfig.java
@@ -85,7 +85,8 @@ public class OracleSourceConfig extends JdbcSourceConfig {
                 connectTimeout,
                 connectMaxRetries,
                 connectionPoolSize,
-                chunkKeyColumn);
+                chunkKeyColumn,
+                true);
         this.url = url;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresDialect.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresDialect.java
@@ -28,7 +28,6 @@ import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitBase;
 import com.ververica.cdc.connectors.base.source.reader.external.FetchTask;
 import com.ververica.cdc.connectors.base.source.reader.external.JdbcSourceFetchTaskContext;
 import com.ververica.cdc.connectors.postgres.source.config.PostgresSourceConfig;
-import com.ververica.cdc.connectors.postgres.source.config.PostgresSourceConfigFactory;
 import com.ververica.cdc.connectors.postgres.source.fetch.PostgresScanFetchTask;
 import com.ververica.cdc.connectors.postgres.source.fetch.PostgresSourceFetchTaskContext;
 import com.ververica.cdc.connectors.postgres.source.fetch.PostgresStreamFetchTask;
@@ -70,8 +69,8 @@ public class PostgresDialect implements JdbcDataSourceDialect {
 
     @Nullable private PostgresStreamFetchTask streamFetchTask;
 
-    public PostgresDialect(PostgresSourceConfigFactory configFactory) {
-        this.sourceConfig = configFactory.create(0);
+    public PostgresDialect(PostgresSourceConfig sourceConfig) {
+        this.sourceConfig = sourceConfig;
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresSourceBuilder.java
@@ -254,7 +254,7 @@ public class PostgresSourceBuilder<T> {
      */
     public PostgresIncrementalSource<T> build() {
         PostgresOffsetFactory offsetFactory = new PostgresOffsetFactory();
-        PostgresDialect dialect = new PostgresDialect(configFactory);
+        PostgresDialect dialect = new PostgresDialect(configFactory.create(0));
         return new PostgresIncrementalSource<>(
                 configFactory, checkNotNull(deserializer), offsetFactory, dialect);
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresSourceBuilder.java
@@ -248,6 +248,22 @@ public class PostgresSourceBuilder<T> {
     }
 
     /**
+     * Whether to skip backfill in snapshot reading phase.
+     *
+     * <p>If backfill is skipped, changes on captured tables during snapshot phase will be consumed
+     * later in binlog reading phase instead of being merged into the snapshot.
+     *
+     * <p>WARNING: Skipping backfill might lead to data inconsistency because some binlog events
+     * happened within the snapshot phase might be replayed (only at-least-once semantic is
+     * promised). For example updating an already updated value in snapshot, or deleting an already
+     * deleted entry in snapshot. These replayed binlog events should be handled specially.
+     */
+    public PostgresSourceBuilder<T> skipSnapshotBackfill(boolean skipSnapshotBackfill) {
+        this.configFactory.skipSnapshotBackfill(skipSnapshotBackfill);
+        return this;
+    }
+
+    /**
      * Build the {@link PostgresIncrementalSource}.
      *
      * @return a PostgresParallelSource with the settings made for this builder.

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
@@ -61,7 +61,8 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
             Duration connectTimeout,
             int connectMaxRetries,
             int connectionPoolSize,
-            @Nullable String chunkKeyColumn) {
+            @Nullable String chunkKeyColumn,
+            boolean skipSnapshotBackfill) {
         super(
                 startupOptions,
                 databaseList,
@@ -86,7 +87,7 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
                 connectMaxRetries,
                 connectionPoolSize,
                 chunkKeyColumn,
-                true);
+                skipSnapshotBackfill);
         this.subtaskId = subtaskId;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
@@ -85,7 +85,8 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
                 connectTimeout,
                 connectMaxRetries,
                 connectionPoolSize,
-                chunkKeyColumn);
+                chunkKeyColumn,
+                true);
         this.subtaskId = subtaskId;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfigFactory.java
@@ -126,7 +126,8 @@ public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
                 connectTimeout,
                 connectMaxRetries,
                 connectionPoolSize,
-                chunkKeyColumn);
+                chunkKeyColumn,
+                skipSnapshotBackfill);
     }
 
     /**

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgreSQLTableFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgreSQLTableFactory.java
@@ -43,6 +43,7 @@ import static com.ververica.cdc.connectors.base.options.JdbcSourceOptions.SCHEMA
 import static com.ververica.cdc.connectors.base.options.JdbcSourceOptions.TABLE_NAME;
 import static com.ververica.cdc.connectors.base.options.JdbcSourceOptions.USERNAME;
 import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED;
+import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP;
 import static com.ververica.cdc.connectors.base.utils.ObjectUtils.doubleCompare;
 import static com.ververica.cdc.connectors.postgres.source.config.PostgresSourceOptions.CHANGELOG_MODE;
 import static com.ververica.cdc.connectors.postgres.source.config.PostgresSourceOptions.CHUNK_META_GROUP_SIZE;
@@ -110,6 +111,7 @@ public class PostgreSQLTableFactory implements DynamicTableSourceFactory {
                 config.getOptional(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN).orElse(null);
 
         boolean closeIdlerReaders = config.get(SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED);
+        boolean skipSnapshotBackfill = config.get(SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
 
         if (enableParallelRead) {
             validateIntegerOption(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE, splitSize, 1);
@@ -152,7 +154,8 @@ public class PostgreSQLTableFactory implements DynamicTableSourceFactory {
                 heartbeatInterval,
                 startupOptions,
                 chunkKeyColumn,
-                closeIdlerReaders);
+                closeIdlerReaders,
+                skipSnapshotBackfill);
     }
 
     @Override
@@ -192,6 +195,7 @@ public class PostgreSQLTableFactory implements DynamicTableSourceFactory {
         options.add(CONNECTION_POOL_SIZE);
         options.add(HEARTBEAT_INTERVAL);
         options.add(SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED);
+        options.add(SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
         return options;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgreSQLTableSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgreSQLTableSource.java
@@ -83,6 +83,8 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
     private final String chunkKeyColumn;
     private final boolean closeIdleReaders;
 
+    private final boolean skipSnapshotBackfill;
+
     // --------------------------------------------------------------------------------------------
     // Mutable attributes
     // --------------------------------------------------------------------------------------------
@@ -118,7 +120,8 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
             Duration heartbeatInterval,
             StartupOptions startupOptions,
             @Nullable String chunkKeyColumn,
-            boolean closeIdleReaders) {
+            boolean closeIdleReaders,
+            boolean skipSnapshotBackfill) {
         this.physicalSchema = physicalSchema;
         this.port = port;
         this.hostname = checkNotNull(hostname);
@@ -147,6 +150,7 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
         this.producedDataType = physicalSchema.toPhysicalRowDataType();
         this.metadataKeys = Collections.emptyList();
         this.closeIdleReaders = closeIdleReaders;
+        this.skipSnapshotBackfill = skipSnapshotBackfill;
     }
 
     @Override
@@ -206,6 +210,7 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
                             .chunkKeyColumn(chunkKeyColumn)
                             .heartbeatInterval(heartbeatInterval)
                             .closeIdleReaders(closeIdleReaders)
+                            .skipSnapshotBackfill(skipSnapshotBackfill)
                             .build();
             return SourceProvider.of(parallelSource);
         } else {
@@ -271,7 +276,8 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
                         heartbeatInterval,
                         startupOptions,
                         chunkKeyColumn,
-                        closeIdleReaders);
+                        closeIdleReaders,
+                        skipSnapshotBackfill);
         source.metadataKeys = metadataKeys;
         source.producedDataType = producedDataType;
         return source;
@@ -312,7 +318,8 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
                 && Objects.equals(heartbeatInterval, that.heartbeatInterval)
                 && Objects.equals(startupOptions, that.startupOptions)
                 && Objects.equals(chunkKeyColumn, that.chunkKeyColumn)
-                && Objects.equals(closeIdleReaders, that.closeIdleReaders);
+                && Objects.equals(closeIdleReaders, that.closeIdleReaders)
+                && Objects.equals(skipSnapshotBackfill, that.skipSnapshotBackfill);
     }
 
     @Override
@@ -344,7 +351,8 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
                 heartbeatInterval,
                 startupOptions,
                 chunkKeyColumn,
-                closeIdleReaders);
+                closeIdleReaders,
+                skipSnapshotBackfill);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/PostgresTestBase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/PostgresTestBase.java
@@ -20,6 +20,8 @@ import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.test.util.AbstractTestBase;
 
 import com.ververica.cdc.connectors.postgres.source.PostgresConnectionPoolFactory;
+import com.ververica.cdc.connectors.postgres.source.config.PostgresSourceConfigFactory;
+import com.ververica.cdc.connectors.postgres.testutils.UniqueDatabase;
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.jdbc.JdbcConfiguration;
@@ -48,7 +50,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Basic class for testing PostgreSQL source, this contains a PostgreSQL container which enables
@@ -186,5 +191,33 @@ public abstract class PostgresTestBase extends AbstractTestBase {
                 return 0;
             }
         }
+    }
+
+    protected PostgresSourceConfigFactory getMockPostgresSourceConfigFactory(
+            UniqueDatabase database, String schemaName, String tableName, int splitSize) {
+
+        PostgresSourceConfigFactory postgresSourceConfigFactory = new PostgresSourceConfigFactory();
+        postgresSourceConfigFactory.hostname(database.getHost());
+        postgresSourceConfigFactory.port(database.getDatabasePort());
+        postgresSourceConfigFactory.username(database.getUsername());
+        postgresSourceConfigFactory.password(database.getPassword());
+        postgresSourceConfigFactory.database(database.getDatabaseName());
+        postgresSourceConfigFactory.schemaList(new String[] {schemaName});
+        postgresSourceConfigFactory.tableList(schemaName + "." + tableName);
+        postgresSourceConfigFactory.splitSize(splitSize);
+        return postgresSourceConfigFactory;
+    }
+
+    public static void assertEqualsInAnyOrder(List<String> expected, List<String> actual) {
+        assertTrue(expected != null && actual != null);
+        assertEqualsInOrder(
+                expected.stream().sorted().collect(Collectors.toList()),
+                actual.stream().sorted().collect(Collectors.toList()));
+    }
+
+    public static void assertEqualsInOrder(List<String> expected, List<String> actual) {
+        assertTrue(expected != null && actual != null);
+        assertEquals(expected.size(), actual.size());
+        assertArrayEquals(expected.toArray(new String[0]), actual.toArray(new String[0]));
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/PostgresTestBase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/PostgresTestBase.java
@@ -195,6 +195,16 @@ public abstract class PostgresTestBase extends AbstractTestBase {
 
     protected PostgresSourceConfigFactory getMockPostgresSourceConfigFactory(
             UniqueDatabase database, String schemaName, String tableName, int splitSize) {
+        return getMockPostgresSourceConfigFactory(
+                database, schemaName, tableName, splitSize, false);
+    }
+
+    protected PostgresSourceConfigFactory getMockPostgresSourceConfigFactory(
+            UniqueDatabase database,
+            String schemaName,
+            String tableName,
+            int splitSize,
+            boolean skipSnapshotBackfill) {
 
         PostgresSourceConfigFactory postgresSourceConfigFactory = new PostgresSourceConfigFactory();
         postgresSourceConfigFactory.hostname(database.getHost());
@@ -205,6 +215,7 @@ public abstract class PostgresTestBase extends AbstractTestBase {
         postgresSourceConfigFactory.schemaList(new String[] {schemaName});
         postgresSourceConfigFactory.tableList(schemaName + "." + tableName);
         postgresSourceConfigFactory.splitSize(splitSize);
+        postgresSourceConfigFactory.skipSnapshotBackfill(skipSnapshotBackfill);
         return postgresSourceConfigFactory;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/source/PostgresDialectTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/source/PostgresDialectTest.java
@@ -54,16 +54,9 @@ public class PostgresDialectTest extends PostgresTestBase {
         // get table named 'customer.customers' from customDatabase which is actual in
         // inventoryDatabase
         PostgresSourceConfigFactory configFactoryOfCustomDatabase =
-                getMockPostgresSourceConfigFactory(
-                        customDatabase.getHost(),
-                        customDatabase.getDatabasePort(),
-                        customDatabase.getUsername(),
-                        customDatabase.getPassword(),
-                        customDatabase.getDatabaseName(),
-                        "customer",
-                        "customers");
+                getMockPostgresSourceConfigFactory(customDatabase, "customer", "customers", 10);
         PostgresDialect dialectOfcustomDatabase =
-                new PostgresDialect(configFactoryOfCustomDatabase);
+                new PostgresDialect(configFactoryOfCustomDatabase.create(0));
         List<TableId> tableIdsOfcustomDatabase =
                 dialectOfcustomDatabase.discoverDataCollections(
                         configFactoryOfCustomDatabase.create(0));
@@ -73,16 +66,9 @@ public class PostgresDialectTest extends PostgresTestBase {
         // inventoryDatabase
         // however, nothing is found
         PostgresSourceConfigFactory configFactoryOfInventoryDatabase =
-                getMockPostgresSourceConfigFactory(
-                        inventoryDatabase.getHost(),
-                        inventoryDatabase.getDatabasePort(),
-                        inventoryDatabase.getUsername(),
-                        inventoryDatabase.getPassword(),
-                        inventoryDatabase.getDatabaseName(),
-                        "inventory",
-                        "products");
+                getMockPostgresSourceConfigFactory(inventoryDatabase, "inventory", "products", 10);
         PostgresDialect dialectOfInventoryDatabase =
-                new PostgresDialect(configFactoryOfInventoryDatabase);
+                new PostgresDialect(configFactoryOfInventoryDatabase.create(0));
         List<TableId> tableIdsOfInventoryDatabase =
                 dialectOfInventoryDatabase.discoverDataCollections(
                         configFactoryOfInventoryDatabase.create(0));
@@ -92,38 +78,12 @@ public class PostgresDialectTest extends PostgresTestBase {
         // customDatabase
         // however, something is found
         PostgresSourceConfigFactory configFactoryOfInventoryDatabase2 =
-                getMockPostgresSourceConfigFactory(
-                        inventoryDatabase.getHost(),
-                        inventoryDatabase.getDatabasePort(),
-                        inventoryDatabase.getUsername(),
-                        inventoryDatabase.getPassword(),
-                        inventoryDatabase.getDatabaseName(),
-                        "customer",
-                        "customers");
+                getMockPostgresSourceConfigFactory(inventoryDatabase, "customer", "customers", 10);
         PostgresDialect dialectOfInventoryDatabase2 =
-                new PostgresDialect(configFactoryOfInventoryDatabase2);
+                new PostgresDialect(configFactoryOfInventoryDatabase2.create(0));
         List<TableId> tableIdsOfInventoryDatabase2 =
                 dialectOfInventoryDatabase2.discoverDataCollections(
                         configFactoryOfInventoryDatabase2.create(0));
         Assert.assertTrue(tableIdsOfInventoryDatabase2.isEmpty());
-    }
-
-    private static PostgresSourceConfigFactory getMockPostgresSourceConfigFactory(
-            String hostname,
-            int port,
-            String username,
-            String password,
-            String database,
-            String schemaName,
-            String tableName) {
-        PostgresSourceConfigFactory postgresSourceConfigFactory = new PostgresSourceConfigFactory();
-        postgresSourceConfigFactory.hostname(hostname);
-        postgresSourceConfigFactory.port(port);
-        postgresSourceConfigFactory.username(username);
-        postgresSourceConfigFactory.password(password);
-        postgresSourceConfigFactory.database(database);
-        postgresSourceConfigFactory.schemaList(new String[] {schemaName});
-        postgresSourceConfigFactory.tableList(schemaName + "." + tableName);
-        return postgresSourceConfigFactory;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/source/PostgresSourceExampleTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/source/PostgresSourceExampleTest.java
@@ -52,9 +52,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
 /** Tests for Postgres Source based on incremental snapshot framework . */
@@ -256,19 +253,6 @@ public class PostgresSourceExampleTest extends PostgresTestBase {
         PostgresConnection connection = createConnection(properties);
         connection.connect();
         return connection;
-    }
-
-    public static void assertEqualsInAnyOrder(List<String> expected, List<String> actual) {
-        assertTrue(expected != null && actual != null);
-        assertEqualsInOrder(
-                expected.stream().sorted().collect(Collectors.toList()),
-                actual.stream().sorted().collect(Collectors.toList()));
-    }
-
-    public static void assertEqualsInOrder(List<String> expected, List<String> actual) {
-        assertTrue(expected != null && actual != null);
-        assertEquals(expected.size(), actual.size());
-        assertArrayEquals(expected.toArray(new String[0]), actual.toArray(new String[0]));
     }
 
     private void makeWalEvents(PostgresConnection connection, String tableId) throws SQLException {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/source/PostgresSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/source/PostgresSourceITCase.java
@@ -54,13 +54,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static org.apache.flink.api.common.JobStatus.RUNNING;
 import static org.apache.flink.util.Preconditions.checkState;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /** IT tests for {@link PostgresSourceBuilder.PostgresIncrementalSource}. */
@@ -658,19 +655,6 @@ public class PostgresSourceITCase extends PostgresTestBase {
         miniCluster.terminateTaskManager(0).get();
         afterFailAction.run();
         miniCluster.startTaskManager();
-    }
-
-    public static void assertEqualsInAnyOrder(List<String> expected, List<String> actual) {
-        assertTrue(expected != null && actual != null);
-        assertEqualsInOrder(
-                expected.stream().sorted().collect(Collectors.toList()),
-                actual.stream().sorted().collect(Collectors.toList()));
-    }
-
-    public static void assertEqualsInOrder(List<String> expected, List<String> actual) {
-        assertTrue(expected != null && actual != null);
-        assertEquals(expected.size(), actual.size());
-        assertArrayEquals(expected.toArray(new String[0]), actual.toArray(new String[0]));
     }
 
     private void waitUntilJobRunning(TableResult tableResult)

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.postgres.source.fetch;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
+
+import com.ververica.cdc.connectors.base.dialect.JdbcDataSourceDialect;
+import com.ververica.cdc.connectors.base.source.assigner.splitter.ChunkSplitter;
+import com.ververica.cdc.connectors.base.source.meta.split.SnapshotSplit;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceRecords;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import com.ververica.cdc.connectors.base.source.reader.external.AbstractScanFetchTask;
+import com.ververica.cdc.connectors.base.source.reader.external.FetchTask;
+import com.ververica.cdc.connectors.base.source.reader.external.IncrementalSourceScanFetcher;
+import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHook;
+import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHooks;
+import com.ververica.cdc.connectors.postgres.PostgresTestBase;
+import com.ververica.cdc.connectors.postgres.source.PostgresDialect;
+import com.ververica.cdc.connectors.postgres.source.config.PostgresSourceConfig;
+import com.ververica.cdc.connectors.postgres.source.config.PostgresSourceConfigFactory;
+import com.ververica.cdc.connectors.postgres.testutils.RecordsFormatter;
+import com.ververica.cdc.connectors.postgres.testutils.UniqueDatabase;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.relational.TableId;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link PostgresScanFetchTask}. */
+public class PostgresScanFetchTaskTest extends PostgresTestBase {
+
+    private static final int USE_POST_LOWWATERMARK_HOOK = 1;
+    private static final int USE_PRE_HIGHWATERMARK_HOOK = 2;
+
+    private static String schemaName = "customer";
+    private static String tableName = "customers";
+
+    private final UniqueDatabase customDatabase =
+            new UniqueDatabase(
+                    POSTGRES_CONTAINER,
+                    "postgres",
+                    "customer",
+                    POSTGRES_CONTAINER.getUsername(),
+                    POSTGRES_CONTAINER.getPassword());
+
+    @Test
+    public void testChangingDataInSnapshotScan() throws Exception {
+        customDatabase.createAndInitialize();
+
+        String tableId = schemaName + "." + tableName;
+        String[] changingDataSql =
+                new String[] {
+                    "UPDATE " + tableId + " SET address = 'Hangzhou' where id = 103",
+                    "DELETE FROM " + tableId + " where id = 102",
+                    "INSERT INTO " + tableId + " VALUES(102, 'user_2','hangzhou','123567891234')",
+                    "UPDATE " + tableId + " SET address = 'Shanghai' where id = 103",
+                    "UPDATE " + tableId + " SET address = 'Hangzhou' where id = 110",
+                    "UPDATE " + tableId + " SET address = 'Hangzhou' where id = 111",
+                };
+
+        String[] expected =
+                new String[] {
+                    "+I[101, user_1, Shanghai, 123567891234]",
+                    "+I[102, user_2, hangzhou, 123567891234]",
+                    "+I[103, user_3, Shanghai, 123567891234]",
+                    "+I[109, user_4, Shanghai, 123567891234]",
+                    "+I[110, user_5, Hangzhou, 123567891234]",
+                    "+I[111, user_6, Hangzhou, 123567891234]",
+                    "+I[118, user_7, Shanghai, 123567891234]",
+                    "+I[121, user_8, Shanghai, 123567891234]",
+                    "+I[123, user_9, Shanghai, 123567891234]",
+                };
+        List<String> actual =
+                getDataInSnapshotScan(
+                        changingDataSql, schemaName, tableName, USE_PRE_HIGHWATERMARK_HOOK);
+        assertEqualsInAnyOrder(Arrays.asList(expected), actual);
+    }
+
+    @Test
+    public void testInsertDataInSnapshotScan() throws Exception {
+        customDatabase.createAndInitialize();
+        String tableId = schemaName + "." + tableName;
+        String[] insertDataSql =
+                new String[] {
+                    "INSERT INTO " + tableId + " VALUES(112, 'user_12','Shanghai','123567891234')",
+                    "INSERT INTO " + tableId + " VALUES(113, 'user_13','Shanghai','123567891234')",
+                };
+        String[] expected =
+                new String[] {
+                    "+I[101, user_1, Shanghai, 123567891234]",
+                    "+I[102, user_2, Shanghai, 123567891234]",
+                    "+I[103, user_3, Shanghai, 123567891234]",
+                    "+I[109, user_4, Shanghai, 123567891234]",
+                    "+I[110, user_5, Shanghai, 123567891234]",
+                    "+I[111, user_6, Shanghai, 123567891234]",
+                    "+I[112, user_12, Shanghai, 123567891234]",
+                    "+I[113, user_13, Shanghai, 123567891234]",
+                    "+I[118, user_7, Shanghai, 123567891234]",
+                    "+I[121, user_8, Shanghai, 123567891234]",
+                    "+I[123, user_9, Shanghai, 123567891234]",
+                };
+        List<String> actual =
+                getDataInSnapshotScan(
+                        insertDataSql, schemaName, tableName, USE_POST_LOWWATERMARK_HOOK);
+        assertEqualsInAnyOrder(Arrays.asList(expected), actual);
+    }
+
+    @Test
+    public void testDeleteDataInSnapshotScan() throws Exception {
+        customDatabase.createAndInitialize();
+        String tableId = schemaName + "." + tableName;
+        String[] deleteDataSql =
+                new String[] {
+                    "DELETE FROM " + tableId + " where id = 101",
+                    "DELETE FROM " + tableId + " where id = 102",
+                };
+        String[] expected =
+                new String[] {
+                    "+I[103, user_3, Shanghai, 123567891234]",
+                    "+I[109, user_4, Shanghai, 123567891234]",
+                    "+I[110, user_5, Shanghai, 123567891234]",
+                    "+I[111, user_6, Shanghai, 123567891234]",
+                    "+I[118, user_7, Shanghai, 123567891234]",
+                    "+I[121, user_8, Shanghai, 123567891234]",
+                    "+I[123, user_9, Shanghai, 123567891234]",
+                };
+        List<String> actual =
+                getDataInSnapshotScan(
+                        deleteDataSql, schemaName, tableName, USE_PRE_HIGHWATERMARK_HOOK);
+        assertEqualsInAnyOrder(Arrays.asList(expected), actual);
+    }
+
+    private List<String> getDataInSnapshotScan(
+            String[] changingDataSql, String schemaName, String tableName, int hookType)
+            throws Exception {
+        PostgresSourceConfigFactory sourceConfigFactory =
+                getMockPostgresSourceConfigFactory(customDatabase, schemaName, tableName, 10);
+        PostgresSourceConfig sourceConfig = sourceConfigFactory.create(0);
+        PostgresDialect postgresDialect = new PostgresDialect(sourceConfigFactory.create(0));
+        SnapshotPhaseHooks hooks = new SnapshotPhaseHooks();
+
+        try (PostgresConnection postgresConnection = postgresDialect.openJdbcConnection()) {
+            SnapshotPhaseHook snapshotPhaseHook =
+                    (postgresSourceConfig, split) -> {
+                        postgresConnection.execute(changingDataSql);
+                        postgresConnection.commit();
+                    };
+
+            if (hookType == USE_POST_LOWWATERMARK_HOOK) {
+                hooks.setPostLowWatermarkAction(snapshotPhaseHook);
+            } else if (hookType == USE_PRE_HIGHWATERMARK_HOOK) {
+                hooks.setPreHighWatermarkAction(snapshotPhaseHook);
+            }
+
+            final DataType dataType =
+                    DataTypes.ROW(
+                            DataTypes.FIELD("id", DataTypes.BIGINT()),
+                            DataTypes.FIELD("name", DataTypes.STRING()),
+                            DataTypes.FIELD("address", DataTypes.STRING()),
+                            DataTypes.FIELD("phone_number", DataTypes.STRING()));
+            List<SnapshotSplit> snapshotSplits = getSnapshotSplits(sourceConfig, postgresDialect);
+
+            PostgresSourceFetchTaskContext postgresSourceFetchTaskContext =
+                    new PostgresSourceFetchTaskContext(sourceConfig, postgresDialect);
+            List<String> actual =
+                    readTableSnapshotSplits(
+                            snapshotSplits, postgresSourceFetchTaskContext, 1, dataType, hooks);
+            return actual;
+        }
+    }
+
+    private List<String> readTableSnapshotSplits(
+            List<SnapshotSplit> snapshotSplits,
+            PostgresSourceFetchTaskContext taskContext,
+            int scanSplitsNum,
+            DataType dataType,
+            SnapshotPhaseHooks snapshotPhaseHooks)
+            throws Exception {
+        IncrementalSourceScanFetcher sourceScanFetcher =
+                new IncrementalSourceScanFetcher(taskContext, 0);
+
+        List<SourceRecord> result = new ArrayList<>();
+        for (int i = 0; i < scanSplitsNum; i++) {
+            SnapshotSplit sqlSplit = snapshotSplits.get(i);
+            if (sourceScanFetcher.isFinished()) {
+                FetchTask<SourceSplitBase> fetchTask =
+                        taskContext.getDataSourceDialect().createFetchTask(sqlSplit);
+                ((AbstractScanFetchTask) fetchTask).setSnapshotPhaseHooks(snapshotPhaseHooks);
+                sourceScanFetcher.submitTask(fetchTask);
+            }
+            Iterator<SourceRecords> res;
+            while ((res = sourceScanFetcher.pollSplitRecords()) != null) {
+                while (res.hasNext()) {
+                    SourceRecords sourceRecords = res.next();
+                    result.addAll(sourceRecords.getSourceRecordList());
+                }
+            }
+        }
+
+        sourceScanFetcher.close();
+
+        assertNotNull(sourceScanFetcher.getExecutorService());
+        assertTrue(sourceScanFetcher.getExecutorService().isTerminated());
+
+        return formatResult(result, dataType);
+    }
+
+    private List<String> formatResult(List<SourceRecord> records, DataType dataType) {
+        final RecordsFormatter formatter = new RecordsFormatter(dataType);
+        return formatter.format(records);
+    }
+
+    private List<SnapshotSplit> getSnapshotSplits(
+            PostgresSourceConfig sourceConfig, JdbcDataSourceDialect sourceDialect) {
+        List<TableId> discoverTables = sourceDialect.discoverDataCollections(sourceConfig);
+        final ChunkSplitter chunkSplitter = sourceDialect.createChunkSplitter(sourceConfig);
+
+        List<SnapshotSplit> snapshotSplitList = new ArrayList<>();
+        for (TableId table : discoverTables) {
+            Collection<SnapshotSplit> snapshotSplits = chunkSplitter.generateSplits(table);
+            snapshotSplitList.addAll(snapshotSplits);
+        }
+        return snapshotSplitList;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/table/PostgreSQLTableFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/table/PostgreSQLTableFactoryTest.java
@@ -50,6 +50,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED;
+import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP;
 import static com.ververica.cdc.connectors.postgres.source.config.PostgresSourceOptions.CHUNK_META_GROUP_SIZE;
 import static com.ververica.cdc.connectors.postgres.source.config.PostgresSourceOptions.CONNECTION_POOL_SIZE;
 import static com.ververica.cdc.connectors.postgres.source.config.PostgresSourceOptions.CONNECT_MAX_RETRIES;
@@ -146,7 +147,8 @@ public class PostgreSQLTableFactoryTest {
                         HEARTBEAT_INTERVAL.defaultValue(),
                         StartupOptions.initial(),
                         null,
-                        SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT);
+                        SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT,
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -157,6 +159,7 @@ public class PostgreSQLTableFactoryTest {
         options.put("decoding.plugin.name", "wal2json");
         options.put("debezium.snapshot.mode", "never");
         options.put("changelog-mode", "upsert");
+        options.put("scan.incremental.snapshot.backfill.skip", "true");
 
         DynamicTableSource actualSource = createTableSource(options);
         Properties dbzProperties = new Properties();
@@ -187,7 +190,8 @@ public class PostgreSQLTableFactoryTest {
                         HEARTBEAT_INTERVAL.defaultValue(),
                         StartupOptions.initial(),
                         null,
-                        SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT);
+                        SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT,
+                        true);
         assertEquals(expectedSource, actualSource);
     }
 
@@ -228,7 +232,8 @@ public class PostgreSQLTableFactoryTest {
                         HEARTBEAT_INTERVAL.defaultValue(),
                         StartupOptions.initial(),
                         null,
-                        SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT);
+                        SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT,
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         expectedSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
         expectedSource.metadataKeys =
                 Arrays.asList("op_ts", "database_name", "schema_name", "table_name");
@@ -279,7 +284,8 @@ public class PostgreSQLTableFactoryTest {
                         HEARTBEAT_INTERVAL.defaultValue(),
                         StartupOptions.initial(),
                         null,
-                        SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT);
+                        SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT,
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -320,7 +326,8 @@ public class PostgreSQLTableFactoryTest {
                         HEARTBEAT_INTERVAL.defaultValue(),
                         StartupOptions.latest(),
                         null,
-                        SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT);
+                        SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED_DEFAULT,
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/testutils/RecordsFormatter.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/testutils/RecordsFormatter.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.postgres.testutils;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.conversion.RowRowConverter;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Collector;
+
+import com.ververica.cdc.connectors.base.utils.SourceRecordUtils;
+import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import com.ververica.cdc.debezium.table.RowDataDebeziumDeserializeSchema;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Formatter that formats the {@link org.apache.kafka.connect.source.SourceRecord} to String. */
+public class RecordsFormatter {
+
+    private final DataType dataType;
+    private final ZoneId zoneId;
+
+    private TypeInformation<RowData> typeInfo;
+    private DebeziumDeserializationSchema<RowData> deserializationSchema;
+    private SimpleCollector collector;
+    private RowRowConverter rowRowConverter;
+
+    public RecordsFormatter(DataType dataType) {
+        this(dataType, ZoneId.of("UTC"));
+    }
+
+    public RecordsFormatter(DataType dataType, ZoneId zoneId) {
+        this.dataType = dataType;
+        this.zoneId = zoneId;
+        this.typeInfo =
+                (TypeInformation<RowData>) TypeConversions.fromDataTypeToLegacyInfo(dataType);
+        this.deserializationSchema =
+                RowDataDebeziumDeserializeSchema.newBuilder()
+                        .setPhysicalRowType((RowType) dataType.getLogicalType())
+                        .setResultTypeInfo(typeInfo)
+                        .build();
+        this.collector = new SimpleCollector();
+        this.rowRowConverter = RowRowConverter.create(dataType);
+        rowRowConverter.open(Thread.currentThread().getContextClassLoader());
+    }
+
+    public List<String> format(List<SourceRecord> records) {
+        records.stream()
+                // Keep DataChangeEvent only
+                .filter(SourceRecordUtils::isDataChangeRecord)
+                .forEach(
+                        r -> {
+                            try {
+                                deserializationSchema.deserialize(r, collector);
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+        return collector.list.stream()
+                .map(rowRowConverter::toExternal)
+                .map(Row::toString)
+                .collect(Collectors.toList());
+    }
+
+    private static class SimpleCollector implements Collector<RowData> {
+
+        private List<RowData> list = new ArrayList<>();
+
+        @Override
+        public void collect(RowData record) {
+            list.add(record);
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/testutils/TestTable.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/testutils/TestTable.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.postgres.testutils;
+
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.conversion.RowRowConverter;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+
+import com.ververica.cdc.connectors.postgres.table.PostgreSQLDeserializationConverterFactory;
+import com.ververica.cdc.debezium.table.RowDataDebeziumDeserializeSchema;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.util.List;
+
+/**
+ * Test utility for creating converter, formatter and deserializer of a table in the test database.
+ */
+public class TestTable {
+
+    private final String databaseName;
+    private final String tableName;
+
+    private final String schemaName;
+
+    private final ResolvedSchema schema;
+
+    // Lazily initialized components
+    private RowRowConverter rowRowConverter;
+    private RowDataDebeziumDeserializeSchema deserializer;
+    private RecordsFormatter recordsFormatter;
+
+    public TestTable(
+            UniqueDatabase database, String schemaName, String tableName, ResolvedSchema schema) {
+        this(database.getDatabaseName(), schemaName, tableName, schema);
+    }
+
+    public TestTable(
+            String databaseName, String schemaName, String tableName, ResolvedSchema schema) {
+        this.databaseName = databaseName;
+        this.schemaName = schemaName;
+        this.tableName = tableName;
+        this.schema = schema;
+    }
+
+    public String getTableId() {
+        return String.format("%s.%s", schemaName, tableName);
+    }
+
+    public RowType getRowType() {
+        return (RowType) schema.toPhysicalRowDataType().getLogicalType();
+    }
+
+    public RowDataDebeziumDeserializeSchema getDeserializer() {
+        if (deserializer == null) {
+            deserializer =
+                    RowDataDebeziumDeserializeSchema.newBuilder()
+                            .setPhysicalRowType(getRowType())
+                            .setResultTypeInfo(InternalTypeInfo.of(getRowType()))
+                            .setUserDefinedConverterFactory(
+                                    PostgreSQLDeserializationConverterFactory.instance())
+                            .build();
+        }
+        return deserializer;
+    }
+
+    public RowRowConverter getRowRowConverter() {
+        if (rowRowConverter == null) {
+            rowRowConverter = RowRowConverter.create(schema.toPhysicalRowDataType());
+        }
+        return rowRowConverter;
+    }
+
+    public RecordsFormatter getRecordsFormatter() {
+        if (recordsFormatter == null) {
+            recordsFormatter = new RecordsFormatter(schema.toPhysicalRowDataType());
+        }
+        return recordsFormatter;
+    }
+
+    public String stringify(RowData rowData) {
+        return getRowRowConverter().toExternal(rowData).toString();
+    }
+
+    public List<String> stringify(List<SourceRecord> sourceRecord) {
+        return getRecordsFormatter().format(sourceRecord);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/testutils/UniqueDatabase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/com/ververica/cdc/connectors/postgres/testutils/UniqueDatabase.java
@@ -154,16 +154,15 @@ public class UniqueDatabase {
         }
     }
 
-    /**
-     * Drop slot from database.
-     *
-     * @param slotName
-     */
-    public void removeSlot(String slotName) throws SQLException {
+    /** Drop slot from database. */
+    public boolean removeSlot(String slotName) {
         String sql = String.format("SELECT pg_drop_replication_slot('%s')", slotName);
         try (Connection connection = PostgresTestBase.getJdbcConnection(container, databaseName);
                 Statement statement = connection.createStatement()) {
             statement.execute(sql);
+            return true;
+        } catch (Exception exception) {
+            return false;
         }
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/SqlServerSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/SqlServerSourceBuilder.java
@@ -219,7 +219,7 @@ public class SqlServerSourceBuilder<T> {
      */
     public SqlServerIncrementalSource<T> build() {
         this.offsetFactory = new LsnFactory();
-        this.dialect = new SqlServerDialect(configFactory);
+        this.dialect = new SqlServerDialect(configFactory.create(0));
         return new SqlServerIncrementalSource<T>(
                 configFactory, checkNotNull(deserializer), offsetFactory, dialect);
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/SqlServerSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/SqlServerSourceBuilder.java
@@ -213,6 +213,22 @@ public class SqlServerSourceBuilder<T> {
     }
 
     /**
+     * Whether to skip backfill in snapshot reading phase.
+     *
+     * <p>If backfill is skipped, changes on captured tables during snapshot phase will be consumed
+     * later in binlog reading phase instead of being merged into the snapshot.
+     *
+     * <p>WARNING: Skipping backfill might lead to data inconsistency because some binlog events
+     * happened within the snapshot phase might be replayed (only at-least-once semantic is
+     * promised). For example updating an already updated value in snapshot, or deleting an already
+     * deleted entry in snapshot. These replayed binlog events should be handled specially.
+     */
+    public SqlServerSourceBuilder<T> skipSnapshotBackfill(boolean skipSnapshotBackfill) {
+        this.configFactory.skipSnapshotBackfill(skipSnapshotBackfill);
+        return this;
+    }
+
+    /**
      * Build the {@link SqlServerIncrementalSource}.
      *
      * @return a SqlSeverParallelSource with the settings made for this builder.

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfig.java
@@ -77,7 +77,8 @@ public class SqlServerSourceConfig extends JdbcSourceConfig {
                 connectTimeout,
                 connectMaxRetries,
                 connectionPoolSize,
-                chunkKeyColumn);
+                chunkKeyColumn,
+                true);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfig.java
@@ -53,7 +53,8 @@ public class SqlServerSourceConfig extends JdbcSourceConfig {
             Duration connectTimeout,
             int connectMaxRetries,
             int connectionPoolSize,
-            String chunkKeyColumn) {
+            String chunkKeyColumn,
+            boolean skipSnapshotBackfill) {
         super(
                 startupOptions,
                 databaseList,
@@ -78,7 +79,7 @@ public class SqlServerSourceConfig extends JdbcSourceConfig {
                 connectMaxRetries,
                 connectionPoolSize,
                 chunkKeyColumn,
-                true);
+                skipSnapshotBackfill);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfigFactory.java
@@ -100,6 +100,7 @@ public class SqlServerSourceConfigFactory extends JdbcSourceConfigFactory {
                 connectTimeout,
                 connectMaxRetries,
                 connectionPoolSize,
-                chunkKeyColumn);
+                chunkKeyColumn,
+                skipSnapshotBackfill);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/dialect/SqlServerDialect.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/dialect/SqlServerDialect.java
@@ -27,7 +27,6 @@ import com.ververica.cdc.connectors.base.source.meta.offset.Offset;
 import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitBase;
 import com.ververica.cdc.connectors.base.source.reader.external.FetchTask;
 import com.ververica.cdc.connectors.sqlserver.source.config.SqlServerSourceConfig;
-import com.ververica.cdc.connectors.sqlserver.source.config.SqlServerSourceConfigFactory;
 import com.ververica.cdc.connectors.sqlserver.source.reader.fetch.SqlServerScanFetchTask;
 import com.ververica.cdc.connectors.sqlserver.source.reader.fetch.SqlServerSourceFetchTaskContext;
 import com.ververica.cdc.connectors.sqlserver.source.reader.fetch.SqlServerStreamFetchTask;
@@ -53,8 +52,8 @@ public class SqlServerDialect implements JdbcDataSourceDialect {
     private final SqlServerSourceConfig sourceConfig;
     private transient SqlServerSchema sqlserverSchema;
 
-    public SqlServerDialect(SqlServerSourceConfigFactory configFactory) {
-        this.sourceConfig = configFactory.create(0);
+    public SqlServerDialect(SqlServerSourceConfig sourceConfig) {
+        this.sourceConfig = sourceConfig;
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/table/SqlServerTableFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/table/SqlServerTableFactory.java
@@ -40,6 +40,7 @@ import static com.ververica.cdc.connectors.base.options.JdbcSourceOptions.CONNEC
 import static com.ververica.cdc.connectors.base.options.JdbcSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN;
 import static com.ververica.cdc.connectors.base.options.SourceOptions.CHUNK_META_GROUP_SIZE;
 import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED;
+import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP;
 import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE;
 import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED;
 import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_SNAPSHOT_FETCH_SIZE;
@@ -137,6 +138,7 @@ public class SqlServerTableFactory implements DynamicTableSourceFactory {
         String chunkKeyColumn =
                 config.getOptional(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN).orElse(null);
         boolean closeIdleReaders = config.get(SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED);
+        boolean skipSnapshotBackfill = config.get(SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
 
         if (enableParallelRead) {
             validateIntegerOption(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE, splitSize, 1);
@@ -171,7 +173,8 @@ public class SqlServerTableFactory implements DynamicTableSourceFactory {
                 distributionFactorUpper,
                 distributionFactorLower,
                 chunkKeyColumn,
-                closeIdleReaders);
+                closeIdleReaders,
+                skipSnapshotBackfill);
     }
 
     @Override
@@ -207,6 +210,7 @@ public class SqlServerTableFactory implements DynamicTableSourceFactory {
         options.add(SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND);
         options.add(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN);
         options.add(SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED);
+        options.add(SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
         return options;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/table/SqlServerTableSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/table/SqlServerTableSource.java
@@ -78,6 +78,7 @@ public class SqlServerTableSource implements ScanTableSource, SupportsReadingMet
     private final double distributionFactorLower;
     private final String chunkKeyColumn;
     private final boolean closeIdleReaders;
+    private final boolean skipSnapshotBackfill;
 
     // --------------------------------------------------------------------------------------------
     // Mutable attributes
@@ -110,7 +111,8 @@ public class SqlServerTableSource implements ScanTableSource, SupportsReadingMet
             double distributionFactorUpper,
             double distributionFactorLower,
             @Nullable String chunkKeyColumn,
-            boolean closeIdleReaders) {
+            boolean closeIdleReaders,
+            boolean skipSnapshotBackfill) {
         this.physicalSchema = physicalSchema;
         this.port = port;
         this.hostname = checkNotNull(hostname);
@@ -134,6 +136,7 @@ public class SqlServerTableSource implements ScanTableSource, SupportsReadingMet
         this.distributionFactorLower = distributionFactorLower;
         this.chunkKeyColumn = chunkKeyColumn;
         this.closeIdleReaders = closeIdleReaders;
+        this.skipSnapshotBackfill = skipSnapshotBackfill;
     }
 
     @Override
@@ -181,6 +184,7 @@ public class SqlServerTableSource implements ScanTableSource, SupportsReadingMet
                             .distributionFactorLower(distributionFactorLower)
                             .chunkKeyColumn(chunkKeyColumn)
                             .closeIdleReaders(closeIdleReaders)
+                            .skipSnapshotBackfill(skipSnapshotBackfill)
                             .build();
             return SourceProvider.of(sqlServerChangeEventSource);
         } else {
@@ -240,7 +244,8 @@ public class SqlServerTableSource implements ScanTableSource, SupportsReadingMet
                         distributionFactorUpper,
                         distributionFactorLower,
                         chunkKeyColumn,
-                        closeIdleReaders);
+                        closeIdleReaders,
+                        skipSnapshotBackfill);
         source.metadataKeys = metadataKeys;
         source.producedDataType = producedDataType;
         return source;
@@ -277,7 +282,8 @@ public class SqlServerTableSource implements ScanTableSource, SupportsReadingMet
                 && Objects.equals(distributionFactorUpper, that.distributionFactorUpper)
                 && Objects.equals(distributionFactorLower, that.distributionFactorLower)
                 && Objects.equals(chunkKeyColumn, that.chunkKeyColumn)
-                && Objects.equals(closeIdleReaders, that.closeIdleReaders);
+                && Objects.equals(closeIdleReaders, that.closeIdleReaders)
+                && Objects.equals(skipSnapshotBackfill, that.skipSnapshotBackfill);
     }
 
     @Override
@@ -305,7 +311,8 @@ public class SqlServerTableSource implements ScanTableSource, SupportsReadingMet
                 distributionFactorUpper,
                 distributionFactorLower,
                 chunkKeyColumn,
-                closeIdleReaders);
+                closeIdleReaders,
+                skipSnapshotBackfill);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/source/SqlServerSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/source/SqlServerSourceITCase.java
@@ -17,13 +17,24 @@
 package com.ververica.cdc.connectors.sqlserver.source;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
+import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
+import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHook;
+import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHooks;
+import com.ververica.cdc.connectors.sqlserver.source.config.SqlServerSourceConfig;
+import com.ververica.cdc.connectors.sqlserver.source.dialect.SqlServerDialect;
+import com.ververica.cdc.connectors.sqlserver.testutils.TestTable;
+import io.debezium.jdbc.JdbcConnection;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,10 +44,16 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static org.apache.flink.table.api.DataTypes.BIGINT;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.catalog.Column.physical;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.testcontainers.containers.MSSQLServerContainer.MS_SQL_SERVER_PORT;
 
@@ -46,6 +63,9 @@ public class SqlServerSourceITCase extends SqlServerSourceTestBase {
     private static final Logger LOG = LoggerFactory.getLogger(SqlServerSourceITCase.class);
 
     @Rule public final Timeout timeoutPerTest = Timeout.seconds(300);
+
+    private static final int USE_POST_LOWWATERMARK_HOOK = 1;
+    private static final int USE_PRE_HIGHWATERMARK_HOOK = 2;
 
     @Test
     public void testReadSingleTableWithSingleParallelism() throws Exception {
@@ -90,6 +110,234 @@ public class SqlServerSourceITCase extends SqlServerSourceTestBase {
                 1, FailoverType.JM, FailoverPhase.SNAPSHOT, new String[] {"dbo.customers"});
     }
 
+    @Test
+    public void testReadSingleTableWithSingleParallelismAndSkipBackfill() throws Exception {
+        testSqlServerParallelSource(
+                DEFAULT_PARALLELISM,
+                FailoverType.TM,
+                FailoverPhase.SNAPSHOT,
+                new String[] {"dbo.customers"},
+                true);
+    }
+
+    @Test
+    public void testEnableBackfillWithDMLPreHighWaterMark() throws Exception {
+
+        List<String> records = testBackfillWhenWritingEvents(false, 21, USE_PRE_HIGHWATERMARK_HOOK);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Pittsburgh, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]");
+        // when enable backfill, the wal log between [snapshot, high_watermark) will be
+        // applied as snapshot image
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    @Test
+    public void testEnableBackfillWithDMLPostLowWaterMark() throws Exception {
+
+        List<String> records = testBackfillWhenWritingEvents(false, 21, USE_POST_LOWWATERMARK_HOOK);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Pittsburgh, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]");
+        // when enable backfill, the wal log between [low_watermark, snapshot) will be applied
+        // as snapshot image
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    @Test
+    public void testSkipBackfillWithDMLPreHighWaterMark() throws Exception {
+
+        List<String> records = testBackfillWhenWritingEvents(true, 25, USE_PRE_HIGHWATERMARK_HOOK);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[1019, user_20, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Shanghai, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]",
+                        "-U[2000, user_21, Shanghai, 123567891234]",
+                        "+U[2000, user_21, Pittsburgh, 123567891234]",
+                        "-D[1019, user_20, Shanghai, 123567891234]");
+        // when skip backfill, the wal log between (snapshot, high_watermark) will be seen as
+        // stream event.
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    @Test
+    public void testSkipBackfillWithDMLPostLowWaterMark() throws Exception {
+
+        List<String> records = testBackfillWhenWritingEvents(true, 25, USE_POST_LOWWATERMARK_HOOK);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Pittsburgh, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]",
+                        "-U[2000, user_21, Shanghai, 123567891234]",
+                        "+U[2000, user_21, Pittsburgh, 123567891234]",
+                        "-D[1019, user_20, Shanghai, 123567891234]");
+        // when skip backfill, the wal log between (snapshot, high_watermark) will still be
+        // seen as stream event. This will occur data duplicate. For example, user_20 will be
+        // deleted twice, and user_15213 will be inserted twice.
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    private List<String> testBackfillWhenWritingEvents(
+            boolean skipSnapshotBackfill, int fetchSize, int hookType) throws Exception {
+
+        String databaseName = "customer";
+
+        initializeSqlServerTable(databaseName);
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(1000);
+        env.setParallelism(1);
+
+        ResolvedSchema customersSchame =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                physical("id", BIGINT().notNull()),
+                                physical("name", STRING()),
+                                physical("address", STRING()),
+                                physical("phone_number", STRING())),
+                        new ArrayList<>(),
+                        UniqueConstraint.primaryKey("pk", Collections.singletonList("id")));
+        TestTable customerTable = new TestTable(databaseName, "dbo", "customers", customersSchame);
+        String tableId = customerTable.getTableId();
+
+        SqlServerSourceBuilder.SqlServerIncrementalSource source =
+                SqlServerSourceBuilder.SqlServerIncrementalSource.<RowData>builder()
+                        .hostname(MSSQL_SERVER_CONTAINER.getHost())
+                        .port(MSSQL_SERVER_CONTAINER.getMappedPort(MS_SQL_SERVER_PORT))
+                        .username(MSSQL_SERVER_CONTAINER.getUsername())
+                        .password(MSSQL_SERVER_CONTAINER.getPassword())
+                        .databaseList(databaseName)
+                        .tableList(getTableNameRegex(new String[] {"dbo.customers"}))
+                        .deserializer(customerTable.getDeserializer())
+                        .skipSnapshotBackfill(skipSnapshotBackfill)
+                        .build();
+
+        // Do some database operations during hook in snapshot period.
+        SnapshotPhaseHooks hooks = new SnapshotPhaseHooks();
+        String[] statements =
+                new String[] {
+                    String.format(
+                            "INSERT INTO %s VALUES (15213, 'user_15213', 'Shanghai', '123567891234')",
+                            tableId),
+                    String.format("UPDATE %s SET address='Pittsburgh' WHERE id=2000", tableId),
+                    String.format("DELETE FROM %s WHERE id=1019", tableId)
+                };
+        SnapshotPhaseHook snapshotPhaseHook =
+                (sourceConfig, split) -> {
+                    SqlServerDialect dialect =
+                            new SqlServerDialect((SqlServerSourceConfig) sourceConfig);
+                    JdbcConnection postgresConnection =
+                            dialect.openJdbcConnection((JdbcSourceConfig) sourceConfig);
+                    postgresConnection.execute(statements);
+                    postgresConnection.commit();
+                    try {
+                        Thread.sleep(1000L);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                };
+
+        if (hookType == USE_POST_LOWWATERMARK_HOOK) {
+            hooks.setPostLowWatermarkAction(snapshotPhaseHook);
+        } else if (hookType == USE_PRE_HIGHWATERMARK_HOOK) {
+            hooks.setPreHighWatermarkAction(snapshotPhaseHook);
+        }
+        source.setSnapshotHooks(hooks);
+
+        List<String> records = new ArrayList<>();
+        try (CloseableIterator<RowData> iterator =
+                env.fromSource(source, WatermarkStrategy.noWatermarks(), "Backfill Skipped Source")
+                        .executeAndCollect()) {
+            records = fetchRowData(iterator, fetchSize, customerTable::stringify);
+            env.close();
+        }
+        return records;
+    }
+
     private void testSqlServerParallelSource(
             FailoverType failoverType, FailoverPhase failoverPhase, String[] captureCustomerTables)
             throws Exception {
@@ -102,6 +350,17 @@ public class SqlServerSourceITCase extends SqlServerSourceTestBase {
             FailoverType failoverType,
             FailoverPhase failoverPhase,
             String[] captureCustomerTables)
+            throws Exception {
+        testSqlServerParallelSource(
+                parallelism, failoverType, failoverPhase, captureCustomerTables, false);
+    }
+
+    private void testSqlServerParallelSource(
+            int parallelism,
+            FailoverType failoverType,
+            FailoverPhase failoverPhase,
+            String[] captureCustomerTables,
+            boolean skipSnapshotBackfill)
             throws Exception {
 
         String databaseName = "customer";
@@ -131,14 +390,16 @@ public class SqlServerSourceITCase extends SqlServerSourceTestBase {
                                 + " 'database-name' = '%s',"
                                 + " 'table-name' = '%s',"
                                 + " 'scan.incremental.snapshot.enabled' = 'true',"
-                                + " 'scan.incremental.snapshot.chunk.size' = '4'"
+                                + " 'scan.incremental.snapshot.chunk.size' = '4',"
+                                + " 'scan.incremental.snapshot.backfill.skip' = '%s'"
                                 + ")",
                         MSSQL_SERVER_CONTAINER.getHost(),
                         MSSQL_SERVER_CONTAINER.getMappedPort(MS_SQL_SERVER_PORT),
                         MSSQL_SERVER_CONTAINER.getUsername(),
                         MSSQL_SERVER_CONTAINER.getPassword(),
                         databaseName,
-                        getTableNameRegex(captureCustomerTables));
+                        getTableNameRegex(captureCustomerTables),
+                        skipSnapshotBackfill);
 
         // first step: check the snapshot data
         String[] snapshotForSingleTable =
@@ -237,6 +498,17 @@ public class SqlServerSourceITCase extends SqlServerSourceTestBase {
             Thread.sleep(millis);
         } catch (InterruptedException ignored) {
         }
+    }
+
+    public static List<String> fetchRowData(
+            Iterator<RowData> iter, int size, Function<RowData, String> stringifier) {
+        List<RowData> rows = new ArrayList<>(size);
+        while (size > 0 && iter.hasNext()) {
+            RowData row = iter.next();
+            rows.add(row);
+            size--;
+        }
+        return rows.stream().map(stringifier).collect(Collectors.toList());
     }
 
     private static List<String> fetchRows(Iterator<Row> iter, int size) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/source/read/fetch/SqlServerScanFetchTaskTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/source/read/fetch/SqlServerScanFetchTaskTest.java
@@ -183,7 +183,7 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
 
         SqlServerSourceConfigFactory sourceConfigFactory =
                 getConfigFactory(databaseName, new String[] {tableName}, 10);
-        SqlServerSourceConfig sourceConfig = sourceConfigFactory.create(0);
+        SqlServerSourceConfig sqlServerSourceConfigs = sourceConfigFactory.create(0);
         SqlServerDialect sqlServerDialect = new SqlServerDialect(sourceConfigFactory.create(0));
 
         String tableId = databaseName + "." + tableName;
@@ -195,13 +195,13 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
 
         SnapshotPhaseHooks hooks = new SnapshotPhaseHooks();
         hooks.setPostLowWatermarkAction(
-                (dialect, split) -> executeSql(sourceConfig, deleteDataSql));
+                (sourceConfig, split) -> executeSql(sqlServerSourceConfigs, deleteDataSql));
         SqlServerSourceFetchTaskContext sqlServerSourceFetchTaskContext =
                 new SqlServerSourceFetchTaskContext(
-                        sourceConfig,
+                        sqlServerSourceConfigs,
                         sqlServerDialect,
-                        createSqlServerConnection(sourceConfig.getDbzConnectorConfig()),
-                        createSqlServerConnection(sourceConfig.getDbzConnectorConfig()));
+                        createSqlServerConnection(sqlServerSourceConfigs.getDbzConnectorConfig()),
+                        createSqlServerConnection(sqlServerSourceConfigs.getDbzConnectorConfig()));
 
         final DataType dataType =
                 DataTypes.ROW(
@@ -209,7 +209,8 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
                         DataTypes.FIELD("name", DataTypes.STRING()),
                         DataTypes.FIELD("address", DataTypes.STRING()),
                         DataTypes.FIELD("phone_number", DataTypes.STRING()));
-        List<SnapshotSplit> snapshotSplits = getSnapshotSplits(sourceConfig, sqlServerDialect);
+        List<SnapshotSplit> snapshotSplits =
+                getSnapshotSplits(sqlServerSourceConfigs, sqlServerDialect);
 
         String[] expected =
                 new String[] {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/source/read/fetch/SqlServerScanFetchTaskTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/source/read/fetch/SqlServerScanFetchTaskTest.java
@@ -19,12 +19,15 @@ package com.ververica.cdc.connectors.sqlserver.source.read.fetch;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.DataType;
 
-import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
 import com.ververica.cdc.connectors.base.dialect.JdbcDataSourceDialect;
 import com.ververica.cdc.connectors.base.source.assigner.splitter.ChunkSplitter;
 import com.ververica.cdc.connectors.base.source.meta.split.SnapshotSplit;
 import com.ververica.cdc.connectors.base.source.meta.split.SourceRecords;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import com.ververica.cdc.connectors.base.source.reader.external.AbstractScanFetchTask;
+import com.ververica.cdc.connectors.base.source.reader.external.FetchTask;
 import com.ververica.cdc.connectors.base.source.reader.external.IncrementalSourceScanFetcher;
+import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHooks;
 import com.ververica.cdc.connectors.sqlserver.source.SqlServerSourceTestBase;
 import com.ververica.cdc.connectors.sqlserver.source.config.SqlServerSourceConfig;
 import com.ververica.cdc.connectors.sqlserver.source.config.SqlServerSourceConfigFactory;
@@ -32,16 +35,8 @@ import com.ververica.cdc.connectors.sqlserver.source.dialect.SqlServerDialect;
 import com.ververica.cdc.connectors.sqlserver.source.reader.fetch.SqlServerScanFetchTask;
 import com.ververica.cdc.connectors.sqlserver.source.reader.fetch.SqlServerSourceFetchTaskContext;
 import com.ververica.cdc.connectors.sqlserver.testutils.RecordsFormatter;
-import io.debezium.connector.sqlserver.SqlServerConnection;
-import io.debezium.connector.sqlserver.SqlServerPartition;
-import io.debezium.data.Envelope;
 import io.debezium.jdbc.JdbcConnection;
-import io.debezium.pipeline.EventDispatcher;
-import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.TableId;
-import io.debezium.schema.DataCollectionSchema;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Test;
 
@@ -51,7 +46,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.ververica.cdc.connectors.sqlserver.source.utils.SqlServerConnectionUtils.createSqlServerConnection;
@@ -72,7 +66,7 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
         SqlServerSourceConfigFactory sourceConfigFactory =
                 getConfigFactory(databaseName, new String[] {tableName}, 10);
         SqlServerSourceConfig sourceConfig = sourceConfigFactory.create(0);
-        SqlServerDialect sqlServerDialect = new SqlServerDialect(sourceConfigFactory);
+        SqlServerDialect sqlServerDialect = new SqlServerDialect(sourceConfigFactory.create(0));
 
         String tableId = databaseName + "." + tableName;
         String[] changingDataSql =
@@ -85,13 +79,15 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
                     "UPDATE " + tableId + " SET address = 'Hangzhou' where id = 111",
                 };
 
-        MakeChangeEventTaskContext makeChangeEventTaskContext =
-                new MakeChangeEventTaskContext(
+        SnapshotPhaseHooks hooks = new SnapshotPhaseHooks();
+        hooks.setPostHighWatermarkAction(
+                (dialect, split) -> executeSql(sourceConfig, changingDataSql));
+        SqlServerSourceFetchTaskContext sqlServerSourceFetchTaskContext =
+                new SqlServerSourceFetchTaskContext(
                         sourceConfig,
                         sqlServerDialect,
                         createSqlServerConnection(sourceConfig.getDbzConnectorConfig()),
-                        createSqlServerConnection(sourceConfig.getDbzConnectorConfig()),
-                        () -> executeSql(sourceConfig, changingDataSql));
+                        createSqlServerConnection(sourceConfig.getDbzConnectorConfig()));
 
         final DataType dataType =
                 DataTypes.ROW(
@@ -115,7 +111,8 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
                 };
 
         List<String> actual =
-                readTableSnapshotSplits(snapshotSplits, makeChangeEventTaskContext, 1, dataType);
+                readTableSnapshotSplits(
+                        snapshotSplits, sqlServerSourceFetchTaskContext, 1, dataType);
         assertEqualsInAnyOrder(Arrays.asList(expected), actual);
     }
 
@@ -129,7 +126,7 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
         SqlServerSourceConfigFactory sourceConfigFactory =
                 getConfigFactory(databaseName, new String[] {tableName}, 10);
         SqlServerSourceConfig sourceConfig = sourceConfigFactory.create(0);
-        SqlServerDialect sqlServerDialect = new SqlServerDialect(sourceConfigFactory);
+        SqlServerDialect sqlServerDialect = new SqlServerDialect(sourceConfigFactory.create(0));
 
         String tableId = databaseName + "." + tableName;
         String[] insertDataSql =
@@ -138,13 +135,15 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
                     "INSERT INTO " + tableId + " VALUES(113, 'user_13','Shanghai','123567891234')",
                 };
 
-        MakeChangeEventTaskContext makeChangeEventTaskContext =
-                new MakeChangeEventTaskContext(
+        SnapshotPhaseHooks hooks = new SnapshotPhaseHooks();
+        hooks.setPostHighWatermarkAction(
+                (dialect, split) -> executeSql(sourceConfig, insertDataSql));
+        SqlServerSourceFetchTaskContext sqlServerSourceFetchTaskContext =
+                new SqlServerSourceFetchTaskContext(
                         sourceConfig,
                         sqlServerDialect,
                         createSqlServerConnection(sourceConfig.getDbzConnectorConfig()),
-                        createSqlServerConnection(sourceConfig.getDbzConnectorConfig()),
-                        () -> executeSql(sourceConfig, insertDataSql));
+                        createSqlServerConnection(sourceConfig.getDbzConnectorConfig()));
 
         final DataType dataType =
                 DataTypes.ROW(
@@ -170,7 +169,8 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
                 };
 
         List<String> actual =
-                readTableSnapshotSplits(snapshotSplits, makeChangeEventTaskContext, 1, dataType);
+                readTableSnapshotSplits(
+                        snapshotSplits, sqlServerSourceFetchTaskContext, 1, dataType);
         assertEqualsInAnyOrder(Arrays.asList(expected), actual);
     }
 
@@ -184,7 +184,7 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
         SqlServerSourceConfigFactory sourceConfigFactory =
                 getConfigFactory(databaseName, new String[] {tableName}, 10);
         SqlServerSourceConfig sourceConfig = sourceConfigFactory.create(0);
-        SqlServerDialect sqlServerDialect = new SqlServerDialect(sourceConfigFactory);
+        SqlServerDialect sqlServerDialect = new SqlServerDialect(sourceConfigFactory.create(0));
 
         String tableId = databaseName + "." + tableName;
         String[] deleteDataSql =
@@ -193,13 +193,15 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
                     "DELETE FROM " + tableId + " where id = 102",
                 };
 
-        MakeChangeEventTaskContext makeChangeEventTaskContext =
-                new MakeChangeEventTaskContext(
+        SnapshotPhaseHooks hooks = new SnapshotPhaseHooks();
+        hooks.setPostLowWatermarkAction(
+                (dialect, split) -> executeSql(sourceConfig, deleteDataSql));
+        SqlServerSourceFetchTaskContext sqlServerSourceFetchTaskContext =
+                new SqlServerSourceFetchTaskContext(
                         sourceConfig,
                         sqlServerDialect,
                         createSqlServerConnection(sourceConfig.getDbzConnectorConfig()),
-                        createSqlServerConnection(sourceConfig.getDbzConnectorConfig()),
-                        () -> executeSql(sourceConfig, deleteDataSql));
+                        createSqlServerConnection(sourceConfig.getDbzConnectorConfig()));
 
         final DataType dataType =
                 DataTypes.ROW(
@@ -221,7 +223,8 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
                 };
 
         List<String> actual =
-                readTableSnapshotSplits(snapshotSplits, makeChangeEventTaskContext, 1, dataType);
+                readTableSnapshotSplits(
+                        snapshotSplits, sqlServerSourceFetchTaskContext, 1, dataType, hooks);
         assertEqualsInAnyOrder(Arrays.asList(expected), actual);
     }
 
@@ -231,6 +234,17 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
             int scanSplitsNum,
             DataType dataType)
             throws Exception {
+        return readTableSnapshotSplits(
+                snapshotSplits, taskContext, scanSplitsNum, dataType, SnapshotPhaseHooks.empty());
+    }
+
+    private List<String> readTableSnapshotSplits(
+            List<SnapshotSplit> snapshotSplits,
+            SqlServerSourceFetchTaskContext taskContext,
+            int scanSplitsNum,
+            DataType dataType,
+            SnapshotPhaseHooks snapshotPhaseHooks)
+            throws Exception {
         IncrementalSourceScanFetcher sourceScanFetcher =
                 new IncrementalSourceScanFetcher(taskContext, 0);
 
@@ -238,8 +252,10 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
         for (int i = 0; i < scanSplitsNum; i++) {
             SnapshotSplit sqlSplit = snapshotSplits.get(i);
             if (sourceScanFetcher.isFinished()) {
-                sourceScanFetcher.submitTask(
-                        taskContext.getDataSourceDialect().createFetchTask(sqlSplit));
+                FetchTask<SourceSplitBase> fetchTask =
+                        taskContext.getDataSourceDialect().createFetchTask(sqlSplit);
+                ((AbstractScanFetchTask) fetchTask).setSnapshotPhaseHooks(snapshotPhaseHooks);
+                sourceScanFetcher.submitTask(fetchTask);
             }
             Iterator<SourceRecords> res;
             while ((res = sourceScanFetcher.pollSplitRecords()) != null) {
@@ -304,50 +320,5 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
             return false;
         }
         return true;
-    }
-
-    static class MakeChangeEventTaskContext extends SqlServerSourceFetchTaskContext {
-
-        private final Supplier<Boolean> makeChangeEventFunction;
-
-        public MakeChangeEventTaskContext(
-                JdbcSourceConfig jdbcSourceConfig,
-                SqlServerDialect sqlServerDialect,
-                SqlServerConnection connection,
-                SqlServerConnection metaDataConnection,
-                Supplier<Boolean> makeChangeEventFunction) {
-            super(jdbcSourceConfig, sqlServerDialect, connection, metaDataConnection);
-            this.makeChangeEventFunction = makeChangeEventFunction;
-        }
-
-        @Override
-        public EventDispatcher.SnapshotReceiver<SqlServerPartition> getSnapshotReceiver() {
-            EventDispatcher.SnapshotReceiver<SqlServerPartition> snapshotReceiver =
-                    super.getSnapshotReceiver();
-            return new EventDispatcher.SnapshotReceiver<SqlServerPartition>() {
-
-                @Override
-                public void changeRecord(
-                        SqlServerPartition partition,
-                        DataCollectionSchema schema,
-                        Envelope.Operation operation,
-                        Object key,
-                        Struct value,
-                        OffsetContext offset,
-                        ConnectHeaders headers)
-                        throws InterruptedException {
-                    snapshotReceiver.changeRecord(
-                            partition, schema, operation, key, value, offset, headers);
-                }
-
-                @Override
-                public void completeSnapshot() throws InterruptedException {
-                    snapshotReceiver.completeSnapshot();
-                    // make change events
-                    makeChangeEventFunction.get();
-                    Thread.sleep(10 * 1000);
-                }
-            };
-        }
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/table/SqlServerTableFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/table/SqlServerTableFactoryTest.java
@@ -110,7 +110,8 @@ public class SqlServerTableFactoryTest {
                         JdbcSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND
                                 .defaultValue(),
                         null,
-                        false);
+                        false,
+                        JdbcSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -126,6 +127,7 @@ public class SqlServerTableFactoryTest {
         properties.put("connect.timeout", "45s");
         properties.put("scan.incremental.snapshot.chunk.key-column", "testCol");
         properties.put("scan.incremental.close-idle-reader.enabled", "true");
+        properties.put("scan.incremental.snapshot.backfill.skip", "true");
 
         // validation for source
         DynamicTableSource actualSource = createTableSource(SCHEMA, properties);
@@ -151,6 +153,7 @@ public class SqlServerTableFactoryTest {
                         40.5d,
                         0.01d,
                         "testCol",
+                        true,
                         true);
         assertEquals(expectedSource, actualSource);
     }
@@ -191,7 +194,8 @@ public class SqlServerTableFactoryTest {
                         JdbcSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND
                                 .defaultValue(),
                         "testCol",
-                        true);
+                        true,
+                        JdbcSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -230,7 +234,8 @@ public class SqlServerTableFactoryTest {
                         JdbcSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND
                                 .defaultValue(),
                         null,
-                        false);
+                        false,
+                        JdbcSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         expectedSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
         expectedSource.metadataKeys =
                 Arrays.asList("op_ts", "database_name", "schema_name", "table_name");

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/testutils/TestTable.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/testutils/TestTable.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.sqlserver.testutils;
+
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.conversion.RowRowConverter;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+
+import com.ververica.cdc.connectors.sqlserver.table.SqlServerDeserializationConverterFactory;
+import com.ververica.cdc.debezium.table.RowDataDebeziumDeserializeSchema;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.util.List;
+
+/**
+ * Test utility for creating converter, formatter and deserializer of a table in the test database.
+ */
+public class TestTable {
+
+    private final String databaseName;
+    private final String tableName;
+
+    private final String schemaName;
+
+    private final ResolvedSchema schema;
+
+    // Lazily initialized components
+    private RowRowConverter rowRowConverter;
+    private RowDataDebeziumDeserializeSchema deserializer;
+    private RecordsFormatter recordsFormatter;
+
+    public TestTable(
+            String databaseName, String schemaName, String tableName, ResolvedSchema schema) {
+        this.databaseName = databaseName;
+        this.schemaName = schemaName;
+        this.tableName = tableName;
+        this.schema = schema;
+    }
+
+    public String getTableId() {
+        return String.format("%s.%s.%s", databaseName, schemaName, tableName);
+    }
+
+    public RowType getRowType() {
+        return (RowType) schema.toPhysicalRowDataType().getLogicalType();
+    }
+
+    public RowDataDebeziumDeserializeSchema getDeserializer() {
+        if (deserializer == null) {
+            deserializer =
+                    RowDataDebeziumDeserializeSchema.newBuilder()
+                            .setPhysicalRowType(getRowType())
+                            .setResultTypeInfo(InternalTypeInfo.of(getRowType()))
+                            .setUserDefinedConverterFactory(
+                                    SqlServerDeserializationConverterFactory.instance())
+                            .build();
+        }
+        return deserializer;
+    }
+
+    public RowRowConverter getRowRowConverter() {
+        if (rowRowConverter == null) {
+            rowRowConverter = RowRowConverter.create(schema.toPhysicalRowDataType());
+        }
+        return rowRowConverter;
+    }
+
+    public RecordsFormatter getRecordsFormatter() {
+        if (recordsFormatter == null) {
+            recordsFormatter = new RecordsFormatter(schema.toPhysicalRowDataType());
+        }
+        return recordsFormatter;
+    }
+
+    public String stringify(RowData rowData) {
+        return getRowRowConverter().toExternal(rowData).toString();
+    }
+
+    public List<String> stringify(List<SourceRecord> sourceRecord) {
+        return getRecordsFormatter().format(sourceRecord);
+    }
+}


### PR DESCRIPTION
As shown in https://github.com/ververica/flink-cdc-connectors/issues/2553, this PR do two things:
* Support ability to skip backfill in CDC frame, and expose the ability to mysql & postgres & mongodb & sqlserver. ( oracle depends on bug fix of https://github.com/ververica/flink-cdc-connectors/pull/2707, thus another pr later)
* Add hooks to test more situations when do DML operations during snapshot phase, including exactly-once and backfill-skipped.