### PR TITLE
[hotfix] Fix NoSuchMethodError of CollectionUtil.newHashMapWithExpectedSize.

### DIFF
--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/utils/InstantiationUtil.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/utils/InstantiationUtil.java
@@ -19,7 +19,6 @@ package com.ververica.cdc.common.utils;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-import org.apache.flink.util.CollectionUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -112,8 +111,7 @@ public class InstantiationUtil {
 
         // ------------------------------------------------
 
-        private static final HashMap<String, Class<?>> primitiveClasses =
-                CollectionUtil.newHashMapWithExpectedSize(9);
+        private static final HashMap<String, Class<?>> primitiveClasses = new HashMap<>(9);
 
         static {
             primitiveClasses.put("boolean", boolean.class);


### PR DESCRIPTION
This closes https://github.com/ververica/flink-cdc-connectors/issues/2943.
It was verified using Flink 1.17.1, but e2e verification is still required.