### PR TITLE
[build] Let surefire plugin to keep the full stacktrace on test failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,6 +406,7 @@ under the License.
                 <configuration>
                     <forkCount>${flink.forkCount}</forkCount>
                     <reuseForks>${flink.reuseForks}</reuseForks>
+                    <trimStackTrace>false</trimStackTrace>
                     <systemPropertyVariables>
                         <forkNumber>0${surefire.forkNumber}</forkNumber>
                     </systemPropertyVariables>


### PR DESCRIPTION
This pull request sets `trimStacktrace` to false in maven-surefire-plugin to keep the full stacktrace on test failure.