### PR TITLE
[mysql-cdc] Fix table metadata field type 0 when parsing binlog event

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventDataDeserializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventDataDeserializer.java
@@ -77,6 +77,7 @@ public class TableMapEventDataDeserializer implements EventDataDeserializer<Tabl
                 case NEWDECIMAL:
                 case FLOAT:
                 case DOUBLE:
+                case YEAR:
                     count++;
                     break;
                 default:

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
@@ -25,15 +25,19 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Copied from mysql-binlog-connector-java 0.27.2 to support read the signedness based on the packed.
+ * Copied from mysql-binlog-connector-java 0.27.2 to support read the signedness based on the
+ * packed.
  *
- * <p>Line 110:
+ * <p>Line 116: The length of the {@link TableMapEventMetadataDeserializer#readBooleanList} is
+ * determined by the length * of the packet header.
  */
 public class TableMapEventMetadataDeserializer {
 
     private final Logger logger = Logger.getLogger(getClass().getName());
 
-    public TableMapEventMetadata deserialize(ByteArrayInputStream inputStream, int nColumns, int nNumericColumns) throws IOException {
+    public TableMapEventMetadata deserialize(
+            ByteArrayInputStream inputStream, int nColumns, int nNumericColumns)
+            throws IOException {
         int remainingBytes = inputStream.available();
         if (remainingBytes <= 0) {
             return null;
@@ -62,7 +66,8 @@ public class TableMapEventMetadataDeserializer {
 
             switch (fieldType) {
                 case SIGNEDNESS:
-                    result.setSignedness(readBooleanList(inputStream, nNumericColumns, fieldLength));
+                    result.setSignedness(
+                            readBooleanList(inputStream, nNumericColumns, fieldLength));
                     break;
                 case DEFAULT_CHARSET:
                     result.setDefaultCharset(readDefaultCharset(inputStream));
@@ -105,7 +110,8 @@ public class TableMapEventMetadataDeserializer {
         return result;
     }
 
-    private static BitSet readBooleanList(ByteArrayInputStream inputStream, int length, int fieldLength) throws IOException {
+    private static BitSet readBooleanList(
+            ByteArrayInputStream inputStream, int length, int fieldLength) throws IOException {
         BitSet result = new BitSet();
         byte[] bytes = inputStream.read(fieldLength);
         for (int i = 0; i < length; ++i) {
@@ -116,7 +122,8 @@ public class TableMapEventMetadataDeserializer {
         return result;
     }
 
-    private static DefaultCharset readDefaultCharset(ByteArrayInputStream inputStream) throws IOException {
+    private static DefaultCharset readDefaultCharset(ByteArrayInputStream inputStream)
+            throws IOException {
         DefaultCharset result = new DefaultCharset();
         result.setDefaultCharsetCollation(inputStream.readPackedInteger());
         Map<Integer, Integer> charsetCollations = readIntegerPairs(inputStream);
@@ -134,7 +141,8 @@ public class TableMapEventMetadataDeserializer {
         return result;
     }
 
-    private static List<String> readColumnNames(ByteArrayInputStream inputStream) throws IOException {
+    private static List<String> readColumnNames(ByteArrayInputStream inputStream)
+            throws IOException {
         List<String> columnNames = new ArrayList<String>();
         while (inputStream.available() > 0) {
             columnNames.add(inputStream.readLengthEncodedString());
@@ -142,7 +150,8 @@ public class TableMapEventMetadataDeserializer {
         return columnNames;
     }
 
-    private static List<String[]> readTypeValues(ByteArrayInputStream inputStream) throws IOException {
+    private static List<String[]> readTypeValues(ByteArrayInputStream inputStream)
+            throws IOException {
         List<String[]> result = new ArrayList<String[]>();
         while (inputStream.available() > 0) {
             List<String> typeValues = new ArrayList<String>();
@@ -155,7 +164,8 @@ public class TableMapEventMetadataDeserializer {
         return result;
     }
 
-    private static Map<Integer, Integer> readIntegerPairs(ByteArrayInputStream inputStream) throws IOException {
+    private static Map<Integer, Integer> readIntegerPairs(ByteArrayInputStream inputStream)
+            throws IOException {
         Map<Integer, Integer> result = new LinkedHashMap<Integer, Integer>();
         while (inputStream.available() > 0) {
             int columnIndex = inputStream.readPackedInteger();
@@ -166,19 +176,20 @@ public class TableMapEventMetadataDeserializer {
     }
 
     private enum MetadataFieldType {
-        SIGNEDNESS(1),                      // Signedness of numeric colums
-        DEFAULT_CHARSET(2),                 // Charsets of character columns
-        COLUMN_CHARSET(3),                  // Charsets of character columns
-        COLUMN_NAME(4),                     // Names of columns
-        SET_STR_VALUE(5),                   // The string values of SET columns
-        ENUM_STR_VALUE(6),                  // The string values is ENUM columns
-        GEOMETRY_TYPE(7),                   // The real type of geometry columns
-        SIMPLE_PRIMARY_KEY(8),              // The primary key without any prefix
-        PRIMARY_KEY_WITH_PREFIX(9),         // The primary key with some prefix
-        ENUM_AND_SET_DEFAULT_CHARSET(10),   // Charsets of ENUM and SET columns
-        ENUM_AND_SET_COLUMN_CHARSET(11),    // Charsets of ENUM and SET columns
-        VISIBILITY(12),                     // Column visibility (8.0.23 and newer)
-        UNKNOWN_METADATA_FIELD_TYPE(128);   // Returned with binlog-row-metadata=FULL from MySQL 8.0 in some cases
+        SIGNEDNESS(1), // Signedness of numeric colums
+        DEFAULT_CHARSET(2), // Charsets of character columns
+        COLUMN_CHARSET(3), // Charsets of character columns
+        COLUMN_NAME(4), // Names of columns
+        SET_STR_VALUE(5), // The string values of SET columns
+        ENUM_STR_VALUE(6), // The string values is ENUM columns
+        GEOMETRY_TYPE(7), // The real type of geometry columns
+        SIMPLE_PRIMARY_KEY(8), // The primary key without any prefix
+        PRIMARY_KEY_WITH_PREFIX(9), // The primary key with some prefix
+        ENUM_AND_SET_DEFAULT_CHARSET(10), // Charsets of ENUM and SET columns
+        ENUM_AND_SET_COLUMN_CHARSET(11), // Charsets of ENUM and SET columns
+        VISIBILITY(12), // Column visibility (8.0.23 and newer)
+        UNKNOWN_METADATA_FIELD_TYPE(
+                128); // Returned with binlog-row-metadata=FULL from MySQL 8.0 in some cases
 
         private final int code;
 
@@ -186,7 +197,9 @@ public class TableMapEventMetadataDeserializer {
             this.code = code;
         }
 
-        public int getCode() { return code; }
+        public int getCode() {
+            return code;
+        }
 
         private static final Map<Integer, MetadataFieldType> INDEX_BY_CODE;
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.github.shyiko.mysql.binlog.event.deserialization;
 
 import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata;
@@ -20,7 +21,12 @@ import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata.DefaultCharset
 import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -28,7 +34,7 @@ import java.util.logging.Logger;
  * Copied from mysql-binlog-connector-java 0.27.2 to support read the signedness based on the
  * packed.
  *
- * <p>Line 116: The length of the {@link TableMapEventMetadataDeserializer#readBooleanList} is
+ * <p>Line 123: The length of the {@link TableMapEventMetadataDeserializer#readBooleanList} is
  * determined by the length * of the packet header.
  */
 public class TableMapEventMetadataDeserializer {
@@ -98,6 +104,7 @@ public class TableMapEventMetadataDeserializer {
                     break;
                 case ENUM_AND_SET_COLUMN_CHARSET:
                     result.setEnumAndSetColumnCharsets(readIntegers(inputStream));
+                    break;
                 case VISIBILITY:
                     result.setVisibility(readBooleanList(inputStream, nColumns, fieldLength));
                     break;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 Stanley Shyiko
+ * Copyright 2023 Ververica Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2013 Stanley Shyiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.shyiko.mysql.binlog.event.deserialization;
+
+import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata;
+import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata.DefaultCharset;
+import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Copied from mysql-binlog-connector-java 0.27.2 to support read the signedness based on the packed.
+ *
+ * <p>Line 110:
+ */
+public class TableMapEventMetadataDeserializer {
+
+    private final Logger logger = Logger.getLogger(getClass().getName());
+
+    public TableMapEventMetadata deserialize(ByteArrayInputStream inputStream, int nColumns, int nNumericColumns) throws IOException {
+        int remainingBytes = inputStream.available();
+        if (remainingBytes <= 0) {
+            return null;
+        }
+
+        TableMapEventMetadata result = new TableMapEventMetadata();
+
+        for (; remainingBytes > 0; inputStream.enterBlock(remainingBytes)) {
+            int code = inputStream.readInteger(1);
+
+            MetadataFieldType fieldType = MetadataFieldType.byCode(code);
+            if (fieldType == null) {
+                throw new IOException("Unsupported table metadata field type " + code);
+            }
+            if (MetadataFieldType.UNKNOWN_METADATA_FIELD_TYPE.equals(fieldType)) {
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.fine("Received metadata field of unknown type");
+                }
+                continue;
+            }
+
+            int fieldLength = inputStream.readPackedInteger();
+
+            remainingBytes = inputStream.available();
+            inputStream.enterBlock(fieldLength);
+
+            switch (fieldType) {
+                case SIGNEDNESS:
+                    result.setSignedness(readBooleanList(inputStream, nNumericColumns, fieldLength));
+                    break;
+                case DEFAULT_CHARSET:
+                    result.setDefaultCharset(readDefaultCharset(inputStream));
+                    break;
+                case COLUMN_CHARSET:
+                    result.setColumnCharsets(readIntegers(inputStream));
+                    break;
+                case COLUMN_NAME:
+                    result.setColumnNames(readColumnNames(inputStream));
+                    break;
+                case SET_STR_VALUE:
+                    result.setSetStrValues(readTypeValues(inputStream));
+                    break;
+                case ENUM_STR_VALUE:
+                    result.setEnumStrValues(readTypeValues(inputStream));
+                    break;
+                case GEOMETRY_TYPE:
+                    result.setGeometryTypes(readIntegers(inputStream));
+                    break;
+                case SIMPLE_PRIMARY_KEY:
+                    result.setSimplePrimaryKeys(readIntegers(inputStream));
+                    break;
+                case PRIMARY_KEY_WITH_PREFIX:
+                    result.setPrimaryKeysWithPrefix(readIntegerPairs(inputStream));
+                    break;
+                case ENUM_AND_SET_DEFAULT_CHARSET:
+                    result.setEnumAndSetDefaultCharset(readDefaultCharset(inputStream));
+                    break;
+                case ENUM_AND_SET_COLUMN_CHARSET:
+                    result.setEnumAndSetColumnCharsets(readIntegers(inputStream));
+                case VISIBILITY:
+                    result.setVisibility(readBooleanList(inputStream, nColumns, fieldLength));
+                    break;
+                default:
+                    inputStream.enterBlock(remainingBytes);
+                    throw new IOException("Unsupported table metadata field type " + code);
+            }
+            remainingBytes -= fieldLength;
+        }
+        return result;
+    }
+
+    private static BitSet readBooleanList(ByteArrayInputStream inputStream, int length, int fieldLength) throws IOException {
+        BitSet result = new BitSet();
+        byte[] bytes = inputStream.read(fieldLength);
+        for (int i = 0; i < length; ++i) {
+            if ((bytes[i >> 3] & (1 << (7 - (i % 8)))) != 0) {
+                result.set(i);
+            }
+        }
+        return result;
+    }
+
+    private static DefaultCharset readDefaultCharset(ByteArrayInputStream inputStream) throws IOException {
+        DefaultCharset result = new DefaultCharset();
+        result.setDefaultCharsetCollation(inputStream.readPackedInteger());
+        Map<Integer, Integer> charsetCollations = readIntegerPairs(inputStream);
+        if (!charsetCollations.isEmpty()) {
+            result.setCharsetCollations(charsetCollations);
+        }
+        return result;
+    }
+
+    private static List<Integer> readIntegers(ByteArrayInputStream inputStream) throws IOException {
+        List<Integer> result = new ArrayList<Integer>();
+        while (inputStream.available() > 0) {
+            result.add(inputStream.readPackedInteger());
+        }
+        return result;
+    }
+
+    private static List<String> readColumnNames(ByteArrayInputStream inputStream) throws IOException {
+        List<String> columnNames = new ArrayList<String>();
+        while (inputStream.available() > 0) {
+            columnNames.add(inputStream.readLengthEncodedString());
+        }
+        return columnNames;
+    }
+
+    private static List<String[]> readTypeValues(ByteArrayInputStream inputStream) throws IOException {
+        List<String[]> result = new ArrayList<String[]>();
+        while (inputStream.available() > 0) {
+            List<String> typeValues = new ArrayList<String>();
+            int valuesCount = inputStream.readPackedInteger();
+            for (int i = 0; i < valuesCount; ++i) {
+                typeValues.add(inputStream.readLengthEncodedString());
+            }
+            result.add(typeValues.toArray(new String[typeValues.size()]));
+        }
+        return result;
+    }
+
+    private static Map<Integer, Integer> readIntegerPairs(ByteArrayInputStream inputStream) throws IOException {
+        Map<Integer, Integer> result = new LinkedHashMap<Integer, Integer>();
+        while (inputStream.available() > 0) {
+            int columnIndex = inputStream.readPackedInteger();
+            int columnCharset = inputStream.readPackedInteger();
+            result.put(columnIndex, columnCharset);
+        }
+        return result;
+    }
+
+    private enum MetadataFieldType {
+        SIGNEDNESS(1),                      // Signedness of numeric colums
+        DEFAULT_CHARSET(2),                 // Charsets of character columns
+        COLUMN_CHARSET(3),                  // Charsets of character columns
+        COLUMN_NAME(4),                     // Names of columns
+        SET_STR_VALUE(5),                   // The string values of SET columns
+        ENUM_STR_VALUE(6),                  // The string values is ENUM columns
+        GEOMETRY_TYPE(7),                   // The real type of geometry columns
+        SIMPLE_PRIMARY_KEY(8),              // The primary key without any prefix
+        PRIMARY_KEY_WITH_PREFIX(9),         // The primary key with some prefix
+        ENUM_AND_SET_DEFAULT_CHARSET(10),   // Charsets of ENUM and SET columns
+        ENUM_AND_SET_COLUMN_CHARSET(11),    // Charsets of ENUM and SET columns
+        VISIBILITY(12),                     // Column visibility (8.0.23 and newer)
+        UNKNOWN_METADATA_FIELD_TYPE(128);   // Returned with binlog-row-metadata=FULL from MySQL 8.0 in some cases
+
+        private final int code;
+
+        private MetadataFieldType(int code) {
+            this.code = code;
+        }
+
+        public int getCode() { return code; }
+
+        private static final Map<Integer, MetadataFieldType> INDEX_BY_CODE;
+
+        static {
+            INDEX_BY_CODE = new HashMap<Integer, MetadataFieldType>();
+            for (MetadataFieldType fieldType : values()) {
+                INDEX_BY_CODE.put(fieldType.code, fieldType);
+            }
+        }
+
+        public static MetadataFieldType byCode(int code) {
+            return INDEX_BY_CODE.get(code);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
  * packed.
  *
  * <p>Line 123: The length of the {@link TableMapEventMetadataDeserializer#readBooleanList} is
- * determined by the length * of the packet header.
+ * determined by the length of the packet header.
  */
 public class TableMapEventMetadataDeserializer {
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializerTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.shyiko.mysql.binlog.event.deserialization;
+
+import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata;
+import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the copied class {@link TableMapEventMetadataDeserializer}. */
+public class TableMapEventMetadataDeserializerTest {
+    @Test
+    public void testDeserialize() throws IOException {
+        TableMapEventMetadataDeserializer metadataDeserializer =
+                new TableMapEventMetadataDeserializer();
+
+        byte[] data = {1, 2, 64, 0, 2, 3, -4, -1, 0};
+
+        TableMapEventMetadata tableMapEventMetadata =
+                metadataDeserializer.deserialize(new ByteArrayInputStream(data), 10, 8);
+
+        assertThat(tableMapEventMetadata.getSignedness().get(1));
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializerTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializerTest.java
@@ -21,6 +21,7 @@ import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.BitSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,6 +37,15 @@ public class TableMapEventMetadataDeserializerTest {
         TableMapEventMetadata tableMapEventMetadata =
                 metadataDeserializer.deserialize(new ByteArrayInputStream(data), 10, 8);
 
-        assertThat(tableMapEventMetadata.getSignedness().get(1));
+        TableMapEventMetadata expectedTableMapEventMetadata = new TableMapEventMetadata();
+        BitSet bitSet = new BitSet();
+        bitSet.set(1);
+        TableMapEventMetadata.DefaultCharset result = new TableMapEventMetadata.DefaultCharset();
+        result.setCharsetCollations(null);
+        result.setDefaultCharsetCollation(255);
+        expectedTableMapEventMetadata.setSignedness(bitSet);
+        expectedTableMapEventMetadata.setDefaultCharset(result);
+
+        assertThat(tableMapEventMetadata.toString()).isEqualTo(expectedTableMapEventMetadata.toString());
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializerTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializerTest.java
@@ -46,6 +46,7 @@ public class TableMapEventMetadataDeserializerTest {
         expectedTableMapEventMetadata.setSignedness(bitSet);
         expectedTableMapEventMetadata.setDefaultCharset(result);
 
-        assertThat(tableMapEventMetadata.toString()).isEqualTo(expectedTableMapEventMetadata.toString());
+        assertThat(tableMapEventMetadata.toString())
+                .isEqualTo(expectedTableMapEventMetadata.toString());
     }
 }


### PR DESCRIPTION
As described by https://github.com/ververica/flink-cdc-connectors/issues/2784, in specific scenarios will appear table metadata field type 0 when parsing binlog event
When reading the sign bit of a numerical type, use the packed to determine the number of bytes to read to avoid the possibility of misreading due to errors in calculations.
