### PR TITLE
[cdc-common][cdc-pipelines][cdc-runtime] Use name instead of column in DropColumnEvent/AddColumnEvent.

### DIFF
--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/event/AddColumnEvent.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/event/AddColumnEvent.java
@@ -66,20 +66,20 @@ public final class AddColumnEvent implements SchemaChangeEvent {
         private final ColumnPosition position;
 
         /** The added column lies in the position relative to this column. */
-        private final @Nullable Column existingColumn;
+        private final @Nullable String existedColumnName;
 
         /** In the default scenario, we add fields at the end of the column. */
         public ColumnWithPosition(Column addColumn) {
             this.addColumn = addColumn;
             position = ColumnPosition.LAST;
-            existingColumn = null;
+            existedColumnName = null;
         }
 
         public ColumnWithPosition(
-                Column addColumn, ColumnPosition position, Column existingColumn) {
+                Column addColumn, ColumnPosition position, @Nullable String existedColumnName) {
             this.addColumn = addColumn;
             this.position = position;
-            this.existingColumn = existingColumn;
+            this.existedColumnName = existedColumnName;
         }
 
         public Column getAddColumn() {
@@ -90,8 +90,9 @@ public final class AddColumnEvent implements SchemaChangeEvent {
             return position;
         }
 
-        public Column getExistingColumn() {
-            return existingColumn;
+        @Nullable
+        public String getExistedColumnName() {
+            return existedColumnName;
         }
 
         @Override
@@ -105,12 +106,12 @@ public final class AddColumnEvent implements SchemaChangeEvent {
             ColumnWithPosition position1 = (ColumnWithPosition) o;
             return Objects.equals(addColumn, position1.addColumn)
                     && position == position1.position
-                    && Objects.equals(existingColumn, position1.existingColumn);
+                    && Objects.equals(existedColumnName, position1.existedColumnName);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(addColumn, position, existingColumn);
+            return Objects.hash(addColumn, position, existedColumnName);
         }
 
         @Override
@@ -120,8 +121,8 @@ public final class AddColumnEvent implements SchemaChangeEvent {
                     + addColumn
                     + ", position="
                     + position
-                    + ", existingColumn="
-                    + existingColumn
+                    + ", existedColumnName="
+                    + existedColumnName
                     + '}';
         }
     }

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/event/DropColumnEvent.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/event/DropColumnEvent.java
@@ -17,7 +17,6 @@
 package com.ververica.cdc.common.event;
 
 import com.ververica.cdc.common.annotation.PublicEvolving;
-import com.ververica.cdc.common.schema.Column;
 
 import java.util.List;
 import java.util.Objects;
@@ -33,16 +32,15 @@ public class DropColumnEvent implements SchemaChangeEvent {
 
     private final TableId tableId;
 
-    private final List<Column> droppedColumns;
+    private final List<String> droppedColumnNames;
 
-    public DropColumnEvent(TableId tableId, List<Column> droppedColumns) {
+    public DropColumnEvent(TableId tableId, List<String> droppedColumnNames) {
         this.tableId = tableId;
-        this.droppedColumns = droppedColumns;
+        this.droppedColumnNames = droppedColumnNames;
     }
 
-    /** Returns the dropped columns. */
-    public List<Column> getDroppedColumns() {
-        return droppedColumns;
+    public List<String> getDroppedColumnNames() {
+        return droppedColumnNames;
     }
 
     @Override
@@ -55,12 +53,12 @@ public class DropColumnEvent implements SchemaChangeEvent {
         }
         DropColumnEvent that = (DropColumnEvent) o;
         return Objects.equals(tableId, that.tableId)
-                && Objects.equals(droppedColumns, that.droppedColumns);
+                && Objects.equals(droppedColumnNames, that.droppedColumnNames);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tableId, droppedColumns);
+        return Objects.hash(tableId, droppedColumnNames);
     }
 
     @Override
@@ -68,8 +66,8 @@ public class DropColumnEvent implements SchemaChangeEvent {
         return "DropColumnEvent{"
                 + "tableId="
                 + tableId
-                + ", droppedColumns="
-                + droppedColumns
+                + ", droppedColumnNames="
+                + droppedColumnNames
                 + '}';
     }
 

--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/utils/SchemaUtils.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/utils/SchemaUtils.java
@@ -87,16 +87,14 @@ public class SchemaUtils {
                 case BEFORE:
                     {
                         Preconditions.checkNotNull(
-                                columnWithPosition.getExistingColumn(),
-                                "existingColumn could not be null in BEFORE type AddColumnEvent");
+                                columnWithPosition.getExistedColumnName(),
+                                "existedColumnName could not be null in BEFORE type AddColumnEvent");
                         List<String> columnNames =
                                 columns.stream().map(Column::getName).collect(Collectors.toList());
-                        int index =
-                                columnNames.indexOf(
-                                        columnWithPosition.getExistingColumn().getName());
+                        int index = columnNames.indexOf(columnWithPosition.getExistedColumnName());
                         if (index < 0) {
                             throw new IllegalArgumentException(
-                                    columnWithPosition.getExistingColumn().getName()
+                                    columnWithPosition.getExistedColumnName()
                                             + " of AddColumnEvent is not existed");
                         }
                         columns.add(index, columnWithPosition.getAddColumn());
@@ -105,16 +103,14 @@ public class SchemaUtils {
                 case AFTER:
                     {
                         Preconditions.checkNotNull(
-                                columnWithPosition.getExistingColumn(),
-                                "existingColumn could not be null in AFTER type AddColumnEvent");
+                                columnWithPosition.getExistedColumnName(),
+                                "existedColumnName could not be null in AFTER type AddColumnEvent");
                         List<String> columnNames =
                                 columns.stream().map(Column::getName).collect(Collectors.toList());
-                        int index =
-                                columnNames.indexOf(
-                                        columnWithPosition.getExistingColumn().getName());
+                        int index = columnNames.indexOf(columnWithPosition.getExistedColumnName());
                         if (index < 0) {
                             throw new IllegalArgumentException(
-                                    columnWithPosition.getExistingColumn().getName()
+                                    columnWithPosition.getExistedColumnName()
                                             + " of AddColumnEvent is not existed");
                         }
                         columns.add(index + 1, columnWithPosition.getAddColumn());
@@ -126,17 +122,19 @@ public class SchemaUtils {
     }
 
     private static Schema applyDropColumnEvent(DropColumnEvent event, Schema oldSchema) {
-        event.getDroppedColumns()
+        event.getDroppedColumnNames()
                 .forEach(
                         column -> {
-                            if (!oldSchema.getColumn(column.getName()).isPresent()) {
+                            if (!oldSchema.getColumn(column).isPresent()) {
                                 throw new IllegalArgumentException(
-                                        column.getName() + " of DropColumnEvent is not existed");
+                                        column + " of DropColumnEvent is not existed");
                             }
                         });
         List<Column> columns =
                 oldSchema.getColumns().stream()
-                        .filter((column -> !event.getDroppedColumns().contains(column)))
+                        .filter(
+                                (column ->
+                                        !event.getDroppedColumnNames().contains(column.getName())))
                         .collect(Collectors.toList());
         return oldSchema.copy(columns);
     }

--- a/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/DropColumnEventAssert.java
+++ b/flink-cdc-common/src/test/java/com/ververica/cdc/common/testutils/assertions/DropColumnEventAssert.java
@@ -17,7 +17,6 @@
 package com.ververica.cdc.common.testutils.assertions;
 
 import com.ververica.cdc.common.event.DropColumnEvent;
-import com.ververica.cdc.common.schema.Column;
 import org.assertj.core.internal.Iterables;
 
 import java.util.List;
@@ -35,8 +34,8 @@ public class DropColumnEventAssert
         super(event, DropColumnEventAssert.class);
     }
 
-    public DropColumnEventAssert containsDroppedColumns(Column... droppedColumns) {
-        List<Column> actualDroppedColumns = actual.getDroppedColumns();
+    public DropColumnEventAssert containsDroppedColumns(String... droppedColumns) {
+        List<String> actualDroppedColumns = actual.getDroppedColumnNames();
         iterables.assertContainsExactlyInAnyOrder(info, actualDroppedColumns, droppedColumns);
         return myself;
     }

--- a/flink-cdc-common/src/test/java/com/ververica/cdc/common/utils/SchemaUtilsTest.java
+++ b/flink-cdc-common/src/test/java/com/ververica/cdc/common/utils/SchemaUtilsTest.java
@@ -67,7 +67,7 @@ public class SchemaUtilsTest {
                 new AddColumnEvent.ColumnWithPosition(
                         Column.physicalColumn("col4", DataTypes.STRING()),
                         AddColumnEvent.ColumnPosition.BEFORE,
-                        Column.physicalColumn("col3", DataTypes.STRING())));
+                        "col3"));
         addColumnEvent = new AddColumnEvent(tableId, addedColumns);
         schema = SchemaUtils.applySchemaChangeEvent(schema, addColumnEvent);
         Assert.assertEquals(
@@ -85,7 +85,7 @@ public class SchemaUtilsTest {
                 new AddColumnEvent.ColumnWithPosition(
                         Column.physicalColumn("col5", DataTypes.STRING()),
                         AddColumnEvent.ColumnPosition.AFTER,
-                        Column.physicalColumn("col4", DataTypes.STRING())));
+                        "col4"));
         addColumnEvent = new AddColumnEvent(tableId, addedColumns);
         schema = SchemaUtils.applySchemaChangeEvent(schema, addColumnEvent);
         Assert.assertEquals(
@@ -120,11 +120,7 @@ public class SchemaUtilsTest {
 
         // drop columns
         DropColumnEvent dropColumnEvent =
-                new DropColumnEvent(
-                        tableId,
-                        Arrays.asList(
-                                Column.physicalColumn("col3", DataTypes.STRING()),
-                                Column.physicalColumn("col5", DataTypes.STRING())));
+                new DropColumnEvent(tableId, Arrays.asList("col3", "col5"));
         schema = SchemaUtils.applySchemaChangeEvent(schema, dropColumnEvent);
         Assert.assertEquals(
                 schema,

--- a/flink-cdc-composer/src/test/java/com/ververica/cdc/composer/flink/FlinkPipelineComposerITCase.java
+++ b/flink-cdc-composer/src/test/java/com/ververica/cdc/composer/flink/FlinkPipelineComposerITCase.java
@@ -137,9 +137,9 @@ class FlinkPipelineComposerITCase {
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[], after=[1, 1], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[], after=[2, 2], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[], after=[3, 3], op=INSERT, meta=()}",
-                        "AddColumnEvent{tableId=default_namespace.default_schema.table1, addedColumns=[ColumnWithPosition{column=`col3` STRING, position=LAST, existingColumn=null}]}",
+                        "AddColumnEvent{tableId=default_namespace.default_schema.table1, addedColumns=[ColumnWithPosition{column=`col3` STRING, position=LAST, existedColumnName=null}]}",
                         "RenameColumnEvent{tableId=default_namespace.default_schema.table1, nameMapping={col2=newCol2, col3=newCol3}}",
-                        "DropColumnEvent{tableId=default_namespace.default_schema.table1, droppedColumns=[`newCol2` STRING]}",
+                        "DropColumnEvent{tableId=default_namespace.default_schema.table1, droppedColumnNames=[newCol2]}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[1, 1], after=[], op=DELETE, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[2, ], after=[2, x], op=UPDATE, meta=()}");
     }
@@ -198,12 +198,12 @@ class FlinkPipelineComposerITCase {
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[], after=[1, 1], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[], after=[2, 2], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[], after=[3, 3], op=INSERT, meta=()}",
-                        "AddColumnEvent{tableId=default_namespace.default_schema.table1, addedColumns=[ColumnWithPosition{column=`col3` STRING, position=LAST, existingColumn=null}]}",
+                        "AddColumnEvent{tableId=default_namespace.default_schema.table1, addedColumns=[ColumnWithPosition{column=`col3` STRING, position=LAST, existedColumnName=null}]}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.table2, before=[], after=[1, 1], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.table2, before=[], after=[2, 2], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.table2, before=[], after=[3, 3], op=INSERT, meta=()}",
                         "RenameColumnEvent{tableId=default_namespace.default_schema.table1, nameMapping={col2=newCol2, col3=newCol3}}",
-                        "DropColumnEvent{tableId=default_namespace.default_schema.table1, droppedColumns=[`newCol2` STRING]}",
+                        "DropColumnEvent{tableId=default_namespace.default_schema.table1, droppedColumnNames=[newCol2]}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[1, 1], after=[], op=DELETE, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[2, 2], after=[2, x], op=UPDATE, meta=()}");
     }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/com/ververica/cdc/connectors/doris/sink/DorisMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/com/ververica/cdc/connectors/doris/sink/DorisMetadataApplier.java
@@ -173,10 +173,9 @@ public class DorisMetadataApplier implements MetadataApplier {
     private void applyDropColumnEvent(DropColumnEvent event)
             throws IOException, IllegalArgumentException {
         TableId tableId = event.tableId();
-        List<Column> droppedColumns = event.getDroppedColumns();
-        for (Column col : droppedColumns) {
-            schemaChangeManager.dropColumn(
-                    tableId.getSchemaName(), tableId.getTableName(), col.getName());
+        List<String> droppedColumns = event.getDroppedColumnNames();
+        for (String col : droppedColumns) {
+            schemaChangeManager.dropColumn(tableId.getSchemaName(), tableId.getTableName(), col);
         }
     }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/com/ververica/cdc/connectors/mysql/source/parser/CustomAlterTableParserListener.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/com/ververica/cdc/connectors/mysql/source/parser/CustomAlterTableParserListener.java
@@ -22,7 +22,6 @@ import com.ververica.cdc.common.event.DropColumnEvent;
 import com.ververica.cdc.common.event.RenameColumnEvent;
 import com.ververica.cdc.common.event.SchemaChangeEvent;
 import com.ververica.cdc.common.types.DataType;
-import com.ververica.cdc.common.types.DataTypes;
 import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
 import io.debezium.connector.mysql.antlr.listener.AlterTableParserListener;
 import io.debezium.ddl.parser.mysql.generated.MySqlParser;
@@ -35,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -116,10 +114,7 @@ public class CustomAlterTableParserListener extends MySqlParserBaseListener {
                                                 new AddColumnEvent.ColumnWithPosition(
                                                         toCdcColumn(column),
                                                         AddColumnEvent.ColumnPosition.AFTER,
-                                                        com.ververica.cdc.common.schema.Column
-                                                                .physicalColumn(
-                                                                        afterColumn,
-                                                                        DataTypes.BIGINT())))));
+                                                        afterColumn))));
                     } else {
                         changes.add(
                                 new AddColumnEvent(
@@ -223,12 +218,7 @@ public class CustomAlterTableParserListener extends MySqlParserBaseListener {
     @Override
     public void enterAlterByDropColumn(MySqlParser.AlterByDropColumnContext ctx) {
         String removedColName = parser.parseName(ctx.uid());
-        changes.add(
-                new DropColumnEvent(
-                        currentTable,
-                        Arrays.asList(
-                                com.ververica.cdc.common.schema.Column.physicalColumn(
-                                        removedColName, DataTypes.BIGINT()))));
+        changes.add(new DropColumnEvent(currentTable, Collections.singletonList(removedColName)));
         super.enterAlterByDropColumn(ctx);
     }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlPipelineITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlPipelineITCase.java
@@ -313,7 +313,7 @@ public class MySqlPipelineITCase extends MySqlSourceTestBase {
                         .physicalColumn("name", DataTypes.VARCHAR(255).notNull())
                         .physicalColumn("description", DataTypes.VARCHAR(512))
                         .physicalColumn("weight", DataTypes.FLOAT())
-                        .primaryKey(Arrays.asList("id"))
+                        .primaryKey(Collections.singletonList("id"))
                         .build());
     }
 
@@ -466,11 +466,11 @@ public class MySqlPipelineITCase extends MySqlSourceTestBase {
         expected.add(
                 new AddColumnEvent(
                         tableId,
-                        Arrays.asList(
+                        Collections.singletonList(
                                 new AddColumnEvent.ColumnWithPosition(
                                         Column.physicalColumn("desc1", DataTypes.VARCHAR(45)),
                                         AddColumnEvent.ColumnPosition.AFTER,
-                                        Column.physicalColumn("weight", DataTypes.BIGINT())))));
+                                        "weight"))));
 
         statement.execute(
                 String.format(
@@ -479,29 +479,25 @@ public class MySqlPipelineITCase extends MySqlSourceTestBase {
         expected.add(
                 new AddColumnEvent(
                         tableId,
-                        Arrays.asList(
+                        Collections.singletonList(
                                 new AddColumnEvent.ColumnWithPosition(
                                         Column.physicalColumn("col1", DataTypes.VARCHAR(45)),
                                         AddColumnEvent.ColumnPosition.AFTER,
-                                        Column.physicalColumn("weight", DataTypes.BIGINT())))));
+                                        "weight"))));
         expected.add(
                 new AddColumnEvent(
                         tableId,
-                        Arrays.asList(
+                        Collections.singletonList(
                                 new AddColumnEvent.ColumnWithPosition(
                                         Column.physicalColumn("col2", DataTypes.VARCHAR(55)),
                                         AddColumnEvent.ColumnPosition.AFTER,
-                                        Column.physicalColumn("desc1", DataTypes.BIGINT())))));
+                                        "desc1"))));
 
         statement.execute(
                 String.format(
                         "ALTER TABLE `%s`.`products` DROP COLUMN `desc2`, CHANGE COLUMN `desc1` `desc1` VARCHAR(65) NULL DEFAULT NULL;",
                         inventoryDatabase.getDatabaseName()));
-        expected.add(
-                new DropColumnEvent(
-                        tableId,
-                        Collections.singletonList(
-                                Column.physicalColumn("desc2", DataTypes.BIGINT()))));
+        expected.add(new DropColumnEvent(tableId, Collections.singletonList("desc2")));
         expected.add(
                 new AlterColumnTypeEvent(
                         tableId, Collections.singletonMap("desc1", DataTypes.VARCHAR(65))));
@@ -517,11 +513,7 @@ public class MySqlPipelineITCase extends MySqlSourceTestBase {
                 String.format(
                         "ALTER TABLE `%s`.`products` DROP COLUMN `DESC3`;",
                         inventoryDatabase.getDatabaseName()));
-        expected.add(
-                new DropColumnEvent(
-                        tableId,
-                        Collections.singletonList(
-                                Column.physicalColumn("DESC3", DataTypes.BIGINT()))));
+        expected.add(new DropColumnEvent(tableId, Collections.singletonList("DESC3")));
 
         // Should not catch SchemaChangeEvent of tables other than `products`
         statement.execute(

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/com/ververica/cdc/connectors/starrocks/sink/StarRocksMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/com/ververica/cdc/connectors/starrocks/sink/StarRocksMetadataApplier.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.ververica.cdc.connectors.starrocks.sink.StarRocksUtils.toStarRocksDataType;
 
@@ -187,10 +186,7 @@ public class StarRocksMetadataApplier implements MetadataApplier {
     }
 
     private void applyDropColumn(DropColumnEvent dropColumnEvent) {
-        List<String> dropColumns =
-                dropColumnEvent.getDroppedColumns().stream()
-                        .map(Column::getName)
-                        .collect(Collectors.toList());
+        List<String> dropColumns = dropColumnEvent.getDroppedColumnNames();
         TableId tableId = dropColumnEvent.tableId();
         StarRocksCatalogException alterException = null;
         try {

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/com/ververical/cdc/connectors/starrocks/sink/EventRecordSerializationSchemaTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/com/ververical/cdc/connectors/starrocks/sink/EventRecordSerializationSchemaTest.java
@@ -71,6 +71,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -234,15 +235,11 @@ public class EventRecordSerializationSchemaTest {
         verifySerializeResult(
                 table1,
                 "{\"col1\":4,\"col2\":true,\"col3\":\"2023-11-27 21:00:00\",\"col4\":83.23,\"col5\":9,\"col6\":\"2023-11-27 19:00:00\",\"__op\":1}",
-                serializer.serialize(deleteEvent2));
+                Objects.requireNonNull(serializer.serialize(deleteEvent2)));
 
         // 4. drop columns from table2, and insert data
         DropColumnEvent dropColumnEvent =
-                new DropColumnEvent(
-                        table2,
-                        Arrays.asList(
-                                Column.physicalColumn("col2", new FloatType()),
-                                Column.physicalColumn("col3", new VarCharType(20))));
+                new DropColumnEvent(table2, Arrays.asList("col2", "col3"));
         Schema newSchema2 = SchemaUtils.applySchemaChangeEvent(schema2, dropColumnEvent);
         BinaryRecordDataGenerator newGenerator2 =
                 new BinaryRecordDataGenerator(
@@ -255,7 +252,9 @@ public class EventRecordSerializationSchemaTest {
                         newGenerator2.generate(
                                 new Object[] {(int) LocalDate.of(2023, 11, 28).toEpochDay()}));
         verifySerializeResult(
-                table2, "{\"col1\":\"2023-11-28\",\"__op\":0}", serializer.serialize(insertEvent3));
+                table2,
+                "{\"col1\":\"2023-11-28\",\"__op\":0}",
+                Objects.requireNonNull(serializer.serialize(insertEvent3)));
     }
 
     private void verifySerializeResult(

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/com/ververical/cdc/connectors/starrocks/sink/StarRocksMetadataApplierTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/com/ververical/cdc/connectors/starrocks/sink/StarRocksMetadataApplierTest.java
@@ -200,11 +200,7 @@ public class StarRocksMetadataApplierTest {
         metadataApplier.applySchemaChange(createTableEvent);
 
         DropColumnEvent dropColumnEvent =
-                new DropColumnEvent(
-                        tableId,
-                        Arrays.asList(
-                                Column.physicalColumn("col2", new BooleanType()),
-                                Column.physicalColumn("col3", new TimestampType())));
+                new DropColumnEvent(tableId, Arrays.asList("col2", "col3"));
         metadataApplier.applySchemaChange(dropColumnEvent);
 
         StarRocksTable actualTable =

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/com/ververica/cdc/connectors/values/source/ValuesDataSourceHelper.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/com/ververica/cdc/connectors/values/source/ValuesDataSourceHelper.java
@@ -168,10 +168,7 @@ public class ValuesDataSourceHelper {
 
         // drop column
         DropColumnEvent dropColumnEvent =
-                new DropColumnEvent(
-                        TABLE_1,
-                        Collections.singletonList(
-                                Column.physicalColumn("newCol2", DataTypes.STRING())));
+                new DropColumnEvent(TABLE_1, Collections.singletonList("newCol2"));
         split1.add(dropColumnEvent);
 
         // delete
@@ -296,10 +293,7 @@ public class ValuesDataSourceHelper {
 
         // drop column
         DropColumnEvent dropColumnEvent =
-                new DropColumnEvent(
-                        TABLE_1,
-                        Collections.singletonList(
-                                Column.physicalColumn("newCol2", DataTypes.STRING())));
+                new DropColumnEvent(TABLE_1, Collections.singletonList("newCol2"));
         split1.add(dropColumnEvent);
 
         // delete

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/test/java/com/ververica/cdc/connectors/values/ValuesDatabaseTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/test/java/com/ververica/cdc/connectors/values/ValuesDatabaseTest.java
@@ -188,10 +188,7 @@ public class ValuesDatabaseTest {
         Assert.assertEquals(schema, metadataAccessor.getTableSchema(table1));
 
         DropColumnEvent dropColumnEvent =
-                new DropColumnEvent(
-                        table1,
-                        Collections.singletonList(
-                                Column.physicalColumn("newCol2", new CharType())));
+                new DropColumnEvent(table1, Collections.singletonList("newCol2"));
         metadataApplier.applySchemaChange(dropColumnEvent);
         schema =
                 Schema.newBuilder()
@@ -284,10 +281,7 @@ public class ValuesDatabaseTest {
         Assert.assertEquals(results, ValuesDatabase.getResults(table1));
 
         DropColumnEvent dropColumnEvent =
-                new DropColumnEvent(
-                        table1,
-                        Collections.singletonList(
-                                Column.physicalColumn("newCol2", new CharType())));
+                new DropColumnEvent(table1, Collections.singletonList("newCol2"));
         metadataApplier.applySchemaChange(dropColumnEvent);
         results.clear();
         results.add("default.default.table1:col1=1;newCol3=");

--- a/flink-cdc-runtime/src/main/java/com/ververica/cdc/runtime/operators/route/RouteFunction.java
+++ b/flink-cdc-runtime/src/main/java/com/ververica/cdc/runtime/operators/route/RouteFunction.java
@@ -157,7 +157,7 @@ public class RouteFunction extends RichMapFunction<Event, Event> {
         }
         if (schemaChangeEvent instanceof DropColumnEvent) {
             DropColumnEvent dropColumnEvent = (DropColumnEvent) schemaChangeEvent;
-            return new DropColumnEvent(tableId, dropColumnEvent.getDroppedColumns());
+            return new DropColumnEvent(tableId, dropColumnEvent.getDroppedColumnNames());
         }
         if (schemaChangeEvent instanceof AddColumnEvent) {
             AddColumnEvent addColumnEvent = (AddColumnEvent) schemaChangeEvent;

--- a/flink-cdc-runtime/src/main/java/com/ververica/cdc/runtime/serializer/event/DropColumnEventSerializer.java
+++ b/flink-cdc-runtime/src/main/java/com/ververica/cdc/runtime/serializer/event/DropColumnEventSerializer.java
@@ -24,11 +24,10 @@ import org.apache.flink.core.memory.DataOutputView;
 
 import com.ververica.cdc.common.event.DropColumnEvent;
 import com.ververica.cdc.common.event.TableId;
-import com.ververica.cdc.common.schema.Column;
 import com.ververica.cdc.runtime.serializer.ListSerializer;
+import com.ververica.cdc.runtime.serializer.StringSerializer;
 import com.ververica.cdc.runtime.serializer.TableIdSerializer;
 import com.ververica.cdc.runtime.serializer.TypeSerializerSingleton;
-import com.ververica.cdc.runtime.serializer.schema.ColumnSerializer;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -42,8 +41,8 @@ public class DropColumnEventSerializer extends TypeSerializerSingleton<DropColum
     public static final DropColumnEventSerializer INSTANCE = new DropColumnEventSerializer();
 
     private final TableIdSerializer tableIdSerializer = TableIdSerializer.INSTANCE;
-    private final ListSerializer<Column> columnsSerializer =
-            new ListSerializer<>(ColumnSerializer.INSTANCE);
+    private final ListSerializer<String> columnNamesSerializer =
+            new ListSerializer<>(StringSerializer.INSTANCE);
 
     @Override
     public boolean isImmutableType() {
@@ -58,7 +57,7 @@ public class DropColumnEventSerializer extends TypeSerializerSingleton<DropColum
     @Override
     public DropColumnEvent copy(DropColumnEvent from) {
         return new DropColumnEvent(
-                from.tableId(), columnsSerializer.copy(from.getDroppedColumns()));
+                from.tableId(), columnNamesSerializer.copy(from.getDroppedColumnNames()));
     }
 
     @Override
@@ -74,13 +73,13 @@ public class DropColumnEventSerializer extends TypeSerializerSingleton<DropColum
     @Override
     public void serialize(DropColumnEvent record, DataOutputView target) throws IOException {
         tableIdSerializer.serialize(record.tableId(), target);
-        columnsSerializer.serialize(record.getDroppedColumns(), target);
+        columnNamesSerializer.serialize(record.getDroppedColumnNames(), target);
     }
 
     @Override
     public DropColumnEvent deserialize(DataInputView source) throws IOException {
         return new DropColumnEvent(
-                tableIdSerializer.deserialize(source), columnsSerializer.deserialize(source));
+                tableIdSerializer.deserialize(source), columnNamesSerializer.deserialize(source));
     }
 
     @Override

--- a/flink-cdc-runtime/src/main/java/com/ververica/cdc/runtime/serializer/schema/ColumnWithPositionSerializer.java
+++ b/flink-cdc-runtime/src/main/java/com/ververica/cdc/runtime/serializer/schema/ColumnWithPositionSerializer.java
@@ -27,6 +27,7 @@ import com.ververica.cdc.common.schema.Column;
 import com.ververica.cdc.common.types.DataTypes;
 import com.ververica.cdc.runtime.serializer.EnumSerializer;
 import com.ververica.cdc.runtime.serializer.NullableSerializerWrapper;
+import com.ververica.cdc.runtime.serializer.StringSerializer;
 import com.ververica.cdc.runtime.serializer.TypeSerializerSingleton;
 
 import java.io.IOException;
@@ -40,8 +41,11 @@ public class ColumnWithPositionSerializer
     /** Sharable instance of the TableIdSerializer. */
     public static final ColumnWithPositionSerializer INSTANCE = new ColumnWithPositionSerializer();
 
-    private final TypeSerializer<Column> columnSerializer =
+    private final TypeSerializer<Column> addColumnSerializer =
             new NullableSerializerWrapper<>(ColumnSerializer.INSTANCE);
+
+    private final TypeSerializer<String> existedColumnSerializer = new StringSerializer();
+
     private final EnumSerializer<AddColumnEvent.ColumnPosition> positionEnumSerializer =
             new EnumSerializer<>(AddColumnEvent.ColumnPosition.class);
 
@@ -59,9 +63,9 @@ public class ColumnWithPositionSerializer
     @Override
     public AddColumnEvent.ColumnWithPosition copy(AddColumnEvent.ColumnWithPosition from) {
         return new AddColumnEvent.ColumnWithPosition(
-                columnSerializer.copy(from.getAddColumn()),
+                addColumnSerializer.copy(from.getAddColumn()),
                 from.getPosition(),
-                columnSerializer.copy(from.getExistingColumn()));
+                existedColumnSerializer.copy(from.getExistedColumnName()));
     }
 
     @Override
@@ -78,23 +82,23 @@ public class ColumnWithPositionSerializer
     @Override
     public void serialize(AddColumnEvent.ColumnWithPosition record, DataOutputView target)
             throws IOException {
-        columnSerializer.serialize(record.getAddColumn(), target);
+        addColumnSerializer.serialize(record.getAddColumn(), target);
         positionEnumSerializer.serialize(record.getPosition(), target);
-        if (record.getExistingColumn() == null) {
+        if (record.getExistedColumnName() == null) {
             target.writeInt(0);
         } else {
             target.writeInt(1);
-            columnSerializer.serialize(record.getExistingColumn(), target);
+            existedColumnSerializer.serialize(record.getExistedColumnName(), target);
         }
     }
 
     @Override
     public AddColumnEvent.ColumnWithPosition deserialize(DataInputView source) throws IOException {
-        Column addColumn = columnSerializer.deserialize(source);
+        Column addColumn = addColumnSerializer.deserialize(source);
         AddColumnEvent.ColumnPosition position = positionEnumSerializer.deserialize(source);
         if (source.readInt() == 1) {
             return new AddColumnEvent.ColumnWithPosition(
-                    addColumn, position, columnSerializer.deserialize(source));
+                    addColumn, position, existedColumnSerializer.deserialize(source));
         }
         return new AddColumnEvent.ColumnWithPosition(addColumn, position, null);
     }

--- a/flink-cdc-runtime/src/main/java/com/ververica/cdc/runtime/serializer/schema/ColumnWithPositionSerializer.java
+++ b/flink-cdc-runtime/src/main/java/com/ververica/cdc/runtime/serializer/schema/ColumnWithPositionSerializer.java
@@ -44,7 +44,7 @@ public class ColumnWithPositionSerializer
     private final TypeSerializer<Column> addColumnSerializer =
             new NullableSerializerWrapper<>(ColumnSerializer.INSTANCE);
 
-    private final TypeSerializer<String> existedColumnSerializer = new StringSerializer();
+    private final TypeSerializer<String> existedColumnNameSerializer = StringSerializer.INSTANCE;
 
     private final EnumSerializer<AddColumnEvent.ColumnPosition> positionEnumSerializer =
             new EnumSerializer<>(AddColumnEvent.ColumnPosition.class);
@@ -65,7 +65,7 @@ public class ColumnWithPositionSerializer
         return new AddColumnEvent.ColumnWithPosition(
                 addColumnSerializer.copy(from.getAddColumn()),
                 from.getPosition(),
-                existedColumnSerializer.copy(from.getExistedColumnName()));
+                existedColumnNameSerializer.copy(from.getExistedColumnName()));
     }
 
     @Override
@@ -84,23 +84,15 @@ public class ColumnWithPositionSerializer
             throws IOException {
         addColumnSerializer.serialize(record.getAddColumn(), target);
         positionEnumSerializer.serialize(record.getPosition(), target);
-        if (record.getExistedColumnName() == null) {
-            target.writeInt(0);
-        } else {
-            target.writeInt(1);
-            existedColumnSerializer.serialize(record.getExistedColumnName(), target);
-        }
+        existedColumnNameSerializer.serialize(record.getExistedColumnName(), target);
     }
 
     @Override
     public AddColumnEvent.ColumnWithPosition deserialize(DataInputView source) throws IOException {
         Column addColumn = addColumnSerializer.deserialize(source);
         AddColumnEvent.ColumnPosition position = positionEnumSerializer.deserialize(source);
-        if (source.readInt() == 1) {
-            return new AddColumnEvent.ColumnWithPosition(
-                    addColumn, position, existedColumnSerializer.deserialize(source));
-        }
-        return new AddColumnEvent.ColumnWithPosition(addColumn, position, null);
+        return new AddColumnEvent.ColumnWithPosition(
+                addColumn, position, existedColumnNameSerializer.deserialize(source));
     }
 
     @Override

--- a/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/operators/route/RouteFunctionTest.java
+++ b/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/operators/route/RouteFunctionTest.java
@@ -164,12 +164,12 @@ class RouteFunctionTest {
 
         // DropColumnEvent
         PhysicalColumn droppedColumn = Column.physicalColumn("address", DataTypes.STRING());
-        List<Column> droppedColumns = Collections.singletonList(droppedColumn);
+        List<String> droppedColumns = Collections.singletonList(droppedColumn.getName());
         DropColumnEvent dropColumnEvent = new DropColumnEvent(CUSTOMERS, droppedColumns);
         assertThat(router.map(dropColumnEvent))
                 .asSchemaChangeEvent()
                 .asDropColumnEvent()
-                .containsDroppedColumns(droppedColumn)
+                .containsDroppedColumns(droppedColumn.getName())
                 .hasTableId(NEW_CUSTOMERS);
 
         // RenameColumnEvent

--- a/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/operators/schema/coordinator/SchemaManagerTest.java
+++ b/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/operators/schema/coordinator/SchemaManagerTest.java
@@ -86,11 +86,11 @@ class SchemaManagerTest {
                         new AddColumnEvent.ColumnWithPosition(
                                 Column.physicalColumn("append_after_id", DataTypes.BIGINT()),
                                 AddColumnEvent.ColumnPosition.AFTER,
-                                Column.physicalColumn("id", DataTypes.INT())),
+                                "id"),
                         new AddColumnEvent.ColumnWithPosition(
                                 Column.physicalColumn("append_before_phone", DataTypes.BIGINT()),
                                 AddColumnEvent.ColumnPosition.BEFORE,
-                                Column.physicalColumn("phone", DataTypes.BIGINT())));
+                                "phone"));
 
         schemaManager.applySchemaChange(new CreateTableEvent(CUSTOMERS, CUSTOMERS_SCHEMA));
         schemaManager.applySchemaChange(new AddColumnEvent(CUSTOMERS, newColumns));
@@ -129,11 +129,7 @@ class SchemaManagerTest {
         SchemaManager schemaManager = new SchemaManager();
         schemaManager.applySchemaChange(new CreateTableEvent(CUSTOMERS, CUSTOMERS_SCHEMA));
         schemaManager.applySchemaChange(
-                new DropColumnEvent(
-                        CUSTOMERS,
-                        Arrays.asList(
-                                Column.physicalColumn("name", DataTypes.STRING()),
-                                Column.physicalColumn("phone", DataTypes.BIGINT()))));
+                new DropColumnEvent(CUSTOMERS, Arrays.asList("name", "phone")));
         assertThat(schemaManager.getLatestSchema(CUSTOMERS))
                 .contains(
                         Schema.newBuilder()

--- a/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/serializer/event/AddColumnEventSerializerTest.java
+++ b/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/serializer/event/AddColumnEventSerializerTest.java
@@ -54,7 +54,7 @@ public class AddColumnEventSerializerTest extends SerializerTestBase<AddColumnEv
                             new AddColumnEvent.ColumnWithPosition(
                                     Column.physicalColumn("testCol2", DataTypes.DOUBLE(), "desc"),
                                     AddColumnEvent.ColumnPosition.AFTER,
-                                    Column.physicalColumn("testCol1", DataTypes.TIMESTAMP())))),
+                                    "testCol1"))),
             new AddColumnEvent(
                     TableId.tableId("schema", "table"),
                     Arrays.asList(
@@ -65,7 +65,7 @@ public class AddColumnEventSerializerTest extends SerializerTestBase<AddColumnEv
                             new AddColumnEvent.ColumnWithPosition(
                                     Column.metadataColumn("testCol2", DataTypes.DOUBLE(), "mKey"),
                                     AddColumnEvent.ColumnPosition.BEFORE,
-                                    Column.metadataColumn("testCol1", DataTypes.TIMESTAMP())))),
+                                    "testCol1"))),
             new AddColumnEvent(
                     TableId.tableId("namespace", "schema", "table"),
                     Arrays.asList(
@@ -77,7 +77,7 @@ public class AddColumnEventSerializerTest extends SerializerTestBase<AddColumnEv
                                     Column.metadataColumn(
                                             "testCol2", DataTypes.DOUBLE(), "mKey", "desc"),
                                     AddColumnEvent.ColumnPosition.BEFORE,
-                                    Column.physicalColumn("testCol1", DataTypes.TIMESTAMP()))))
+                                    "testCol1")))
         };
     }
 }

--- a/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/serializer/event/DropColumnEventSerializerTest.java
+++ b/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/serializer/event/DropColumnEventSerializerTest.java
@@ -20,8 +20,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import com.ververica.cdc.common.event.DropColumnEvent;
 import com.ververica.cdc.common.event.TableId;
-import com.ververica.cdc.common.schema.Column;
-import com.ververica.cdc.common.types.DataTypes;
 import com.ververica.cdc.runtime.serializer.SerializerTestBase;
 
 import java.util.Arrays;
@@ -46,22 +44,11 @@ public class DropColumnEventSerializerTest extends SerializerTestBase<DropColumn
     @Override
     protected DropColumnEvent[] getTestData() {
         return new DropColumnEvent[] {
+            new DropColumnEvent(TableId.tableId("table"), Arrays.asList("c1", "c2")),
             new DropColumnEvent(
-                    TableId.tableId("table"),
-                    Arrays.asList(
-                            Column.physicalColumn("c1", DataTypes.TIMESTAMP()),
-                            Column.physicalColumn("c2", DataTypes.DOUBLE(), "desc"))),
+                    TableId.tableId("schema", "table"), Arrays.asList("m1", "m2", "m3")),
             new DropColumnEvent(
-                    TableId.tableId("schema", "table"),
-                    Arrays.asList(
-                            Column.metadataColumn("m1", DataTypes.TIMESTAMP()),
-                            Column.metadataColumn("m2", DataTypes.DOUBLE(), "mKey"),
-                            Column.metadataColumn("m3", DataTypes.DOUBLE(), "mKey", "desc"))),
-            new DropColumnEvent(
-                    TableId.tableId("namespace", "schema", "table"),
-                    Arrays.asList(
-                            Column.physicalColumn("c1", DataTypes.TIMESTAMP()),
-                            Column.physicalColumn("c2", DataTypes.DOUBLE(), "desc")))
+                    TableId.tableId("namespace", "schema", "table"), Arrays.asList("c1", "c2"))
         };
     }
 }

--- a/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/serializer/event/SchemaChangeEventSerializerTest.java
+++ b/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/serializer/event/SchemaChangeEventSerializerTest.java
@@ -80,15 +80,11 @@ public class SchemaChangeEventSerializerTest extends SerializerTestBase<SchemaCh
                             new AddColumnEvent.ColumnWithPosition(
                                     Column.physicalColumn("testCol2", DataTypes.DOUBLE(), "desc"),
                                     AddColumnEvent.ColumnPosition.AFTER,
-                                    Column.physicalColumn("testCol1", DataTypes.TIMESTAMP())))),
+                                    "testCol1"))),
             new AlterColumnTypeEvent(TableId.tableId("namespace", "schema", "table"), alterTypeMap),
             new CreateTableEvent(TableId.tableId("schema", "table"), schema),
             new DropColumnEvent(
-                    TableId.tableId("schema", "table"),
-                    Arrays.asList(
-                            Column.metadataColumn("m1", DataTypes.TIMESTAMP()),
-                            Column.metadataColumn("m2", DataTypes.DOUBLE(), "mKey"),
-                            Column.metadataColumn("m3", DataTypes.DOUBLE(), "mKey", "desc"))),
+                    TableId.tableId("schema", "table"), Arrays.asList("m1", "m2", "m3")),
             new RenameColumnEvent(TableId.tableId("table"), renameMap)
         };
     }

--- a/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/serializer/schema/ColumnWithPositionSerializerTest.java
+++ b/flink-cdc-runtime/src/test/java/com/ververica/cdc/runtime/serializer/schema/ColumnWithPositionSerializerTest.java
@@ -51,13 +51,13 @@ public class ColumnWithPositionSerializerTest
             new AddColumnEvent.ColumnWithPosition(
                     Column.metadataColumn("testCol2", DataTypes.DOUBLE(), "mKey"),
                     AddColumnEvent.ColumnPosition.BEFORE,
-                    Column.metadataColumn("testCol1", DataTypes.TIMESTAMP())),
+                    "testCol1"),
             new AddColumnEvent.ColumnWithPosition(
                     Column.physicalColumn("testCol1", DataTypes.TIMESTAMP())),
             new AddColumnEvent.ColumnWithPosition(
                     Column.physicalColumn("testCol2", DataTypes.DOUBLE(), "desc"),
                     AddColumnEvent.ColumnPosition.AFTER,
-                    Column.physicalColumn("testCol1", DataTypes.TIMESTAMP()))
+                    "testCol1")
         };
     }
 }


### PR DESCRIPTION
Refer to #2857.
Using the name of column, replace using column.
@lvyanquan 