### PR TITLE
[cdc-common][pipeline-doris] Fix a typo and fix the doris pipeline connector.

### DIFF
--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/types/utils/DataTypeUtils.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/types/utils/DataTypeUtils.java
@@ -112,7 +112,7 @@ public class DataTypeUtils {
             case DATE:
                 return org.apache.flink.table.api.DataTypes.DATE();
             case TIME_WITHOUT_TIME_ZONE:
-                return org.apache.flink.table.api.DataTypes.TIME(length);
+                return org.apache.flink.table.api.DataTypes.TIME(precision);
             case BIGINT:
                 return org.apache.flink.table.api.DataTypes.BIGINT();
             case FLOAT:
@@ -120,13 +120,13 @@ public class DataTypeUtils {
             case DOUBLE:
                 return org.apache.flink.table.api.DataTypes.DOUBLE();
             case TIMESTAMP_WITHOUT_TIME_ZONE:
-                return org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_TIME_ZONE(length);
-            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-                return org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(length);
             case TIMESTAMP_WITH_TIME_ZONE:
-                return org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_TIME_ZONE(length);
+                return org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_TIME_ZONE(precision);
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(
+                        precision);
             case ARRAY:
-                Preconditions.checkState(children != null && children.size() > 0);
+                Preconditions.checkState(children != null && !children.isEmpty());
                 return org.apache.flink.table.api.DataTypes.ARRAY(toFlinkDataType(children.get(0)));
             case MAP:
                 Preconditions.checkState(children != null && children.size() > 1);

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/com/ververica/cdc/connectors/doris/sink/DorisMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/com/ververica/cdc/connectors/doris/sink/DorisMetadataApplier.java
@@ -79,7 +79,7 @@ public class DorisMetadataApplier implements MetadataApplier {
             } else if (event instanceof RenameColumnEvent) {
                 applyRenameColumnEvent((RenameColumnEvent) event);
             } else if (event instanceof AlterColumnTypeEvent) {
-                throw new RuntimeException("Unsupport schema change event, " + event);
+                throw new RuntimeException("Unsupported schema change event, " + event);
             }
         } catch (Exception ex) {
             throw new RuntimeException(


### PR DESCRIPTION
Fix a typo of 'unsupported' and fix the doris pipeline connector using wrong value for 'precision' of time type.
The length of time type or timestamp type always be null.

<img width="1012" alt="image" src="https://github.com/ververica/flink-cdc-connectors/assets/149778446/ab4459e8-df67-4968-a5a6-847537e79cc6">


cc @lvyanquan 

