### PR TITLE
[cdc-connector][sqlserver][tests] Fix UT errors by increasing the wait time after committing SQL

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/source/SqlServerSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/source/SqlServerSourceITCase.java
@@ -310,12 +310,12 @@ public class SqlServerSourceITCase extends SqlServerSourceTestBase {
                 (sourceConfig, split) -> {
                     SqlServerDialect dialect =
                             new SqlServerDialect((SqlServerSourceConfig) sourceConfig);
-                    JdbcConnection postgresConnection =
+                    JdbcConnection sqlServerConnection =
                             dialect.openJdbcConnection((JdbcSourceConfig) sourceConfig);
-                    postgresConnection.execute(statements);
-                    postgresConnection.commit();
+                    sqlServerConnection.execute(statements);
+                    sqlServerConnection.commit();
                     try {
-                        Thread.sleep(1000L);
+                        Thread.sleep(5000L);
                     } catch (InterruptedException e) {
                         throw new RuntimeException(e);
                     }


### PR DESCRIPTION
 Fix UT errors by increasing the wait time after committing SQL.
 commit() can't be  not effective when wait 1s. So change 1s to 5s.
<img width="1567" alt="image" src="https://github.com/ververica/flink-cdc-connectors/assets/9883232/81b9f3df-ad24-4412-b2c7-a2b09efcfa75">
