### PR TITLE
[cdc-runtime] SchemaRegistry should complete the future after making the checkpoint

### DIFF
--- a/flink-cdc-runtime/src/main/java/com/ververica/cdc/runtime/operators/schema/coordinator/SchemaRegistry.java
+++ b/flink-cdc-runtime/src/main/java/com/ververica/cdc/runtime/operators/schema/coordinator/SchemaRegistry.java
@@ -140,6 +140,7 @@ public class SchemaRegistry implements OperatorCoordinator, CoordinationRequestH
             byte[] serializedSchemaManager = SchemaManager.SERIALIZER.serialize(schemaManager);
             out.writeInt(serializedSchemaManager.length);
             out.write(serializedSchemaManager);
+            resultFuture.complete(baos.toByteArray());
         }
     }
 


### PR DESCRIPTION
This pull request fixes a bug that SchemaRegistry doesn't complete the future after creating the checkpoint, which blocks the checkpoint to proceed anymore.