### PR TITLE
[fix] repair a bug: Sometimes we will get a big chunk when use splitOneUnevenlySizedChunk

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlChunkSplitter.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlChunkSplitter.java
@@ -179,7 +179,7 @@ public class MySqlChunkSplitter implements ChunkSplitter {
                         chunkSize);
         // may sleep a while to avoid DDOS on MySQL server
         maySleep(nextChunkId, tableId);
-        if (chunkEnd != null && ObjectUtils.compare(chunkEnd, minMaxOfSplitColumn[1]) <= 0) {
+        if (chunkEnd != null && ObjectUtils.compare(chunkEnd, minMaxOfSplitColumn[1], jdbcConnection) <= 0) {
             nextChunkStart = ChunkSplitterState.ChunkBound.middleOf(chunkEnd);
             return createSnapshotSplit(
                     jdbcConnection, tableId, nextChunkId++, splitType, chunkStartVal, chunkEnd);
@@ -316,7 +316,7 @@ public class MySqlChunkSplitter implements ChunkSplitter {
             // should query the next one larger than chunkEnd
             chunkEnd = queryMin(jdbc, tableId, splitColumnName, chunkEnd);
         }
-        if (ObjectUtils.compare(chunkEnd, max) >= 0) {
+        if (ObjectUtils.compare(chunkEnd, max, jdbcConnection) >= 0) {
             return null;
         } else {
             return chunkEnd;

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/StatementUtils.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/StatementUtils.java
@@ -321,4 +321,22 @@ public class StatementUtils {
     private static String quotedTableIdString(TableId tableId) {
         return tableId.toQuotedString('`');
     }
+
+    public static int compareStringValueByQuery(JdbcConnection jdbc, String str1, String str2) throws SQLException {
+        final String compareQueryTemplate = "SELECT " +
+                "CASE WHEN '%s' > '%s' THEN 1 " +
+                "WHEN '%s' < '%s' THEN -1 " +
+                "ELSE 0 END";
+        String compareQuery = String.format(compareQueryTemplate, str1, str2, str1, str2);
+        return jdbc.queryAndMap(
+                compareQuery,
+                rs -> {
+                    if(!rs.next()){
+                        throw new SQLException(
+                                String.format("No result returned for query: %s",
+                                        compareQuery));
+                    }
+                    return rs.getInt(1);
+                });
+    }
 }


### PR DESCRIPTION
when use splitOneUnevenlySizedChunk, sometimes we will get a big chunk. For example when the value of primaryKey like ['0000','1111','2222','3333','4444','aaaa','bbbb','cccc','dddd','ZZZZZ',...] almost all of the values which starts with a [a-zA-z] will be split into a big chunk