### PR TITLE
[oracle] Expose ability to skip backfill in snapshot period for Oracle CDC.

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OracleSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OracleSourceBuilder.java
@@ -227,6 +227,22 @@ public class OracleSourceBuilder<T> {
     }
 
     /**
+     * Whether to skip backfill in snapshot reading phase.
+     *
+     * <p>If backfill is skipped, changes on captured tables during snapshot phase will be consumed
+     * later in binlog reading phase instead of being merged into the snapshot.
+     *
+     * <p>WARNING: Skipping backfill might lead to data inconsistency because some binlog events
+     * happened within the snapshot phase might be replayed (only at-least-once semantic is
+     * promised). For example updating an already updated value in snapshot, or deleting an already
+     * deleted entry in snapshot. These replayed binlog events should be handled specially.
+     */
+    public OracleSourceBuilder<T> skipSnapshotBackfill(boolean skipSnapshotBackfill) {
+        this.configFactory.skipSnapshotBackfill(skipSnapshotBackfill);
+        return this;
+    }
+
+    /**
      * Build the {@link OracleIncrementalSource}.
      *
      * @return a OracleParallelSource with the settings made for this builder.

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfig.java
@@ -61,7 +61,8 @@ public class OracleSourceConfig extends JdbcSourceConfig {
             Duration connectTimeout,
             int connectMaxRetries,
             int connectionPoolSize,
-            String chunkKeyColumn) {
+            String chunkKeyColumn,
+            boolean skipSnapshotBackfill) {
         super(
                 startupOptions,
                 databaseList,
@@ -86,7 +87,7 @@ public class OracleSourceConfig extends JdbcSourceConfig {
                 connectMaxRetries,
                 connectionPoolSize,
                 chunkKeyColumn,
-                true);
+                skipSnapshotBackfill);
         this.url = url;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfigFactory.java
@@ -130,6 +130,7 @@ public class OracleSourceConfigFactory extends JdbcSourceConfigFactory {
                 connectTimeout,
                 connectMaxRetries,
                 connectionPoolSize,
-                chunkKeyColumn);
+                chunkKeyColumn,
+                skipSnapshotBackfill);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
@@ -116,7 +116,17 @@ public class OracleScanFetchTask extends AbstractScanFetchTask {
                 context.getSourceConfig()
                         .getDbzConfiguration()
                         .edit()
-                        .with("table.include.list", snapshotSplit.getTableId().toString())
+                        // It will cause data loss before.
+                        // Because the table name contains the database
+                        // prefix when logminer queries the redo log, but in fact the
+                        // logminer content does not contain the database prefix,
+                        // this will cause the back fill tofail,
+                        // thereby affecting data consistency.
+                        .with(
+                                "table.include.list",
+                                String.format(
+                                        "%s.%s",
+                                        snapshotSplit.getTableId().schema(), snapshotSplit.getTableId().table()))
                         // Disable heartbeat event in snapshot split fetcher
                         .with(Heartbeat.HEARTBEAT_INTERVAL, 0)
                         .build();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
@@ -126,7 +126,8 @@ public class OracleScanFetchTask extends AbstractScanFetchTask {
                                 "table.include.list",
                                 String.format(
                                         "%s.%s",
-                                        snapshotSplit.getTableId().schema(), snapshotSplit.getTableId().table()))
+                                        snapshotSplit.getTableId().schema(),
+                                        snapshotSplit.getTableId().table()))
                         // Disable heartbeat event in snapshot split fetcher
                         .with(Heartbeat.HEARTBEAT_INTERVAL, 0)
                         .build();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSource.java
@@ -78,6 +78,7 @@ public class OracleTableSource implements ScanTableSource, SupportsReadingMetada
     private final double distributionFactorLower;
     private final String chunkKeyColumn;
     private final boolean closeIdleReaders;
+    private final boolean skipSnapshotBackfill;
 
     // --------------------------------------------------------------------------------------------
     // Mutable attributes
@@ -111,7 +112,8 @@ public class OracleTableSource implements ScanTableSource, SupportsReadingMetada
             double distributionFactorUpper,
             double distributionFactorLower,
             @Nullable String chunkKeyColumn,
-            boolean closeIdleReaders) {
+            boolean closeIdleReaders,
+            boolean skipSnapshotBackfill) {
         this.physicalSchema = physicalSchema;
         this.url = url;
         this.port = port;
@@ -136,6 +138,7 @@ public class OracleTableSource implements ScanTableSource, SupportsReadingMetada
         this.distributionFactorLower = distributionFactorLower;
         this.chunkKeyColumn = chunkKeyColumn;
         this.closeIdleReaders = closeIdleReaders;
+        this.skipSnapshotBackfill = skipSnapshotBackfill;
     }
 
     @Override
@@ -182,6 +185,7 @@ public class OracleTableSource implements ScanTableSource, SupportsReadingMetada
                             .distributionFactorUpper(distributionFactorUpper)
                             .distributionFactorLower(distributionFactorLower)
                             .closeIdleReaders(closeIdleReaders)
+                            .skipSnapshotBackfill(skipSnapshotBackfill)
                             .build();
 
             return SourceProvider.of(oracleChangeEventSource);
@@ -246,7 +250,8 @@ public class OracleTableSource implements ScanTableSource, SupportsReadingMetada
                         distributionFactorUpper,
                         distributionFactorLower,
                         chunkKeyColumn,
-                        closeIdleReaders);
+                        closeIdleReaders,
+                        skipSnapshotBackfill);
         source.metadataKeys = metadataKeys;
         source.producedDataType = producedDataType;
         return source;
@@ -284,7 +289,8 @@ public class OracleTableSource implements ScanTableSource, SupportsReadingMetada
                 && Objects.equals(distributionFactorUpper, that.distributionFactorUpper)
                 && Objects.equals(distributionFactorLower, that.distributionFactorLower)
                 && Objects.equals(chunkKeyColumn, that.chunkKeyColumn)
-                && Objects.equals(closeIdleReaders, that.closeIdleReaders);
+                && Objects.equals(closeIdleReaders, that.closeIdleReaders)
+                && Objects.equals(skipSnapshotBackfill, that.skipSnapshotBackfill);
     }
 
     @Override
@@ -313,7 +319,8 @@ public class OracleTableSource implements ScanTableSource, SupportsReadingMetada
                 distributionFactorUpper,
                 distributionFactorLower,
                 chunkKeyColumn,
-                closeIdleReaders);
+                closeIdleReaders,
+                skipSnapshotBackfill);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactory.java
@@ -41,10 +41,10 @@ import static com.ververica.cdc.connectors.base.options.JdbcSourceOptions.HOSTNA
 import static com.ververica.cdc.connectors.base.options.JdbcSourceOptions.PASSWORD;
 import static com.ververica.cdc.connectors.base.options.JdbcSourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED;
 import static com.ververica.cdc.connectors.base.options.JdbcSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN;
-import static com.ververica.cdc.connectors.base.options.JdbcSourceOptions.SERVER_TIME_ZONE;
 import static com.ververica.cdc.connectors.base.options.JdbcSourceOptions.TABLE_NAME;
 import static com.ververica.cdc.connectors.base.options.JdbcSourceOptions.USERNAME;
 import static com.ververica.cdc.connectors.base.options.SourceOptions.CHUNK_META_GROUP_SIZE;
+import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP;
 import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE;
 import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED;
 import static com.ververica.cdc.connectors.base.options.SourceOptions.SCAN_SNAPSHOT_FETCH_SIZE;
@@ -92,9 +92,9 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
         double distributionFactorLower = config.get(SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND);
         String chunkKeyColumn =
                 config.getOptional(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN).orElse(null);
-        String serverTimezone = config.get(SERVER_TIME_ZONE);
 
         boolean closeIdlerReaders = config.get(SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED);
+        boolean skipSnapshotBackfill = config.get(SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
 
         if (enableParallelRead) {
             validateIntegerOption(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE, splitSize, 1);
@@ -130,7 +130,8 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
                 distributionFactorUpper,
                 distributionFactorLower,
                 chunkKeyColumn,
-                closeIdlerReaders);
+                closeIdlerReaders,
+                skipSnapshotBackfill);
     }
 
     @Override
@@ -167,6 +168,7 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
         options.add(SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND);
         options.add(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN);
         options.add(SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED);
+        options.add(SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
         return options;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/source/OracleSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/source/OracleSourceITCase.java
@@ -17,15 +17,27 @@
 package com.ververica.cdc.connectors.oracle.source;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.runtime.highavailability.nonha.embedded.HaLeadershipControl;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
+import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
+import com.ververica.cdc.connectors.base.options.StartupOptions;
+import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHook;
+import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHooks;
+import com.ververica.cdc.connectors.oracle.source.utils.OracleConnectionUtils;
+import com.ververica.cdc.connectors.oracle.testutils.TestTable;
+import io.debezium.connector.oracle.OracleConnection;
+import io.debezium.jdbc.JdbcConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,14 +49,22 @@ import java.sql.Connection;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static org.apache.flink.table.api.DataTypes.BIGINT;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.catalog.Column.physical;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /** IT tests for {@link OracleSourceBuilder.OracleIncrementalSource}. */
 public class OracleSourceITCase extends OracleSourceTestBase {
+    private static final int USE_POST_LOWWATERMARK_HOOK = 1;
+    private static final int USE_PRE_HIGHWATERMARK_HOOK = 2;
 
     private static final Logger LOG = LoggerFactory.getLogger(OracleSourceITCase.class);
 
@@ -99,6 +119,236 @@ public class OracleSourceITCase extends OracleSourceTestBase {
                 1, FailoverType.JM, FailoverPhase.SNAPSHOT, new String[] {"CUSTOMERS"});
     }
 
+    @Test
+    public void testReadSingleTableWithSingleParallelismAndSkipBackfill() throws Exception {
+        testOracleParallelSource(
+                DEFAULT_PARALLELISM,
+                FailoverType.TM,
+                FailoverPhase.SNAPSHOT,
+                new String[] {"CUSTOMERS"},
+                true);
+    }
+
+    @Test
+    public void testEnableBackfillWithDMLPreHighWaterMark() throws Exception {
+
+        List<String> records = testBackfillWhenWritingEvents(false, 21, USE_PRE_HIGHWATERMARK_HOOK);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Pittsburgh, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]");
+        // when enable backfill, the wal log between (snapshot,  high_watermark) will be
+        // applied as snapshot image
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    @Test
+    public void testEnableBackfillWithDMLPostLowWaterMark() throws Exception {
+        List<String> records = testBackfillWhenWritingEvents(false, 21, USE_POST_LOWWATERMARK_HOOK);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Pittsburgh, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]");
+        // when enable backfill, the wal log between [low_watermark, snapshot) will be applied
+        // as snapshot image
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    @Test
+    public void testSkipBackfillWithDMLPreHighWaterMark() throws Exception {
+        List<String> records = testBackfillWhenWritingEvents(true, 25, USE_PRE_HIGHWATERMARK_HOOK);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[1019, user_20, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Shanghai, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]",
+                        "-U[2000, user_21, Shanghai, 123567891234]",
+                        "+U[2000, user_21, Pittsburgh, 123567891234]",
+                        "-D[1019, user_20, Shanghai, 123567891234]");
+        // when skip backfill, the wal log between (snapshot,  high_watermark) will be seen as
+        // stream event.
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    @Test
+    public void testSkipBackfillWithDMLPostLowWaterMark() throws Exception {
+
+        List<String> records = testBackfillWhenWritingEvents(true, 25, USE_POST_LOWWATERMARK_HOOK);
+
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Pittsburgh, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]",
+                        "-U[2000, user_21, Shanghai, 123567891234]",
+                        "+U[2000, user_21, Pittsburgh, 123567891234]",
+                        "-D[1019, user_20, Shanghai, 123567891234]");
+        // when skip backfill, the wal log between (snapshot,  high_watermark) will still be
+        // seen as stream event. This will occur data duplicate. For example, user_20 will be
+        // deleted twice, and user_15213 will be inserted twice.
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    private List<String> testBackfillWhenWritingEvents(
+            boolean skipSnapshotBackfill, int fetchSize, int hookType) throws Exception {
+        createAndInitialize("customer.sql");
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(200L);
+        env.setParallelism(1);
+
+        ResolvedSchema customersSchame =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                physical("ID", BIGINT().notNull()),
+                                physical("NAME", STRING()),
+                                physical("ADDRESS", STRING()),
+                                physical("PHONE_NUMBER", STRING())),
+                        new ArrayList<>(),
+                        UniqueConstraint.primaryKey("pk", Collections.singletonList("ID")));
+        TestTable customerTable =
+                new TestTable(ORACLE_DATABASE, ORACLE_SCHEMA, "CUSTOMERS", customersSchame);
+        String tableId = customerTable.getTableId();
+
+        OracleSourceBuilder.OracleIncrementalSource source =
+                OracleSourceBuilder.OracleIncrementalSource.<RowData>builder()
+                        .hostname(ORACLE_CONTAINER.getHost())
+                        .port(ORACLE_CONTAINER.getOraclePort())
+                        .username(CONNECTOR_USER)
+                        .password(CONNECTOR_PWD)
+                        .databaseList(ORACLE_DATABASE)
+                        .schemaList(ORACLE_SCHEMA)
+                        .tableList("DEBEZIUM.CUSTOMERS")
+                        .skipSnapshotBackfill(skipSnapshotBackfill)
+                        .startupOptions(StartupOptions.initial())
+                        .deserializer(customerTable.getDeserializer())
+                        .build();
+
+        // Do some database operations during hook in snapshot period.
+        SnapshotPhaseHooks hooks = new SnapshotPhaseHooks();
+        String[] statements =
+                new String[] {
+                    String.format(
+                            "INSERT INTO %s VALUES (15213, 'user_15213', 'Shanghai', '123567891234')",
+                            tableId),
+                    String.format("UPDATE %s SET address='Pittsburgh' WHERE id=2000", tableId),
+                    String.format("DELETE FROM %s WHERE id=1019", tableId)
+                };
+        SnapshotPhaseHook snapshotPhaseHook =
+                (sourceConfig, split) -> {
+                    // database update operations use TEST_USER rather than CONNECTOR_USER
+                    JdbcConfiguration configuration =
+                            JdbcConfiguration.copy(
+                                            ((JdbcSourceConfig) sourceConfig)
+                                                    .getDbzConnectorConfig()
+                                                    .getJdbcConfig())
+                                    .withUser("debezium")
+                                    .withPassword("dbz")
+                                    .build();
+                    try (OracleConnection oracleConnection =
+                            OracleConnectionUtils.createOracleConnection(configuration)) {
+                        oracleConnection.execute(statements);
+                        Thread.sleep(500L);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                };
+
+        if (hookType == USE_POST_LOWWATERMARK_HOOK) {
+            hooks.setPostLowWatermarkAction(snapshotPhaseHook);
+        } else if (hookType == USE_PRE_HIGHWATERMARK_HOOK) {
+            hooks.setPreHighWatermarkAction(snapshotPhaseHook);
+        }
+        source.setSnapshotHooks(hooks);
+
+        List<String> records = new ArrayList<>();
+        try (CloseableIterator<RowData> iterator =
+                env.fromSource(source, WatermarkStrategy.noWatermarks(), "Backfill Skipped Source")
+                        .executeAndCollect()) {
+            records = fetchRowData(iterator, fetchSize, customerTable::stringify);
+            env.close();
+        }
+        return records;
+    }
+
     private void testOracleParallelSource(
             FailoverType failoverType, FailoverPhase failoverPhase, String[] captureCustomerTables)
             throws Exception {
@@ -111,6 +361,17 @@ public class OracleSourceITCase extends OracleSourceTestBase {
             FailoverType failoverType,
             FailoverPhase failoverPhase,
             String[] captureCustomerTables)
+            throws Exception {
+        testOracleParallelSource(
+                parallelism, failoverType, failoverPhase, captureCustomerTables, false);
+    }
+
+    private void testOracleParallelSource(
+            int parallelism,
+            FailoverType failoverType,
+            FailoverPhase failoverPhase,
+            String[] captureCustomerTables,
+            boolean skipSnapshotBackfill)
             throws Exception {
         createAndInitialize("customer.sql");
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -139,7 +400,8 @@ public class OracleSourceITCase extends OracleSourceTestBase {
                                 + " 'table-name' = '%s',"
                                 + " 'scan.incremental.snapshot.enabled' = 'false',"
                                 + " 'debezium.log.mining.strategy' = 'online_catalog',"
-                                + " 'debezium.database.history.store.only.captured.tables.ddl' = 'true'"
+                                + " 'debezium.database.history.store.only.captured.tables.ddl' = 'true',"
+                                + " 'scan.incremental.snapshot.backfill.skip' = '%s'"
                                 + ")",
                         ORACLE_CONTAINER.getHost(),
                         ORACLE_CONTAINER.getOraclePort(),
@@ -147,8 +409,8 @@ public class OracleSourceITCase extends OracleSourceTestBase {
                         ORACLE_CONTAINER.getPassword(),
                         ORACLE_DATABASE,
                         ORACLE_SCHEMA,
-                        getTableNameRegex(captureCustomerTables) // (customer|customer_1)
-                        );
+                        getTableNameRegex(captureCustomerTables), // (customer|customer_1)
+                        skipSnapshotBackfill);
 
         // first step: check the snapshot data
         String[] snapshotForSingleTable =
@@ -248,6 +510,17 @@ public class OracleSourceITCase extends OracleSourceTestBase {
             Thread.sleep(millis);
         } catch (InterruptedException ignored) {
         }
+    }
+
+    private static List<String> fetchRowData(
+            Iterator<RowData> iter, int size, Function<RowData, String> stringifier) {
+        List<RowData> rows = new ArrayList<>(size);
+        while (size > 0 && iter.hasNext()) {
+            RowData row = iter.next();
+            rows.add(row);
+            size--;
+        }
+        return rows.stream().map(stringifier).collect(Collectors.toList());
     }
 
     private static List<String> fetchRows(Iterator<Row> iter, int size) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
@@ -119,8 +119,8 @@ public class OracleTableSourceFactoryTest {
                         JdbcSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND
                                 .defaultValue(),
                         null,
-                        JdbcSourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED
-                                .defaultValue());
+                        JdbcSourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue(),
+                        JdbcSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -155,7 +155,8 @@ public class OracleTableSourceFactoryTest {
                         JdbcSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND
                                 .defaultValue(),
                         null,
-                        SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue());
+                        SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue(),
+                        SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -194,7 +195,8 @@ public class OracleTableSourceFactoryTest {
                         JdbcSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND
                                 .defaultValue(),
                         null,
-                        SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue());
+                        SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue(),
+                        SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -219,6 +221,7 @@ public class OracleTableSourceFactoryTest {
         options.put(SourceOptions.CHUNK_META_GROUP_SIZE.key(), String.valueOf(splitMetaGroupSize));
         options.put(SourceOptions.SCAN_SNAPSHOT_FETCH_SIZE.key(), String.valueOf(fetchSize));
         options.put(SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.key(), "true");
+        options.put(SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.key(), "true");
 
         options.put(
                 JdbcSourceOptions.CONNECT_TIMEOUT.key(),
@@ -258,6 +261,7 @@ public class OracleTableSourceFactoryTest {
                         distributionFactorUpper,
                         distributionFactorLower,
                         null,
+                        true,
                         true);
         assertEquals(expectedSource, actualSource);
     }
@@ -294,7 +298,8 @@ public class OracleTableSourceFactoryTest {
                         JdbcSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND
                                 .defaultValue(),
                         null,
-                        SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue());
+                        SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue(),
+                        SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -330,7 +335,8 @@ public class OracleTableSourceFactoryTest {
                         JdbcSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND
                                 .defaultValue(),
                         null,
-                        SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue());
+                        SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue(),
+                        SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -370,7 +376,8 @@ public class OracleTableSourceFactoryTest {
                         JdbcSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND
                                 .defaultValue(),
                         null,
-                        SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue());
+                        SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue(),
+                        SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
         expectedSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
         expectedSource.metadataKeys =
                 Arrays.asList("op_ts", "database_name", "table_name", "schema_name");

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/testutils/RecordsFormatter.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/testutils/RecordsFormatter.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.oracle.testutils;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.conversion.RowRowConverter;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Collector;
+
+import com.ververica.cdc.connectors.base.utils.SourceRecordUtils;
+import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import com.ververica.cdc.debezium.table.RowDataDebeziumDeserializeSchema;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Formatter that formats the {@link org.apache.kafka.connect.source.SourceRecord} to String. */
+public class RecordsFormatter {
+
+    private final DataType dataType;
+    private final ZoneId zoneId;
+
+    private TypeInformation<RowData> typeInfo;
+    private DebeziumDeserializationSchema<RowData> deserializationSchema;
+    private SimpleCollector collector;
+    private RowRowConverter rowRowConverter;
+
+    public RecordsFormatter(DataType dataType) {
+        this(dataType, ZoneId.of("UTC"));
+    }
+
+    public RecordsFormatter(DataType dataType, ZoneId zoneId) {
+        this.dataType = dataType;
+        this.zoneId = zoneId;
+        this.typeInfo =
+                (TypeInformation<RowData>) TypeConversions.fromDataTypeToLegacyInfo(dataType);
+        this.deserializationSchema =
+                RowDataDebeziumDeserializeSchema.newBuilder()
+                        .setPhysicalRowType((RowType) dataType.getLogicalType())
+                        .setResultTypeInfo(typeInfo)
+                        .build();
+        this.collector = new SimpleCollector();
+        this.rowRowConverter = RowRowConverter.create(dataType);
+        rowRowConverter.open(Thread.currentThread().getContextClassLoader());
+    }
+
+    public List<String> format(List<SourceRecord> records) {
+        records.stream()
+                // Keep DataChangeEvent only
+                .filter(SourceRecordUtils::isDataChangeRecord)
+                .forEach(
+                        r -> {
+                            try {
+                                deserializationSchema.deserialize(r, collector);
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+        return collector.list.stream()
+                .map(rowRowConverter::toExternal)
+                .map(Row::toString)
+                .collect(Collectors.toList());
+    }
+
+    private static class SimpleCollector implements Collector<RowData> {
+
+        private List<RowData> list = new ArrayList<>();
+
+        @Override
+        public void collect(RowData record) {
+            list.add(record);
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/testutils/TestTable.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/testutils/TestTable.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.oracle.testutils;
+
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.conversion.RowRowConverter;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+
+import com.ververica.cdc.connectors.oracle.table.OracleDeserializationConverterFactory;
+import com.ververica.cdc.debezium.table.RowDataDebeziumDeserializeSchema;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.util.List;
+
+/**
+ * Test utility for creating converter, formatter and deserializer of a table in the test database.
+ */
+public class TestTable {
+
+    private final String databaseName;
+    private final String tableName;
+
+    private final String schemaName;
+
+    private final ResolvedSchema schema;
+
+    // Lazily initialized components
+    private RowRowConverter rowRowConverter;
+    private RowDataDebeziumDeserializeSchema deserializer;
+    private RecordsFormatter recordsFormatter;
+
+    public TestTable(
+            String databaseName, String schemaName, String tableName, ResolvedSchema schema) {
+        this.databaseName = databaseName;
+        this.schemaName = schemaName;
+        this.tableName = tableName;
+        this.schema = schema;
+    }
+
+    public String getTableId() {
+        return String.format("%s.%s", schemaName, tableName);
+    }
+
+    public RowType getRowType() {
+        return (RowType) schema.toPhysicalRowDataType().getLogicalType();
+    }
+
+    public RowDataDebeziumDeserializeSchema getDeserializer() {
+        if (deserializer == null) {
+            deserializer =
+                    RowDataDebeziumDeserializeSchema.newBuilder()
+                            .setPhysicalRowType(getRowType())
+                            .setResultTypeInfo(InternalTypeInfo.of(getRowType()))
+                            .setUserDefinedConverterFactory(
+                                    OracleDeserializationConverterFactory.instance())
+                            .build();
+        }
+        return deserializer;
+    }
+
+    public RowRowConverter getRowRowConverter() {
+        if (rowRowConverter == null) {
+            rowRowConverter = RowRowConverter.create(schema.toPhysicalRowDataType());
+        }
+        return rowRowConverter;
+    }
+
+    public RecordsFormatter getRecordsFormatter() {
+        if (recordsFormatter == null) {
+            recordsFormatter = new RecordsFormatter(schema.toPhysicalRowDataType());
+        }
+        return recordsFormatter;
+    }
+
+    public String stringify(RowData rowData) {
+        return getRowRowConverter().toExternal(rowData).toString();
+    }
+
+    public List<String> stringify(List<SourceRecord> sourceRecord) {
+        return getRecordsFormatter().format(sourceRecord);
+    }
+}


### PR DESCRIPTION
As shown in https://github.com/ververica/flink-cdc-connectors/issues/2553, this PR exposes the  skip backfill ability to oracle.