### PR TITLE
[cdc-cli][cdc-composer][cdc-dist] Support submitting job to general Flink environment

### DIFF
--- a/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/utils/FlinkEnvironmentUtils.java
+++ b/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/utils/FlinkEnvironmentUtils.java
@@ -16,8 +16,6 @@
 
 package com.ververica.cdc.cli.utils;
 
-import com.ververica.cdc.common.configuration.ConfigOption;
-import com.ververica.cdc.common.configuration.ConfigOptions;
 import com.ververica.cdc.common.configuration.Configuration;
 import com.ververica.cdc.composer.flink.FlinkPipelineComposer;
 
@@ -30,12 +28,6 @@ public class FlinkEnvironmentUtils {
     private static final String FLINK_CONF_DIR = "conf";
     private static final String FLINK_CONF_FILENAME = "flink-conf.yaml";
 
-    public static final ConfigOption<String> FLINK_REST_ADDRESS =
-            ConfigOptions.key("rest.address").stringType().noDefaultValue();
-
-    public static final ConfigOption<Integer> FLINK_REST_PORT =
-            ConfigOptions.key("rest.port").intType().defaultValue(8081);
-
     public static Configuration loadFlinkConfiguration(Path flinkHome) throws Exception {
         Path flinkConfPath = flinkHome.resolve(FLINK_CONF_DIR).resolve(FLINK_CONF_FILENAME);
         return ConfigurationUtils.loadMapFormattedConfig(flinkConfPath);
@@ -46,8 +38,8 @@ public class FlinkEnvironmentUtils {
         if (useMiniCluster) {
             return FlinkPipelineComposer.ofMiniCluster();
         }
-        String host = flinkConfig.get(FLINK_REST_ADDRESS);
-        Integer port = flinkConfig.get(FLINK_REST_PORT);
-        return FlinkPipelineComposer.ofRemoteCluster(host, port, additionalJars);
+        return FlinkPipelineComposer.ofRemoteCluster(
+                org.apache.flink.configuration.Configuration.fromMap(flinkConfig.toMap()),
+                additionalJars);
     }
 }

--- a/flink-cdc-cli/src/test/java/com/ververica/cdc/cli/CliFrontendTest.java
+++ b/flink-cdc-cli/src/test/java/com/ververica/cdc/cli/CliFrontendTest.java
@@ -18,7 +18,6 @@ package com.ververica.cdc.cli;
 
 import org.apache.flink.shaded.guava31.com.google.common.io.Resources;
 
-import com.ververica.cdc.cli.utils.FlinkEnvironmentUtils;
 import com.ververica.cdc.composer.PipelineComposer;
 import com.ververica.cdc.composer.PipelineExecution;
 import com.ververica.cdc.composer.definition.PipelineDef;
@@ -69,15 +68,6 @@ class CliFrontendTest {
                         "Cannot find Flink home from either command line arguments \"--flink-home\" "
                                 + "or the environment variable \"FLINK_HOME\". "
                                 + "Please make sure Flink home is properly set. ");
-    }
-
-    @Test
-    void testFlinkConfigParsing() throws Exception {
-        CliExecutor executor = createExecutor(pipelineDef(), "--flink-home", flinkHome());
-        assertThat(executor.getFlinkConfig().get(FlinkEnvironmentUtils.FLINK_REST_ADDRESS))
-                .isEqualTo("localhost");
-        assertThat(executor.getFlinkConfig().get(FlinkEnvironmentUtils.FLINK_REST_PORT))
-                .isEqualTo(8081);
     }
 
     @Test


### PR DESCRIPTION
This pull request adds support to submit Flink CDC pipeline job to more Flink deployments, such as YARN. 

Please note that there are still many things that can be improved comparing to the native `flink run` or SQL client. For example to submit to a YARN session cluster, user needs to set `execution.target: yarn-session` and `yarn-application-id: {flink-app-id}` in order to make everything works.