### PR TITLE
[cdc-runtime][cdc-composer] Support routing in Flink CDC pipeline

### DIFF
--- a/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/parser/YamlPipelineDefinitionParser.java
+++ b/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/parser/YamlPipelineDefinitionParser.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Pattern;
 
 import static com.ververica.cdc.common.utils.Preconditions.checkNotNull;
 
@@ -50,9 +49,9 @@ public class YamlPipelineDefinitionParser implements PipelineDefinitionParser {
     private static final String NAME_KEY = "name";
 
     // Route keys
-    private static final String MATCHER_KEY = "matcher";
-    private static final String REPLACE_KEY = "replace";
-    private static final String DESCRIPTION_KEY = "description";
+    private static final String ROUTE_SOURCE_TABLE_KEY = "sourceTable";
+    private static final String ROUTE_SINK_TABLE_KEY = "sinkTable";
+    private static final String ROUTE_DESCRIPTION_KEY = "description";
 
     private final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
 
@@ -129,23 +128,23 @@ public class YamlPipelineDefinitionParser implements PipelineDefinitionParser {
     }
 
     private RouteDef toRouteDef(JsonNode routeNode) {
-        String matcher =
+        String sourceTable =
                 checkNotNull(
-                                routeNode.get(MATCHER_KEY),
+                                routeNode.get(ROUTE_SOURCE_TABLE_KEY),
                                 "Missing required field \"%s\" in route configuration",
-                                MATCHER_KEY)
+                                ROUTE_SOURCE_TABLE_KEY)
                         .asText();
-        String replace =
+        String sinkTable =
                 checkNotNull(
-                                routeNode.get(REPLACE_KEY),
+                                routeNode.get(ROUTE_SINK_TABLE_KEY),
                                 "Missing required field \"%s\" in route configuration",
-                                REPLACE_KEY)
+                                ROUTE_SINK_TABLE_KEY)
                         .asText();
         String description =
-                Optional.ofNullable(routeNode.get(DESCRIPTION_KEY))
+                Optional.ofNullable(routeNode.get(ROUTE_DESCRIPTION_KEY))
                         .map(JsonNode::asText)
                         .orElse(null);
-        return new RouteDef(Pattern.compile(matcher), replace, description);
+        return new RouteDef(sourceTable, sinkTable, description);
     }
 
     private Configuration toPipelineConfig(JsonNode pipelineConfigNode) {

--- a/flink-cdc-cli/src/test/java/com/ververica/cdc/cli/parser/YamlPipelineDefinitionParserTest.java
+++ b/flink-cdc-cli/src/test/java/com/ververica/cdc/cli/parser/YamlPipelineDefinitionParserTest.java
@@ -30,7 +30,6 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -99,11 +98,11 @@ class YamlPipelineDefinitionParserTest {
                                             .build())),
                     Arrays.asList(
                             new RouteDef(
-                                    Pattern.compile("mydb.default.app_order_.*"),
+                                    "mydb.default.app_order_.*",
                                     "odsdb.default.app_order",
                                     "sync all sharding tables to one"),
                             new RouteDef(
-                                    Pattern.compile("mydb.default.web_order"),
+                                    "mydb.default.web_order",
                                     "odsdb.default.ods_web_order",
                                     "sync table to with given prefix ods_")),
                     null,
@@ -143,11 +142,11 @@ class YamlPipelineDefinitionParserTest {
                                             .build())),
                     Arrays.asList(
                             new RouteDef(
-                                    Pattern.compile("mydb.default.app_order_.*"),
+                                    "mydb.default.app_order_.*",
                                     "odsdb.default.app_order",
                                     "sync all sharding tables to one"),
                             new RouteDef(
-                                    Pattern.compile("mydb.default.web_order"),
+                                    "mydb.default.web_order",
                                     "odsdb.default.ods_web_order",
                                     "sync table to with given prefix ods_")),
                     null,
@@ -183,9 +182,7 @@ class YamlPipelineDefinitionParserTest {
                                             .build())),
                     Collections.singletonList(
                             new RouteDef(
-                                    Pattern.compile("mydb.default.app_order_.*"),
-                                    "odsdb.default.app_order",
-                                    null)),
+                                    "mydb.default.app_order_.*", "odsdb.default.app_order", null)),
                     null,
                     Configuration.fromMap(
                             ImmutableMap.<String, String>builder()

--- a/flink-cdc-cli/src/test/resources/definitions/pipeline-definition-full.yaml
+++ b/flink-cdc-cli/src/test/resources/definitions/pipeline-definition-full.yaml
@@ -30,11 +30,11 @@ sink:
   auto-create-table: true
 
 route:
-  - matcher: mydb.default.app_order_.*
-    replace: odsdb.default.app_order
+  - sourceTable: mydb.default.app_order_.*
+    sinkTable: odsdb.default.app_order
     description: sync all sharding tables to one
-  - matcher: mydb.default.web_order
-    replace: odsdb.default.ods_web_order
+  - sourceTable: mydb.default.web_order
+    sinkTable: odsdb.default.ods_web_order
     description: sync table to with given prefix ods_
 
 transform:

--- a/flink-cdc-cli/src/test/resources/definitions/pipeline-definition-with-optional.yaml
+++ b/flink-cdc-cli/src/test/resources/definitions/pipeline-definition-with-optional.yaml
@@ -25,8 +25,8 @@ sink:
   bootstrap-servers: localhost:9092
 
 route:
-  - matcher: mydb.default.app_order_.*
-    replace: odsdb.default.app_order
+  - sourceTable: mydb.default.app_order_.*
+    sinkTable: odsdb.default.app_order
 
 pipeline:
   parallelism: 4

--- a/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/AddColumnEventAssert.java
+++ b/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/AddColumnEventAssert.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.testutils.assertions;
+
+import com.ververica.cdc.common.event.AddColumnEvent;
+import org.assertj.core.internal.Iterables;
+
+import java.util.List;
+
+/** Assertions for {@link AddColumnEvent}. */
+public class AddColumnEventAssert extends ChangeEventAssert<AddColumnEventAssert, AddColumnEvent> {
+    private final Iterables iterables = Iterables.instance();
+
+    public static AddColumnEventAssert assertThatAddColumnEvent(AddColumnEvent event) {
+        return new AddColumnEventAssert(event);
+    }
+
+    private AddColumnEventAssert(AddColumnEvent addColumnEvent) {
+        super(addColumnEvent, AddColumnEventAssert.class);
+    }
+
+    public AddColumnEventAssert containsAddedColumns(AddColumnEvent.ColumnWithPosition... columns) {
+        List<AddColumnEvent.ColumnWithPosition> actualAddedColumns = actual.getAddedColumns();
+        iterables.assertContainsExactlyInAnyOrder(info, actualAddedColumns, columns);
+        return myself;
+    }
+}

--- a/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/AlterColumnTypeEventAssert.java
+++ b/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/AlterColumnTypeEventAssert.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.testutils.assertions;
+
+import com.ververica.cdc.common.event.AlterColumnTypeEvent;
+import com.ververica.cdc.common.types.DataType;
+import org.assertj.core.internal.Maps;
+
+import java.util.Map;
+
+/** Assertions for {@link AlterColumnTypeEvent}. */
+public class AlterColumnTypeEventAssert
+        extends ChangeEventAssert<AlterColumnTypeEventAssert, AlterColumnTypeEvent> {
+    private final Maps maps = Maps.instance();
+
+    public static AlterColumnTypeEventAssert assertThatAlterColumnTypeEvent(
+            AlterColumnTypeEvent event) {
+        return new AlterColumnTypeEventAssert(event);
+    }
+
+    private AlterColumnTypeEventAssert(AlterColumnTypeEvent event) {
+        super(event, AlterColumnTypeEventAssert.class);
+    }
+
+    public AlterColumnTypeEventAssert containsTypeMapping(Map<String, DataType> typeMapping) {
+        Map<String, DataType> actualTypeMapping = actual.getTypeMapping();
+        maps.assertContainsAllEntriesOf(info, actualTypeMapping, typeMapping);
+        return myself;
+    }
+}

--- a/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/ChangeEventAssert.java
+++ b/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/ChangeEventAssert.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.testutils.assertions;
+
+import com.ververica.cdc.common.event.ChangeEvent;
+import com.ververica.cdc.common.event.TableId;
+import org.assertj.core.api.AbstractAssert;
+
+/** Assertions for {@link ChangeEvent}. */
+public class ChangeEventAssert<SELF extends AbstractAssert<SELF, EVENT>, EVENT extends ChangeEvent>
+        extends AbstractAssert<SELF, EVENT> {
+
+    public static <SELF extends ChangeEventAssert<SELF, ChangeEvent>>
+            ChangeEventAssert<SELF, ChangeEvent> assertThatChangeEvent(ChangeEvent changeEvent) {
+        return new ChangeEventAssert<>(changeEvent, ChangeEventAssert.class);
+    }
+
+    protected ChangeEventAssert(EVENT event, Class<?> selfType) {
+        super(event, selfType);
+    }
+
+    public SELF hasTableId(TableId tableId) {
+        if (!actual.tableId().equals(tableId)) {
+            failWithActualExpectedAndMessage(
+                    actual.tableId(),
+                    tableId,
+                    "Table ID of the DataChangeEvent is not as expected");
+        }
+        return myself;
+    }
+}

--- a/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/CreateTableEventAssert.java
+++ b/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/CreateTableEventAssert.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.testutils.assertions;
+
+import com.ververica.cdc.common.event.CreateTableEvent;
+import com.ververica.cdc.common.schema.Schema;
+
+/** Assertions for {@link CreateTableEvent}. */
+public class CreateTableEventAssert
+        extends ChangeEventAssert<CreateTableEventAssert, CreateTableEvent> {
+
+    public static CreateTableEventAssert assertThatCreateTableEvent(CreateTableEvent event) {
+        return new CreateTableEventAssert(event);
+    }
+
+    protected CreateTableEventAssert(CreateTableEvent event) {
+        super(event, CreateTableEventAssert.class);
+    }
+
+    public CreateTableEventAssert hasSchema(Schema schema) {
+        isNotNull();
+        if (!actual.getSchema().equals(schema)) {
+            failWithActualExpectedAndMessage(
+                    actual.getSchema(),
+                    schema,
+                    "The schema of the CreateTableEvent is not as expected");
+        }
+        return myself;
+    }
+}

--- a/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/DataChangeEventAssert.java
+++ b/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/DataChangeEventAssert.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.testutils.assertions;
+
+import com.ververica.cdc.common.event.DataChangeEvent;
+import com.ververica.cdc.common.event.OperationType;
+
+/** Assertions for {@link DataChangeEvent}. */
+public class DataChangeEventAssert
+        extends ChangeEventAssert<DataChangeEventAssert, DataChangeEvent> {
+
+    public static DataChangeEventAssert assertThatDataChangeEvent(DataChangeEvent event) {
+        return new DataChangeEventAssert(event);
+    }
+
+    protected DataChangeEventAssert(DataChangeEvent dataChangeEvent) {
+        super(dataChangeEvent, DataChangeEventAssert.class);
+    }
+
+    public DataChangeEventAssert hasOperationType(OperationType operationType) {
+        if (!actual.op().equals(operationType)) {
+            failWithMessage(
+                    "Expect DataChangeEvent to have operation type \"%s\", but was \"%s\"",
+                    operationType, actual.op());
+        }
+        return this;
+    }
+
+    public RecordDataAssert<?> withBeforeRecordData() {
+        if (actual.before() == null) {
+            failWithMessage(
+                    "DataChangeEvent with operation type \"%s\" does not have \"before\" field",
+                    actual.op());
+        }
+        return RecordDataAssert.assertThatRecordData(actual.before());
+    }
+
+    public RecordDataAssert<?> withAfterRecordData() {
+        if (actual.after() == null) {
+            failWithMessage(
+                    "DataChangeEvent with operation type \"%s\" does not have \"after\" field",
+                    actual.op());
+        }
+        return RecordDataAssert.assertThatRecordData(actual.after());
+    }
+}

--- a/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/DropColumnEventAssert.java
+++ b/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/DropColumnEventAssert.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.testutils.assertions;
+
+import com.ververica.cdc.common.event.DropColumnEvent;
+import com.ververica.cdc.common.schema.Column;
+import org.assertj.core.internal.Iterables;
+
+import java.util.List;
+
+/** Assertions for {@link DropColumnEvent}. */
+public class DropColumnEventAssert
+        extends ChangeEventAssert<DropColumnEventAssert, DropColumnEvent> {
+    private final Iterables iterables = Iterables.instance();
+
+    public static DropColumnEventAssert assertThatDropColumnEvent(DropColumnEvent event) {
+        return new DropColumnEventAssert(event);
+    }
+
+    private DropColumnEventAssert(DropColumnEvent event) {
+        super(event, DropColumnEventAssert.class);
+    }
+
+    public DropColumnEventAssert containsDroppedColumns(Column... droppedColumns) {
+        List<Column> actualDroppedColumns = actual.getDroppedColumns();
+        iterables.assertContainsExactlyInAnyOrder(info, actualDroppedColumns, droppedColumns);
+        return myself;
+    }
+}

--- a/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/EventAssert.java
+++ b/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/EventAssert.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.testutils.assertions;
+
+import com.ververica.cdc.common.event.DataChangeEvent;
+import com.ververica.cdc.common.event.Event;
+import com.ververica.cdc.common.event.SchemaChangeEvent;
+import org.assertj.core.api.AbstractAssert;
+
+/** Assertions for {@link EventAssert}. */
+public class EventAssert extends AbstractAssert<EventAssert, Event> {
+    public static EventAssert assertThatEvent(Event event) {
+        return new EventAssert(event);
+    }
+
+    protected EventAssert(Event event) {
+        super(event, EventAssert.class);
+    }
+
+    public DataChangeEventAssert asDataChangeEvent() {
+        isInstanceOf(DataChangeEvent.class);
+        return DataChangeEventAssert.assertThatDataChangeEvent((DataChangeEvent) actual);
+    }
+
+    public SchemaChangeEventAssert asSchemaChangeEvent() {
+        isInstanceOf(SchemaChangeEvent.class);
+        return SchemaChangeEventAssert.assertThatSchemaChangeEvent((SchemaChangeEvent) actual);
+    }
+}

--- a/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/EventAssertions.java
+++ b/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/EventAssertions.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.testutils.assertions;
+
+import com.ververica.cdc.common.data.RecordData;
+import com.ververica.cdc.common.event.AddColumnEvent;
+import com.ververica.cdc.common.event.ChangeEvent;
+import com.ververica.cdc.common.event.CreateTableEvent;
+import com.ververica.cdc.common.event.DataChangeEvent;
+import com.ververica.cdc.common.event.DropColumnEvent;
+import com.ververica.cdc.common.event.Event;
+import com.ververica.cdc.common.event.RenameColumnEvent;
+import com.ververica.cdc.common.event.SchemaChangeEvent;
+import org.assertj.core.api.Assertions;
+
+/** Collection for entries of customized event-related assertions. */
+public class EventAssertions extends Assertions {
+    public static EventAssert assertThat(Event event) {
+        return EventAssert.assertThatEvent(event);
+    }
+
+    public static <SELF extends ChangeEventAssert<SELF, ChangeEvent>>
+            ChangeEventAssert<SELF, ChangeEvent> assertThat(ChangeEvent changeEvent) {
+        return ChangeEventAssert.assertThatChangeEvent(changeEvent);
+    }
+
+    public static DataChangeEventAssert assertThat(DataChangeEvent event) {
+        return DataChangeEventAssert.assertThatDataChangeEvent(event);
+    }
+
+    public static <SELF extends RecordDataAssert<SELF>> RecordDataAssert<SELF> assertThat(
+            RecordData recordData) {
+        return RecordDataAssert.assertThatRecordData(recordData);
+    }
+
+    public static SchemaChangeEventAssert assertThat(SchemaChangeEvent event) {
+        return SchemaChangeEventAssert.assertThatSchemaChangeEvent(event);
+    }
+
+    public static CreateTableEventAssert assertThat(CreateTableEvent event) {
+        return CreateTableEventAssert.assertThatCreateTableEvent(event);
+    }
+
+    public static AddColumnEventAssert assertThat(AddColumnEvent event) {
+        return AddColumnEventAssert.assertThatAddColumnEvent(event);
+    }
+
+    public static DropColumnEventAssert assertThat(DropColumnEvent event) {
+        return DropColumnEventAssert.assertThatDropColumnEvent(event);
+    }
+
+    public static RenameColumnEventAssert assertThat(RenameColumnEvent event) {
+        return RenameColumnEventAssert.assertThatRenameColumnEvent(event);
+    }
+}

--- a/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/RecordDataAssert.java
+++ b/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/RecordDataAssert.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.testutils.assertions;
+
+import com.ververica.cdc.common.data.RecordData;
+import com.ververica.cdc.common.schema.Schema;
+import org.assertj.core.api.AbstractAssert;
+
+/** Assertions for {@link RecordData}. */
+public class RecordDataAssert<SELF extends RecordDataAssert<SELF>>
+        extends AbstractAssert<SELF, RecordData> {
+
+    public static <SELF extends RecordDataAssert<SELF>> RecordDataAssert<SELF> assertThatRecordData(
+            RecordData recordData) {
+        return new RecordDataAssert<>(recordData, RecordDataAssert.class);
+    }
+
+    public RecordDataAssert(RecordData recordData, Class<?> selfType) {
+        super(recordData, selfType);
+    }
+
+    public RecordDataWithSchemaAssert withSchema(Schema schema) {
+        return new RecordDataWithSchemaAssert(actual, schema);
+    }
+
+    public SELF hasArity(int arity) {
+        if (actual.getArity() != arity) {
+            failWithActualExpectedAndMessage(
+                    actual.getArity(), arity, "The RecordData has unexpected arity");
+        }
+        return myself;
+    }
+}

--- a/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/RecordDataWithSchemaAssert.java
+++ b/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/RecordDataWithSchemaAssert.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.testutils.assertions;
+
+import com.ververica.cdc.common.data.RecordData;
+import com.ververica.cdc.common.schema.Schema;
+import com.ververica.cdc.common.utils.SchemaUtils;
+import org.assertj.core.internal.Iterables;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Assertions for {@link RecordData} with schema so that fields in the RecordData can be checked.
+ */
+public class RecordDataWithSchemaAssert extends RecordDataAssert<RecordDataWithSchemaAssert> {
+    private final Schema schema;
+    private final Iterables iterables = Iterables.instance();
+
+    protected RecordDataWithSchemaAssert(RecordData recordData, Schema schema) {
+        super(recordData, RecordDataWithSchemaAssert.class);
+        this.schema = schema;
+    }
+
+    public RecordDataWithSchemaAssert hasFields(Object... fields) {
+        objects.assertNotNull(info, schema);
+        List<RecordData.FieldGetter> fieldGetters = SchemaUtils.createFieldGetters(schema);
+        List<Object> actualFields = new ArrayList<>();
+        for (RecordData.FieldGetter fieldGetter : fieldGetters) {
+            actualFields.add(fieldGetter.getFieldOrNull(actual));
+        }
+        iterables.assertContainsExactly(info, actualFields, fields);
+        return myself;
+    }
+}

--- a/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/RenameColumnEventAssert.java
+++ b/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/RenameColumnEventAssert.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.testutils.assertions;
+
+import com.ververica.cdc.common.event.RenameColumnEvent;
+import org.assertj.core.internal.Maps;
+
+import java.util.Map;
+
+/** Assertions for {@link RenameColumnEvent}. */
+public class RenameColumnEventAssert
+        extends ChangeEventAssert<RenameColumnEventAssert, RenameColumnEvent> {
+    private final Maps maps = Maps.instance();
+
+    public static RenameColumnEventAssert assertThatRenameColumnEvent(RenameColumnEvent event) {
+        return new RenameColumnEventAssert(event);
+    }
+
+    private RenameColumnEventAssert(RenameColumnEvent event) {
+        super(event, RenameColumnEventAssert.class);
+    }
+
+    public RenameColumnEventAssert containsNameMapping(Map<String, String> nameMapping) {
+        Map<String, String> actualNameMapping = actual.getNameMapping();
+        maps.assertContainsAllEntriesOf(info, actualNameMapping, nameMapping);
+        return myself;
+    }
+}

--- a/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/SchemaChangeEventAssert.java
+++ b/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/SchemaChangeEventAssert.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.common.testutils.assertions;
+
+import com.ververica.cdc.common.event.AddColumnEvent;
+import com.ververica.cdc.common.event.AlterColumnTypeEvent;
+import com.ververica.cdc.common.event.CreateTableEvent;
+import com.ververica.cdc.common.event.DropColumnEvent;
+import com.ververica.cdc.common.event.RenameColumnEvent;
+import com.ververica.cdc.common.event.SchemaChangeEvent;
+
+/** Assertions for {@link SchemaChangeEvent}. */
+public class SchemaChangeEventAssert
+        extends ChangeEventAssert<SchemaChangeEventAssert, SchemaChangeEvent> {
+
+    public static SchemaChangeEventAssert assertThatSchemaChangeEvent(SchemaChangeEvent event) {
+        return new SchemaChangeEventAssert(event);
+    }
+
+    protected SchemaChangeEventAssert(SchemaChangeEvent event) {
+        super(event, SchemaChangeEventAssert.class);
+    }
+
+    public CreateTableEventAssert asCreateTableEvent() {
+        isInstanceOf(CreateTableEvent.class);
+        return CreateTableEventAssert.assertThatCreateTableEvent((CreateTableEvent) actual);
+    }
+
+    public AddColumnEventAssert asAddColumnEvent() {
+        isInstanceOf(AddColumnEvent.class);
+        return AddColumnEventAssert.assertThatAddColumnEvent((AddColumnEvent) actual);
+    }
+
+    public DropColumnEventAssert asDropColumnEvent() {
+        isInstanceOf(DropColumnEvent.class);
+        return DropColumnEventAssert.assertThatDropColumnEvent((DropColumnEvent) actual);
+    }
+
+    public RenameColumnEventAssert asRenameColumnEvent() {
+        isInstanceOf(RenameColumnEvent.class);
+        return RenameColumnEventAssert.assertThatRenameColumnEvent(((RenameColumnEvent) actual));
+    }
+
+    public AlterColumnTypeEventAssert asAlterColumnTypeEvent() {
+        isInstanceOf(AlterColumnTypeEvent.class);
+        return AlterColumnTypeEventAssert.assertThatAlterColumnTypeEvent(
+                ((AlterColumnTypeEvent) actual));
+    }
+}

--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/RouteDef.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/RouteDef.java
@@ -20,7 +20,6 @@ import javax.annotation.Nullable;
 
 import java.util.Objects;
 import java.util.Optional;
-import java.util.regex.Pattern;
 
 /**
  * Definition of a router.
@@ -34,22 +33,22 @@ import java.util.regex.Pattern;
  * </ul>
  */
 public class RouteDef {
-    private final Pattern matcher;
-    private final String replace;
+    private final String sourceTable;
+    private final String sinkTable;
     @Nullable private final String description;
 
-    public RouteDef(Pattern matcher, String replace, @Nullable String description) {
-        this.matcher = matcher;
-        this.replace = replace;
+    public RouteDef(String sourceTable, String sinkTable, @Nullable String description) {
+        this.sourceTable = sourceTable;
+        this.sinkTable = sinkTable;
         this.description = description;
     }
 
-    public Pattern getMatcher() {
-        return matcher;
+    public String getSourceTable() {
+        return sourceTable;
     }
 
-    public String getReplace() {
-        return replace;
+    public String getSinkTable() {
+        return sinkTable;
     }
 
     public Optional<String> getDescription() {
@@ -60,9 +59,9 @@ public class RouteDef {
     public String toString() {
         return "RouteDef{"
                 + "matcher="
-                + matcher
+                + sourceTable
                 + ", replace="
-                + replace
+                + sinkTable
                 + ", description='"
                 + description
                 + '\''
@@ -78,13 +77,13 @@ public class RouteDef {
             return false;
         }
         RouteDef routeDef = (RouteDef) o;
-        return Objects.equals(matcher.pattern(), routeDef.matcher.pattern())
-                && Objects.equals(replace, routeDef.replace)
+        return Objects.equals(sourceTable, routeDef.sourceTable)
+                && Objects.equals(sinkTable, routeDef.sinkTable)
                 && Objects.equals(description, routeDef.description);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(matcher, replace, description);
+        return Objects.hash(sourceTable, sinkTable, description);
     }
 }

--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/flink/FlinkPipelineComposer.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/flink/FlinkPipelineComposer.java
@@ -33,6 +33,7 @@ import com.ververica.cdc.composer.flink.coordination.OperatorIDGenerator;
 import com.ververica.cdc.composer.flink.translator.DataSinkTranslator;
 import com.ververica.cdc.composer.flink.translator.DataSourceTranslator;
 import com.ververica.cdc.composer.flink.translator.PartitioningTranslator;
+import com.ververica.cdc.composer.flink.translator.RouteTranslator;
 import com.ververica.cdc.composer.flink.translator.SchemaOperatorTranslator;
 import com.ververica.cdc.composer.utils.FactoryDiscoveryUtils;
 
@@ -71,6 +72,10 @@ public class FlinkPipelineComposer implements PipelineComposer {
         DataSourceTranslator sourceTranslator = new DataSourceTranslator();
         DataStream<Event> stream =
                 sourceTranslator.translate(pipelineDef.getSource(), env, parallelism);
+
+        // Route
+        RouteTranslator routeTranslator = new RouteTranslator();
+        stream = routeTranslator.translate(stream, pipelineDef.getRoute());
 
         // Create sink in advance as schema operator requires MetadataApplier
         DataSink dataSink = createDataSink(pipelineDef.getSink());

--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/flink/translator/RouteTranslator.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/flink/translator/RouteTranslator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.composer.flink.translator;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+
+import com.ververica.cdc.common.event.Event;
+import com.ververica.cdc.common.event.TableId;
+import com.ververica.cdc.composer.definition.RouteDef;
+import com.ververica.cdc.runtime.operators.route.RouteFunction;
+import com.ververica.cdc.runtime.typeutils.EventTypeInfo;
+
+import java.util.List;
+
+/** Translator for router. */
+public class RouteTranslator {
+    public DataStream<Event> translate(DataStream<Event> input, List<RouteDef> routes) {
+        if (routes.isEmpty()) {
+            return input;
+        }
+        RouteFunction.Builder routeFunctionBuilder = RouteFunction.newBuilder();
+        for (RouteDef route : routes) {
+            routeFunctionBuilder.addRoute(
+                    route.getSourceTable(), TableId.parse(route.getSinkTable()));
+        }
+        return input.map(routeFunctionBuilder.build(), new EventTypeInfo());
+    }
+}

--- a/flink-cdc-runtime/pom.xml
+++ b/flink-cdc-runtime/pom.xml
@@ -35,9 +35,15 @@ under the License.
         <dependency>
             <groupId>com.ververica</groupId>
             <artifactId>flink-cdc-common</artifactId>
-            <version>${project.version}</version>
+            <version>${revision}</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.ververica</groupId>
+            <artifactId>flink-cdc-common</artifactId>
+            <version>${revision}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-core</artifactId>

--- a/flink-cdc-runtime/src/main/java/com/ververica/cdc/runtime/operators/route/RouteFunction.java
+++ b/flink-cdc-runtime/src/main/java/com/ververica/cdc/runtime/operators/route/RouteFunction.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.runtime.operators.route;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+
+import com.ververica.cdc.common.event.AddColumnEvent;
+import com.ververica.cdc.common.event.AlterColumnTypeEvent;
+import com.ververica.cdc.common.event.ChangeEvent;
+import com.ververica.cdc.common.event.CreateTableEvent;
+import com.ververica.cdc.common.event.DataChangeEvent;
+import com.ververica.cdc.common.event.DropColumnEvent;
+import com.ververica.cdc.common.event.Event;
+import com.ververica.cdc.common.event.RenameColumnEvent;
+import com.ververica.cdc.common.event.SchemaChangeEvent;
+import com.ververica.cdc.common.event.TableId;
+import com.ververica.cdc.common.schema.Selectors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.ververica.cdc.common.utils.Preconditions.checkState;
+
+/** A map function that applies user-defined routing logics. */
+public class RouteFunction extends RichMapFunction<Event, Event> {
+    private final List<Tuple2<String, TableId>> routingRules;
+    private transient List<Tuple2<Selectors, TableId>> routes;
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /** Builder of {@link RouteFunction}. */
+    public static class Builder {
+        private final List<Tuple2<String, TableId>> routingRules = new ArrayList<>();
+
+        public Builder addRoute(String tableInclusions, TableId replaceBy) {
+            routingRules.add(Tuple2.of(tableInclusions, replaceBy));
+            return this;
+        }
+
+        public RouteFunction build() {
+            return new RouteFunction(routingRules);
+        }
+    }
+
+    private RouteFunction(List<Tuple2<String, TableId>> routingRules) {
+        this.routingRules = routingRules;
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        routes =
+                routingRules.stream()
+                        .map(
+                                tuple2 -> {
+                                    String tableInclusions = tuple2.f0;
+                                    TableId replaceBy = tuple2.f1;
+                                    Selectors selectors =
+                                            new Selectors.SelectorsBuilder()
+                                                    .includeTables(tableInclusions)
+                                                    .build();
+                                    return new Tuple2<>(selectors, replaceBy);
+                                })
+                        .collect(Collectors.toList());
+    }
+
+    @Override
+    public Event map(Event event) throws Exception {
+        checkState(
+                event instanceof ChangeEvent,
+                String.format(
+                        "The input event of the route is not a ChangeEvent but with type \"%s\"",
+                        event.getClass().getCanonicalName()));
+        ChangeEvent changeEvent = (ChangeEvent) event;
+        TableId tableId = changeEvent.tableId();
+
+        for (Tuple2<Selectors, TableId> route : routes) {
+            Selectors selectors = route.f0;
+            TableId replaceBy = route.f1;
+            if (selectors.isMatch(tableId)) {
+                return recreateChangeEvent(changeEvent, replaceBy);
+            }
+        }
+        return event;
+    }
+
+    private ChangeEvent recreateChangeEvent(ChangeEvent event, TableId tableId) {
+        if (event instanceof DataChangeEvent) {
+            return recreateDataChangeEvent(((DataChangeEvent) event), tableId);
+        }
+        if (event instanceof SchemaChangeEvent) {
+            return recreateSchemaChangeEvent(((SchemaChangeEvent) event), tableId);
+        }
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Unsupported change event with type \"%s\"",
+                        event.getClass().getCanonicalName()));
+    }
+
+    private DataChangeEvent recreateDataChangeEvent(
+            DataChangeEvent dataChangeEvent, TableId tableId) {
+        switch (dataChangeEvent.op()) {
+            case INSERT:
+                return DataChangeEvent.insertEvent(
+                        tableId, dataChangeEvent.after(), dataChangeEvent.meta());
+            case UPDATE:
+                return DataChangeEvent.updateEvent(
+                        tableId,
+                        dataChangeEvent.before(),
+                        dataChangeEvent.after(),
+                        dataChangeEvent.meta());
+            case REPLACE:
+                return DataChangeEvent.replaceEvent(
+                        tableId, dataChangeEvent.after(), dataChangeEvent.meta());
+            case DELETE:
+                return DataChangeEvent.deleteEvent(
+                        tableId, dataChangeEvent.before(), dataChangeEvent.meta());
+            default:
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Unsupported operation type \"%s\" in data change event",
+                                dataChangeEvent.op()));
+        }
+    }
+
+    private SchemaChangeEvent recreateSchemaChangeEvent(
+            SchemaChangeEvent schemaChangeEvent, TableId tableId) {
+        if (schemaChangeEvent instanceof CreateTableEvent) {
+            CreateTableEvent createTableEvent = (CreateTableEvent) schemaChangeEvent;
+            return new CreateTableEvent(tableId, createTableEvent.getSchema());
+        }
+        if (schemaChangeEvent instanceof AlterColumnTypeEvent) {
+            AlterColumnTypeEvent alterColumnTypeEvent = (AlterColumnTypeEvent) schemaChangeEvent;
+            return new AlterColumnTypeEvent(tableId, alterColumnTypeEvent.getTypeMapping());
+        }
+        if (schemaChangeEvent instanceof RenameColumnEvent) {
+            RenameColumnEvent renameColumnEvent = (RenameColumnEvent) schemaChangeEvent;
+            return new RenameColumnEvent(tableId, renameColumnEvent.getNameMapping());
+        }
+        if (schemaChangeEvent instanceof DropColumnEvent) {
+            DropColumnEvent dropColumnEvent = (DropColumnEvent) schemaChangeEvent;
+            return new DropColumnEvent(tableId, dropColumnEvent.getDroppedColumns());
+        }
+        if (schemaChangeEvent instanceof AddColumnEvent) {
+            AddColumnEvent addColumnEvent = (AddColumnEvent) schemaChangeEvent;
+            return new AddColumnEvent(tableId, addColumnEvent.getAddedColumns());
+        }
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Unsupported schema change event with type \"%s\"",
+                        schemaChangeEvent.getClass().getCanonicalName()));
+    }
+}

--- a/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/operators/route/RouteFunctionTest.java
+++ b/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/operators/route/RouteFunctionTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.runtime.operators.route;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
+
+import com.ververica.cdc.common.data.binary.BinaryStringData;
+import com.ververica.cdc.common.event.AddColumnEvent;
+import com.ververica.cdc.common.event.AlterColumnTypeEvent;
+import com.ververica.cdc.common.event.CreateTableEvent;
+import com.ververica.cdc.common.event.DataChangeEvent;
+import com.ververica.cdc.common.event.DropColumnEvent;
+import com.ververica.cdc.common.event.OperationType;
+import com.ververica.cdc.common.event.RenameColumnEvent;
+import com.ververica.cdc.common.event.TableId;
+import com.ververica.cdc.common.schema.Column;
+import com.ververica.cdc.common.schema.PhysicalColumn;
+import com.ververica.cdc.common.schema.Schema;
+import com.ververica.cdc.common.types.DataType;
+import com.ververica.cdc.common.types.DataTypes;
+import com.ververica.cdc.common.types.RowType;
+import com.ververica.cdc.runtime.typeutils.BinaryRecordDataGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static com.ververica.cdc.common.testutils.assertions.EventAssertions.assertThat;
+
+class RouteFunctionTest {
+    private static final TableId CUSTOMERS =
+            TableId.tableId("my_company", "my_branch", "customers");
+    private static final TableId NEW_CUSTOMERS =
+            TableId.tableId("my_new_company", "my_new_branch", "customers");
+    private static final Schema CUSTOMERS_SCHEMA =
+            Schema.newBuilder()
+                    .physicalColumn("id", DataTypes.INT())
+                    .physicalColumn("name", DataTypes.STRING())
+                    .physicalColumn("phone", DataTypes.BIGINT())
+                    .primaryKey("id")
+                    .build();
+
+    @Test
+    void testDataChangeEventRouting() throws Exception {
+        RouteFunction router =
+                RouteFunction.newBuilder()
+                        .addRoute("my_company.\\.+.customers", NEW_CUSTOMERS)
+                        .build();
+        router.open(new Configuration());
+        BinaryRecordDataGenerator recordDataGenerator =
+                new BinaryRecordDataGenerator(((RowType) CUSTOMERS_SCHEMA.toRowDataType()));
+
+        // Insert
+        DataChangeEvent insertEvent =
+                DataChangeEvent.insertEvent(
+                        CUSTOMERS,
+                        recordDataGenerator.generate(
+                                new Object[] {1, new BinaryStringData("Alice"), 12345678L}));
+        assertThat(router.map(insertEvent))
+                .asDataChangeEvent()
+                .hasTableId(NEW_CUSTOMERS)
+                .hasOperationType(OperationType.INSERT)
+                .withAfterRecordData()
+                .hasArity(3)
+                .withSchema(CUSTOMERS_SCHEMA)
+                .hasFields(1, new BinaryStringData("Alice"), 12345678L);
+
+        // Update
+        DataChangeEvent updateEvent =
+                DataChangeEvent.updateEvent(
+                        CUSTOMERS,
+                        recordDataGenerator.generate(
+                                new Object[] {1, new BinaryStringData("Alice"), 12345678L}),
+                        recordDataGenerator.generate(
+                                new Object[] {1, new BinaryStringData("Alice"), 87654321L}));
+        DataChangeEvent mappedUpdateEvent = (DataChangeEvent) router.map(updateEvent);
+        assertThat(mappedUpdateEvent)
+                .hasTableId(NEW_CUSTOMERS)
+                .hasOperationType(OperationType.UPDATE);
+        assertThat(mappedUpdateEvent.before())
+                .withSchema(CUSTOMERS_SCHEMA)
+                .hasFields(1, new BinaryStringData("Alice"), 12345678L);
+        assertThat(mappedUpdateEvent.after())
+                .withSchema(CUSTOMERS_SCHEMA)
+                .hasFields(1, new BinaryStringData("Alice"), 87654321L);
+
+        // Replace
+        DataChangeEvent replaceEvent =
+                DataChangeEvent.replaceEvent(
+                        CUSTOMERS,
+                        recordDataGenerator.generate(
+                                new Object[] {1, new BinaryStringData("Bob"), 87654321L}));
+        assertThat(router.map(replaceEvent))
+                .asDataChangeEvent()
+                .hasTableId(NEW_CUSTOMERS)
+                .hasOperationType(OperationType.REPLACE)
+                .withAfterRecordData()
+                .hasArity(3)
+                .withSchema(CUSTOMERS_SCHEMA)
+                .hasFields(1, new BinaryStringData("Bob"), 87654321L);
+
+        // Delete
+        DataChangeEvent deleteEvent =
+                DataChangeEvent.deleteEvent(
+                        CUSTOMERS,
+                        recordDataGenerator.generate(
+                                new Object[] {1, new BinaryStringData("Bob"), 87654321L}));
+        assertThat(router.map(deleteEvent))
+                .asDataChangeEvent()
+                .hasTableId(NEW_CUSTOMERS)
+                .hasOperationType(OperationType.DELETE)
+                .withBeforeRecordData()
+                .hasArity(3)
+                .withSchema(CUSTOMERS_SCHEMA)
+                .hasFields(1, new BinaryStringData("Bob"), 87654321L);
+    }
+
+    @Test
+    void testSchemaChangeEventRouting() throws Exception {
+        RouteFunction router =
+                RouteFunction.newBuilder()
+                        .addRoute("\\.+_company.\\.+_branch.customers", NEW_CUSTOMERS)
+                        .build();
+        router.open(new Configuration());
+
+        // CreateTableEvent
+        CreateTableEvent createTableEvent = new CreateTableEvent(CUSTOMERS, CUSTOMERS_SCHEMA);
+        assertThat(router.map(createTableEvent))
+                .asSchemaChangeEvent()
+                .hasTableId(NEW_CUSTOMERS)
+                .asCreateTableEvent()
+                .hasSchema(CUSTOMERS_SCHEMA);
+
+        // AddColumnEvent
+        AddColumnEvent.ColumnWithPosition newColumn =
+                new AddColumnEvent.ColumnWithPosition(
+                        Column.physicalColumn("address", DataTypes.STRING()),
+                        AddColumnEvent.ColumnPosition.LAST,
+                        null);
+        AddColumnEvent addColumnEvent =
+                new AddColumnEvent(CUSTOMERS, Collections.singletonList(newColumn));
+        assertThat(router.map(addColumnEvent))
+                .asSchemaChangeEvent()
+                .asAddColumnEvent()
+                .hasTableId(NEW_CUSTOMERS)
+                .containsAddedColumns(newColumn);
+
+        // DropColumnEvent
+        PhysicalColumn droppedColumn = Column.physicalColumn("address", DataTypes.STRING());
+        List<Column> droppedColumns = Collections.singletonList(droppedColumn);
+        DropColumnEvent dropColumnEvent = new DropColumnEvent(CUSTOMERS, droppedColumns);
+        assertThat(router.map(dropColumnEvent))
+                .asSchemaChangeEvent()
+                .asDropColumnEvent()
+                .containsDroppedColumns(droppedColumn)
+                .hasTableId(NEW_CUSTOMERS);
+
+        // RenameColumnEvent
+        Map<String, String> columnRenaming = ImmutableMap.of("phone", "mobile");
+        RenameColumnEvent renameColumnEvent = new RenameColumnEvent(CUSTOMERS, columnRenaming);
+        assertThat(router.map(renameColumnEvent))
+                .asSchemaChangeEvent()
+                .asRenameColumnEvent()
+                .containsNameMapping(columnRenaming)
+                .hasTableId(NEW_CUSTOMERS);
+
+        // AlterColumnTypeEvent
+        Map<String, DataType> typeMapping = ImmutableMap.of("mobile", DataTypes.STRING());
+        AlterColumnTypeEvent alterColumnTypeEvent =
+                new AlterColumnTypeEvent(CUSTOMERS, typeMapping);
+        assertThat(router.map(alterColumnTypeEvent))
+                .asSchemaChangeEvent()
+                .asAlterColumnTypeEvent()
+                .containsTypeMapping(typeMapping)
+                .hasTableId(NEW_CUSTOMERS);
+    }
+}


### PR DESCRIPTION
This pull request implements routing in Flink CDC pipeline, including:

- Introduce the new RouteFunction for actually executing the routing logic in Flink job
- Chaining router into the DataStream by Flink composer

This PR also introduces Assertj-style assertion systems for Flink CDC specific data structure, in order to make the test logic easier to be written.