### PR TITLE
[fix][cdc-connector][mongo] Fix scanFullChangelog requires all collections (#3008)

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/utils/MongoUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/utils/MongoUtils.java
@@ -222,9 +222,17 @@ public class MongoUtils {
         }
 
         if (fullDocPrePostImage) {
-            // require both pre-image and post-image
-            changeStream.fullDocument(FullDocument.REQUIRED);
-            changeStream.fullDocumentBeforeChange(FullDocumentBeforeChange.REQUIRED);
+            if (StringUtils.isNotEmpty(database) && StringUtils.isNotEmpty(collection)) {
+                // require both pre-image and post-image records
+                changeStream.fullDocument(FullDocument.REQUIRED);
+                changeStream.fullDocumentBeforeChange(FullDocumentBeforeChange.REQUIRED);
+            } else {
+                // for RegEx limited namespaces, use WHEN_AVAILABLE option
+                // to avoid MongoDB complaining about missing pre- and post-image
+                // coming from irrelevant collections
+                changeStream.fullDocument(FullDocument.WHEN_AVAILABLE);
+                changeStream.fullDocumentBeforeChange(FullDocumentBeforeChange.WHEN_AVAILABLE);
+            }
         } else if (updateLookup) {
             changeStream.fullDocument(FullDocument.UPDATE_LOOKUP);
         }


### PR DESCRIPTION
This PR tried to fix issue #3008, which reports that mongo-cdc connector capturing multiple collections with `.scanFullChangelog` option would require every collection saving pre- and post-image records in that database, even for those excluded by RegEx.

## Reason

Currently, [the entire database was watched](https://github.com/ververica/flink-cdc-connectors/blob/9abf2cf900e48df8ee314f10bac28589d77a3617/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/utils/MongoUtils.java#L181) when an regex was provided to specify required collections. According to [MongoDB docs](https://www.mongodb.com/docs/manual/reference/method/db.watch/), `pipeline` only performs filtering in the final output side, so pre-image and post-image related constraints were applied to all collections.

## Changes

This PR loosens pre- and post-image constraints from `.required` to `.whenAvailable` when multiple databases / collections being watched, suppressing the "pre-image was not found for event" error.