### PR TITLE
[pipeline-common] use column name to judge whether a column is existed in a specific schema.

### DIFF
--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/utils/SchemaUtils.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/utils/SchemaUtils.java
@@ -89,7 +89,11 @@ public class SchemaUtils {
                         Preconditions.checkNotNull(
                                 columnWithPosition.getExistingColumn(),
                                 "existingColumn could not be null in BEFORE type AddColumnEvent");
-                        int index = columns.indexOf(columnWithPosition.getExistingColumn());
+                        List<String> columnNames =
+                                columns.stream().map(Column::getName).collect(Collectors.toList());
+                        int index =
+                                columnNames.indexOf(
+                                        columnWithPosition.getExistingColumn().getName());
                         if (index < 0) {
                             throw new IllegalArgumentException(
                                     columnWithPosition.getExistingColumn().getName()
@@ -103,7 +107,11 @@ public class SchemaUtils {
                         Preconditions.checkNotNull(
                                 columnWithPosition.getExistingColumn(),
                                 "existingColumn could not be null in AFTER type AddColumnEvent");
-                        int index = columns.indexOf(columnWithPosition.getExistingColumn());
+                        List<String> columnNames =
+                                columns.stream().map(Column::getName).collect(Collectors.toList());
+                        int index =
+                                columnNames.indexOf(
+                                        columnWithPosition.getExistingColumn().getName());
                         if (index < 0) {
                             throw new IllegalArgumentException(
                                     columnWithPosition.getExistingColumn().getName()


### PR DESCRIPTION
Will use name instead of Column for some SchemaChangeEvent in the future.