### PR TITLE
[postgres] Add commits of PostgresConnection back to distinguish with debezium's origin class

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -54,6 +54,14 @@ import java.util.concurrent.atomic.AtomicLong;
  * {@link JdbcConnection} connection extension used for connecting to Postgres instances.
  *
  * @author Horia Chiorean
+ *     <p>Copied from Debezium 1.9.2-Final with two additional methods:
+ *     <ul>
+ *       <li>Constructor PostgresConnection( Configuration config, PostgresValueConverterBuilder
+ *           valueConverterBuilder, ConnectionFactory factory) to allow passing a custom
+ *           ConnectionFactory
+ *       <li>override connection() to return a unwrapped PgConnection (otherwise, it will complain
+ *           about HikariProxyConnection cannot be cast to class org.postgresql.core.BaseConnection)
+ *     </ul>
  */
 public class PostgresConnection extends JdbcConnection {
 


### PR DESCRIPTION
In https://github.com/ververica/flink-cdc-connectors/pull/2156, debezium version is bump to 1.9.7.Final, including PostgresConnection. It's a good thing, however some comments of PostgresConnection to distinguish with debezium's origin class are removed. 

Two additional methods of our PostgresConnection is not included in 1.9.7.Final Debezium's PostgresConnection., so these comment should not be removed.

These comments are important for us for future to track the changes of Debezium's  PostgresConnection. If these two PostgresConnection become same, we will remove it from cdc. Without it, it hard for us to distinguish the changes we did.