### PR TITLE
[cdc-composer] Add common and runtime JAR on submit

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/pom.xml
@@ -34,12 +34,14 @@ under the License.
             <groupId>com.ververica</groupId>
             <artifactId>flink-cdc-common</artifactId>
             <version>${revision}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.ververica</groupId>
             <artifactId>flink-cdc-runtime</artifactId>
             <version>${revision}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This pull request adds a logic in composer that discovers runtime and common JARs (usually the same one `flink-cdc-dist`) and submit then to the Flink cluster together with job graph. 

The dependencies of `flink-cdc-pipeline-connectors` are marked as `provided`, in order to not bundling `flink-cdc-runtime` and `flink-cdc-common` into connector JARs.