### PR TITLE
[cdc-cli][cdc-dist] Support loading global config from FLINK_CDC_HOME

### DIFF
--- a/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/parser/YamlPipelineDefinitionParser.java
+++ b/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/parser/YamlPipelineDefinitionParser.java
@@ -148,7 +148,7 @@ public class YamlPipelineDefinitionParser implements PipelineDefinitionParser {
     }
 
     private Configuration toPipelineConfig(JsonNode pipelineConfigNode) {
-        if (pipelineConfigNode == null) {
+        if (pipelineConfigNode == null || pipelineConfigNode.isNull()) {
             return new Configuration();
         }
         Map<String, String> pipelineConfigMap =

--- a/flink-cdc-dist/src/main/flink-cdc-bin/bin/flink-cdc.sh
+++ b/flink-cdc-dist/src/main/flink-cdc-bin/bin/flink-cdc.sh
@@ -44,6 +44,7 @@ FLINK_CONF_DIR=$FLINK_HOME/conf
 # Define Flink CDC directories
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 FLINK_CDC_HOME="$SCRIPT_DIR"/..
+export FLINK_CDC_HOME=$FLINK_CDC_HOME
 FLINK_CDC_CONF="$FLINK_CDC_HOME"/conf
 FLINK_CDC_LIB="$FLINK_CDC_HOME"/lib
 FLINK_CDC_LOG="$FLINK_CDC_HOME"/log

--- a/flink-cdc-dist/src/main/flink-cdc-bin/conf/flink-cdc.yaml
+++ b/flink-cdc-dist/src/main/flink-cdc-bin/conf/flink-cdc.yaml
@@ -1,14 +1,20 @@
-<!--
-  Copyright 2023 Ververica Inc.
-  
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
-  -->
+################################################################################
+#  Copyright 2023 Ververica Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+################################################################################
+
+# Parallelism of the pipeline
+parallelism: 4
+
+# Behavior for handling schema change events from source
+schema.change.behavior: EVOLVE


### PR DESCRIPTION
This pull request adds support to read global pipeline config from FLINK_CDC_HOME/conf/flink-cdc.yaml.