### PR TITLE
[cdc-connector][oracle] Expose SNAPSHOT_ONLY mode for Oracle CDC Source

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/reader/fetch/OracleStreamFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/reader/fetch/OracleStreamFetchTask.java
@@ -31,7 +31,6 @@ import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.logminer.LogMinerStreamingChangeEventSource;
 import io.debezium.connector.oracle.logminer.processor.LogMinerEventProcessor;
 import io.debezium.pipeline.ErrorHandler;
-import io.debezium.pipeline.source.spi.ChangeEventSource;
 import io.debezium.util.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,8 +60,8 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
                         sourceFetchContext.getSourceConfig().getOriginDbzConnectorConfig(),
                         sourceFetchContext.getStreamingChangeEventSourceMetrics(),
                         split);
-        RedoLogSplitChangeEventSourceContext changeEventSourceContext =
-                new RedoLogSplitChangeEventSourceContext();
+        StoppableChangeEventSourceContext changeEventSourceContext =
+                new StoppableChangeEventSourceContext();
         redoLogSplitReadTask.execute(
                 changeEventSourceContext,
                 sourceFetchContext.getPartition(),
@@ -158,18 +157,6 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
                     metrics,
                     errorHandler,
                     redoLogSplit);
-        }
-    }
-
-    /**
-     * The {@link ChangeEventSource.ChangeEventSourceContext} implementation for redo log split
-     * task.
-     */
-    private class RedoLogSplitChangeEventSourceContext
-            implements ChangeEventSource.ChangeEventSourceContext {
-        @Override
-        public boolean isRunning() {
-            return taskRunning;
         }
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/reader/fetch/StoppableChangeEventSourceContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/reader/fetch/StoppableChangeEventSourceContext.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.oracle.source.reader.fetch;
+
+import io.debezium.pipeline.source.spi.ChangeEventSource;
+
+/**
+ * A change event source context that can stop the running source by invoking {@link
+ * #stopChangeEventSource()}.
+ */
+public class StoppableChangeEventSourceContext
+        implements ChangeEventSource.ChangeEventSourceContext {
+
+    private volatile boolean isRunning = true;
+
+    public void stopChangeEventSource() {
+        isRunning = false;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return isRunning;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactory.java
@@ -173,6 +173,7 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
     }
 
     private static final String SCAN_STARTUP_MODE_VALUE_INITIAL = "initial";
+    private static final String SCAN_STARTUP_MODE_VALUE_SNAPSHOT = "snapshot";
     private static final String SCAN_STARTUP_MODE_VALUE_LATEST = "latest-offset";
 
     private static StartupOptions getStartupOptions(ReadableConfig config) {
@@ -181,16 +182,18 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
         switch (modeString.toLowerCase()) {
             case SCAN_STARTUP_MODE_VALUE_INITIAL:
                 return StartupOptions.initial();
-
+            case SCAN_STARTUP_MODE_VALUE_SNAPSHOT:
+                return StartupOptions.snapshot();
             case SCAN_STARTUP_MODE_VALUE_LATEST:
                 return StartupOptions.latest();
 
             default:
                 throw new ValidationException(
                         String.format(
-                                "Invalid value for option '%s'. Supported values are [%s, %s], but was: %s",
+                                "Invalid value for option '%s'. Supported values are [%s, %s, %s], but was: %s",
                                 SCAN_STARTUP_MODE.key(),
                                 SCAN_STARTUP_MODE_VALUE_INITIAL,
+                                SCAN_STARTUP_MODE_VALUE_SNAPSHOT,
                                 SCAN_STARTUP_MODE_VALUE_LATEST,
                                 modeString));
         }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/source/OracleSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/source/OracleSourceITCase.java
@@ -131,9 +131,77 @@ public class OracleSourceITCase extends OracleSourceTestBase {
     }
 
     @Test
+    public void testSnapshotOnlyModeWithDMLPostHighWaterMark() throws Exception {
+        // The data num is 21, set fetchSize = 22 to test the job is bounded.
+        List<String> records =
+                testBackfillWhenWritingEvents(
+                        false, 22, USE_POST_HIGHWATERMARK_HOOK, StartupOptions.snapshot());
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[1019, user_20, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Shanghai, 123567891234]");
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    @Test
+    public void testSnapshotOnlyModeWithDMLPreHighWaterMark() throws Exception {
+        // The data num is 21, set fetchSize = 22 to test the job is bounded.
+        List<String> records =
+                testBackfillWhenWritingEvents(
+                        false, 22, USE_PRE_HIGHWATERMARK_HOOK, StartupOptions.snapshot());
+        List<String> expectedRecords =
+                Arrays.asList(
+                        "+I[101, user_1, Shanghai, 123567891234]",
+                        "+I[102, user_2, Shanghai, 123567891234]",
+                        "+I[103, user_3, Shanghai, 123567891234]",
+                        "+I[109, user_4, Shanghai, 123567891234]",
+                        "+I[110, user_5, Shanghai, 123567891234]",
+                        "+I[111, user_6, Shanghai, 123567891234]",
+                        "+I[118, user_7, Shanghai, 123567891234]",
+                        "+I[121, user_8, Shanghai, 123567891234]",
+                        "+I[123, user_9, Shanghai, 123567891234]",
+                        "+I[1009, user_10, Shanghai, 123567891234]",
+                        "+I[1010, user_11, Shanghai, 123567891234]",
+                        "+I[1011, user_12, Shanghai, 123567891234]",
+                        "+I[1012, user_13, Shanghai, 123567891234]",
+                        "+I[1013, user_14, Shanghai, 123567891234]",
+                        "+I[1014, user_15, Shanghai, 123567891234]",
+                        "+I[1015, user_16, Shanghai, 123567891234]",
+                        "+I[1016, user_17, Shanghai, 123567891234]",
+                        "+I[1017, user_18, Shanghai, 123567891234]",
+                        "+I[1018, user_19, Shanghai, 123567891234]",
+                        "+I[2000, user_21, Pittsburgh, 123567891234]",
+                        "+I[15213, user_15213, Shanghai, 123567891234]");
+        // when enable backfill, the wal log between (snapshot, high_watermark) will be
+        // applied as snapshot image
+        assertEqualsInAnyOrder(expectedRecords, records);
+    }
+
+    @Test
     public void testEnableBackfillWithDMLPreHighWaterMark() throws Exception {
 
-        List<String> records = testBackfillWhenWritingEvents(false, 21, USE_PRE_HIGHWATERMARK_HOOK);
+        List<String> records =
+                testBackfillWhenWritingEvents(
+                        false, 21, USE_PRE_HIGHWATERMARK_HOOK, StartupOptions.initial());
 
         List<String> expectedRecords =
                 Arrays.asList(
@@ -165,7 +233,9 @@ public class OracleSourceITCase extends OracleSourceTestBase {
 
     @Test
     public void testEnableBackfillWithDMLPostLowWaterMark() throws Exception {
-        List<String> records = testBackfillWhenWritingEvents(false, 21, USE_POST_LOWWATERMARK_HOOK);
+        List<String> records =
+                testBackfillWhenWritingEvents(
+                        false, 21, USE_POST_LOWWATERMARK_HOOK, StartupOptions.initial());
 
         List<String> expectedRecords =
                 Arrays.asList(
@@ -198,7 +268,8 @@ public class OracleSourceITCase extends OracleSourceTestBase {
     @Test
     public void testEnableBackfillWithDMLPostHighWaterMark() throws Exception {
         List<String> records =
-                testBackfillWhenWritingEvents(false, 21, USE_POST_HIGHWATERMARK_HOOK);
+                testBackfillWhenWritingEvents(
+                        false, 21, USE_POST_HIGHWATERMARK_HOOK, StartupOptions.initial());
 
         List<String> expectedRecords =
                 Arrays.asList(
@@ -230,7 +301,9 @@ public class OracleSourceITCase extends OracleSourceTestBase {
 
     @Test
     public void testSkipBackfillWithDMLPreHighWaterMark() throws Exception {
-        List<String> records = testBackfillWhenWritingEvents(true, 25, USE_PRE_HIGHWATERMARK_HOOK);
+        List<String> records =
+                testBackfillWhenWritingEvents(
+                        true, 25, USE_PRE_HIGHWATERMARK_HOOK, StartupOptions.initial());
 
         List<String> expectedRecords =
                 Arrays.asList(
@@ -267,7 +340,9 @@ public class OracleSourceITCase extends OracleSourceTestBase {
     @Test
     public void testSkipBackfillWithDMLPostLowWaterMark() throws Exception {
 
-        List<String> records = testBackfillWhenWritingEvents(true, 25, USE_POST_LOWWATERMARK_HOOK);
+        List<String> records =
+                testBackfillWhenWritingEvents(
+                        true, 25, USE_POST_LOWWATERMARK_HOOK, StartupOptions.initial());
 
         List<String> expectedRecords =
                 Arrays.asList(
@@ -303,7 +378,11 @@ public class OracleSourceITCase extends OracleSourceTestBase {
     }
 
     private List<String> testBackfillWhenWritingEvents(
-            boolean skipSnapshotBackfill, int fetchSize, int hookType) throws Exception {
+            boolean skipSnapshotBackfill,
+            int fetchSize,
+            int hookType,
+            StartupOptions startupOptions)
+            throws Exception {
         createAndInitialize("customer.sql");
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.enableCheckpointing(200L);
@@ -332,7 +411,7 @@ public class OracleSourceITCase extends OracleSourceTestBase {
                         .schemaList(ORACLE_SCHEMA)
                         .tableList("DEBEZIUM.CUSTOMERS")
                         .skipSnapshotBackfill(skipSnapshotBackfill)
-                        .startupOptions(StartupOptions.initial())
+                        .startupOptions(startupOptions)
                         .deserializer(customerTable.getDeserializer())
                         .build();
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/com/ververica/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
@@ -442,7 +442,7 @@ public class OracleTableSourceFactoryTest {
         } catch (Throwable t) {
             String msg =
                     "Invalid value for option 'scan.startup.mode'. Supported values are "
-                            + "[initial, latest-offset], "
+                            + "[initial, snapshot, latest-offset], "
                             + "but was: abc";
 
             assertTrue(ExceptionUtils.findThrowableWithMessage(t, msg).isPresent());


### PR DESCRIPTION
As shown in https://github.com/ververica/flink-cdc-connectors/issues/2867, expose SNAPSHOT_ONLY mode for Oracle CDC Source  after until https://github.com/ververica/flink-cdc-connectors/issues/2909 is fixed.