### PR TITLE
[docs] Fix overview docs to remove prefix of pipeline options.

### DIFF
--- a/docs/content/overview/cdc-pipeline.md
+++ b/docs/content/overview/cdc-pipeline.md
@@ -97,5 +97,5 @@ For example, we can use this yaml file to define a pipeline:
 ```yaml
 pipeline:
   name: mysql-to-kafka-pipeline
-  pipeline.global.parallelism: 1
+  parallelism: 1
 ```

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/resources/pipeline-test.yaml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/resources/pipeline-test.yaml
@@ -26,4 +26,4 @@ sink:
   name: Values Sink
 
 pipeline:
-  pipeline.global.parallelism: 1
+  parallelism: 1


### PR DESCRIPTION
In https://github.com/ververica/flink-cdc-connectors/pull/2821, prefix of pipeline options is removed. Thus, prefix of pipeline options in overview docs also need to be removed