### PR TITLE
[cdc-connector][cdc-base][hot-fix] Fix SourceSplitSerializer to get totalFinishedSplitSize from recovery in 4th version.

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/meta/split/SourceSplitSerializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/meta/split/SourceSplitSerializer.java
@@ -159,7 +159,7 @@ public abstract class SourceSplitSerializer
                     readFinishedSplitsInfo(version, in);
             Map<TableId, TableChange> tableChangeMap = readTableSchemas(version, in);
             int totalFinishedSplitSize = finishedSplitsInfo.size();
-            if (version == 3) {
+            if (version >= 3) {
                 totalFinishedSplitSize = in.readInt();
             }
             in.releaseArrays();


### PR DESCRIPTION
From 3rd version of stream split, use totalFinishedSplitSize. But with condition of `version == 3`, cannot 
get totalFinishedSplitSize from recovery deserialization in 4th version.
```java
// com.ververica.cdc.connectors.base.source.meta.split.SourceSplitSerializer#deserializeSplit
     Map<TableId, TableChange> tableChangeMap = readTableSchemas(version, in);
            int totalFinishedSplitSize = finishedSplitsInfo.size();
            if (version == 3) {
                totalFinishedSplitSize = in.readInt();
            }
```

That means that divideMetaToGroups is invalid. A reader  receive and deserialize stream split, totalFinishedSplitSize is always equal to finishedSnapshotSplitInfos, which is a completed splt. See:
```java
// com.ververica.cdc.connectors.base.source.meta.split.StreamSplit#isCompletedSplit
 public boolean isCompletedSplit() {
        return totalFinishedSplitSize == finishedSnapshotSplitInfos.size();
    }
```