### PR TITLE
[cdc] Upgrade to Debezium 1.9.8.Final

### DIFF
--- a/docs/content/quickstart/datastream-api-package-guidance.md
+++ b/docs/content/quickstart/datastream-api-package-guidance.md
@@ -36,7 +36,7 @@ flink 1.17.2  flink mysql cdc 2.4.2
         <flink.version>1.17.2</flink.version>
         <slf4j.version>1.7.15</slf4j.version>
         <log4j.version>2.17.1</log4j.version>
-        <debezium.version>1.9.7.Final</debezium.version>
+        <debezium.version>1.9.8.Final</debezium.version>
     </properties>
     <dependencies>
         <dependency>

--- a/docs/content/快速上手/datastream-api-package-guidance-zh.md
+++ b/docs/content/快速上手/datastream-api-package-guidance-zh.md
@@ -36,7 +36,7 @@ flink 1.17.2  flink mysql cdc 2.4.2
         <flink.version>1.17.2</flink.version>
         <slf4j.version>1.7.15</slf4j.version>
         <log4j.version>2.17.1</log4j.version>
-        <debezium.version>1.9.7.Final</debezium.version>
+        <debezium.version>1.9.8.Final</debezium.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@ under the License.
         <flink.version>1.18.0</flink.version>
         <flink.major.version>1.18</flink.major.version>
         <flink.shaded.version>17.0</flink.shaded.version>
-        <debezium.version>1.9.7.Final</debezium.version>
+        <debezium.version>1.9.8.Final</debezium.version>
         <tikv.version>3.2.0</tikv.version>
         <geometry.version>2.2.0</geometry.version>
         <testcontainers.version>1.18.3</testcontainers.version>


### PR DESCRIPTION
Hey @wuchong, @leonardBang, upgrading to 1.9.8.Final would enable support for streaming off of read replicas with Postgres 16. I've seen though that quite a few classes have been copied from Debezium, so I suppose those would require updating as well? Not sure about the details though, as this probably warrants a discussion about which of those patches could be upstreamed? How should we handle this? 