### PR TITLE
[bug][pipeline-connector][starrocks] Optimize char type mapping for starrocks pipeline connector

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/com/ververica/cdc/connectors/starrocks/sink/StarRocksMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/com/ververica/cdc/connectors/starrocks/sink/StarRocksMetadataApplier.java
@@ -119,7 +119,7 @@ public class StarRocksMetadataApplier implements MetadataApplier {
                             .setColumnName(column.getName())
                             .setOrdinalPosition(-1)
                             .setColumnComment(column.getComment());
-            toStarRocksDataType(column, builder);
+            toStarRocksDataType(column, false, builder);
             addColumns.add(builder.build());
         }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/com/ververica/cdc/connectors/starrocks/sink/StarRocksUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/com/ververica/cdc/connectors/starrocks/sink/StarRocksUtils.java
@@ -76,6 +76,7 @@ public class StarRocksUtils {
             }
         }
 
+        int primaryKeyCount = schema.primaryKeys().size();
         List<StarRocksColumn> starRocksColumns = new ArrayList<>();
         for (int i = 0; i < orderedColumns.size(); i++) {
             Column column = orderedColumns.get(i);
@@ -84,7 +85,7 @@ public class StarRocksUtils {
                             .setColumnName(column.getName())
                             .setOrdinalPosition(i)
                             .setColumnComment(column.getComment());
-            toStarRocksDataType(column, builder);
+            toStarRocksDataType(column, i < primaryKeyCount, builder);
             starRocksColumns.add(builder.build());
         }
 
@@ -106,8 +107,10 @@ public class StarRocksUtils {
     }
 
     /** Convert CDC data type to StarRocks data type. */
-    public static void toStarRocksDataType(Column cdcColumn, StarRocksColumn.Builder builder) {
-        CdcDataTypeTransformer dataTypeTransformer = new CdcDataTypeTransformer(builder);
+    public static void toStarRocksDataType(
+            Column cdcColumn, boolean isPrimaryKeys, StarRocksColumn.Builder builder) {
+        CdcDataTypeTransformer dataTypeTransformer =
+                new CdcDataTypeTransformer(isPrimaryKeys, builder);
         cdcColumn.getType().accept(dataTypeTransformer);
     }
 
@@ -236,8 +239,10 @@ public class StarRocksUtils {
             extends DataTypeDefaultVisitor<StarRocksColumn.Builder> {
 
         private final StarRocksColumn.Builder builder;
+        private final boolean isPrimaryKeys;
 
-        public CdcDataTypeTransformer(StarRocksColumn.Builder builder) {
+        public CdcDataTypeTransformer(boolean isPrimaryKeys, StarRocksColumn.Builder builder) {
+            this.isPrimaryKeys = isPrimaryKeys;
             this.builder = builder;
         }
 
@@ -309,7 +314,11 @@ public class StarRocksUtils {
             // varchar type
             int length = charType.getLength();
             long starRocksLength = length * 3L;
-            if (starRocksLength <= MAX_CHAR_SIZE) {
+            // In the StarRocks, The primary key columns can be any of the following data types:
+            // BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, LARGEINT, STRING, VARCHAR, DATE, and
+            // DATETIME, But it doesn't include CHAR. When a char type appears in the primary key of
+            // MySQL, creating a table in StarRocks requires conversion to varchar type.
+            if (starRocksLength <= MAX_CHAR_SIZE && !isPrimaryKeys) {
                 builder.setDataType(CHAR);
                 builder.setNullable(charType.isNullable());
                 builder.setColumnSize((int) starRocksLength);

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/com/ververical/cdc/connectors/starrocks/sink/CdcDataTypeTransformerTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/com/ververical/cdc/connectors/starrocks/sink/CdcDataTypeTransformerTest.java
@@ -33,7 +33,8 @@ public class CdcDataTypeTransformerTest {
         // map to char of StarRocks if CDC length <= StarRocksUtils.MAX_CHAR_SIZE
         StarRocksColumn.Builder smallLengthBuilder =
                 new StarRocksColumn.Builder().setColumnName("small_char").setOrdinalPosition(0);
-        new CharType(1).accept(new StarRocksUtils.CdcDataTypeTransformer(smallLengthBuilder));
+        new CharType(1)
+                .accept(new StarRocksUtils.CdcDataTypeTransformer(false, smallLengthBuilder));
         StarRocksColumn smallLengthColumn = smallLengthBuilder.build();
         assertEquals("small_char", smallLengthColumn.getColumnName());
         assertEquals(0, smallLengthColumn.getOrdinalPosition());
@@ -45,7 +46,7 @@ public class CdcDataTypeTransformerTest {
         StarRocksColumn.Builder largeLengthBuilder =
                 new StarRocksColumn.Builder().setColumnName("large_char").setOrdinalPosition(1);
         new CharType(StarRocksUtils.MAX_CHAR_SIZE)
-                .accept(new StarRocksUtils.CdcDataTypeTransformer(largeLengthBuilder));
+                .accept(new StarRocksUtils.CdcDataTypeTransformer(false, largeLengthBuilder));
         StarRocksColumn largeLengthColumn = largeLengthBuilder.build();
         assertEquals("large_char", largeLengthColumn.getColumnName());
         assertEquals(1, largeLengthColumn.getOrdinalPosition());
@@ -57,12 +58,27 @@ public class CdcDataTypeTransformerTest {
     }
 
     @Test
+    public void testCharTypeForPrimaryKey() {
+        // map to varchar of StarRocks if column is primary key
+        StarRocksColumn.Builder smallLengthBuilder =
+                new StarRocksColumn.Builder().setColumnName("primary_key").setOrdinalPosition(0);
+        new CharType(1).accept(new StarRocksUtils.CdcDataTypeTransformer(true, smallLengthBuilder));
+        StarRocksColumn smallLengthColumn = smallLengthBuilder.build();
+        assertEquals("primary_key", smallLengthColumn.getColumnName());
+        assertEquals(0, smallLengthColumn.getOrdinalPosition());
+        assertEquals(StarRocksUtils.VARCHAR, smallLengthColumn.getDataType());
+        assertEquals(Integer.valueOf(3), smallLengthColumn.getColumnSize().orElse(null));
+        assertTrue(smallLengthColumn.isNullable());
+    }
+
+    @Test
     public void testVarCharType() {
         // the length fo StarRocks should be 3 times as that of CDC if CDC length * 3 <=
         // StarRocksUtils.MAX_VARCHAR_SIZE
         StarRocksColumn.Builder smallLengthBuilder =
                 new StarRocksColumn.Builder().setColumnName("small_varchar").setOrdinalPosition(0);
-        new VarCharType(3).accept(new StarRocksUtils.CdcDataTypeTransformer(smallLengthBuilder));
+        new VarCharType(3)
+                .accept(new StarRocksUtils.CdcDataTypeTransformer(false, smallLengthBuilder));
         StarRocksColumn smallLengthColumn = smallLengthBuilder.build();
         assertEquals("small_varchar", smallLengthColumn.getColumnName());
         assertEquals(0, smallLengthColumn.getOrdinalPosition());
@@ -75,7 +91,7 @@ public class CdcDataTypeTransformerTest {
         StarRocksColumn.Builder largeLengthBuilder =
                 new StarRocksColumn.Builder().setColumnName("large_varchar").setOrdinalPosition(1);
         new CharType(StarRocksUtils.MAX_VARCHAR_SIZE + 1)
-                .accept(new StarRocksUtils.CdcDataTypeTransformer(largeLengthBuilder));
+                .accept(new StarRocksUtils.CdcDataTypeTransformer(false, largeLengthBuilder));
         StarRocksColumn largeLengthColumn = largeLengthBuilder.build();
         assertEquals("large_varchar", largeLengthColumn.getColumnName());
         assertEquals(1, largeLengthColumn.getOrdinalPosition());


### PR DESCRIPTION
In the StarRocks, The primary key columns can be any of the following data types: BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, LARGEINT, STRING, VARCHAR, DATE, and DATETIME, But it doesn't include CHAR.
When a char type appears in the primary key of MySQL, creating a table in StarRocks requires conversion to varchar type.