### PR TITLE
[BP-3.0][cdc-cli][cdc-composer] Use "source-table" and "sink-table" as keywords of route

### DIFF
--- a/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/parser/YamlPipelineDefinitionParser.java
+++ b/flink-cdc-cli/src/main/java/com/ververica/cdc/cli/parser/YamlPipelineDefinitionParser.java
@@ -49,8 +49,8 @@ public class YamlPipelineDefinitionParser implements PipelineDefinitionParser {
     private static final String NAME_KEY = "name";
 
     // Route keys
-    private static final String ROUTE_SOURCE_TABLE_KEY = "sourceTable";
-    private static final String ROUTE_SINK_TABLE_KEY = "sinkTable";
+    private static final String ROUTE_SOURCE_TABLE_KEY = "source-table";
+    private static final String ROUTE_SINK_TABLE_KEY = "sink-table";
     private static final String ROUTE_DESCRIPTION_KEY = "description";
 
     private final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());

--- a/flink-cdc-cli/src/test/resources/definitions/pipeline-definition-full.yaml
+++ b/flink-cdc-cli/src/test/resources/definitions/pipeline-definition-full.yaml
@@ -30,11 +30,11 @@ sink:
   auto-create-table: true
 
 route:
-  - sourceTable: mydb.default.app_order_.*
-    sinkTable: odsdb.default.app_order
+  - source-table: mydb.default.app_order_.*
+    sink-table: odsdb.default.app_order
     description: sync all sharding tables to one
-  - sourceTable: mydb.default.web_order
-    sinkTable: odsdb.default.ods_web_order
+  - source-table: mydb.default.web_order
+    sink-table: odsdb.default.ods_web_order
     description: sync table to with given prefix ods_
 
 transform:

--- a/flink-cdc-cli/src/test/resources/definitions/pipeline-definition-with-optional.yaml
+++ b/flink-cdc-cli/src/test/resources/definitions/pipeline-definition-with-optional.yaml
@@ -25,8 +25,8 @@ sink:
   bootstrap-servers: localhost:9092
 
 route:
-  - sourceTable: mydb.default.app_order_.*
-    sinkTable: odsdb.default.app_order
+  - source-table: mydb.default.app_order_.*
+    sink-table: odsdb.default.app_order
 
 pipeline:
   parallelism: 4

--- a/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/RouteDef.java
+++ b/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/definition/RouteDef.java
@@ -27,8 +27,8 @@ import java.util.Optional;
  * <p>A router definition contains:
  *
  * <ul>
- *   <li>matcher: a regex pattern for matching input table IDs. Required for the definition.
- *   <li>replace: a string for replacing matched table IDs as output. Required for the definition.
+ *   <li>sourceTable: a regex pattern for matching input table IDs. Required for the definition.
+ *   <li>sinkTable: a string for replacing matched table IDs as output. Required for the definition.
  *   <li>description: description for the router. Optional for the definition.
  * </ul>
  */
@@ -58,9 +58,9 @@ public class RouteDef {
     @Override
     public String toString() {
         return "RouteDef{"
-                + "matcher="
+                + "sourceTable="
                 + sourceTable
-                + ", replace="
+                + ", sinkTable="
                 + sinkTable
                 + ", description='"
                 + description


### PR DESCRIPTION
Unchanged backport of #2823 on release-3.0