### PR TITLE
[cdc-connector][mongodb][hotfix] Close stream fetcher task in MongoDBStreamFetchTask.close

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/reader/fetch/MongoDBStreamFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/reader/fetch/MongoDBStreamFetchTask.java
@@ -225,7 +225,9 @@ public class MongoDBStreamFetchTask implements FetchTask<SourceSplitBase> {
     }
 
     @Override
-    public void close() {}
+    public void close() {
+        taskRunning = false;
+    }
 
     private MongoChangeStreamCursor<BsonDocument> openChangeStreamCursor(
             ChangeStreamDescriptor changeStreamDescriptor) {


### PR DESCRIPTION
In current MongoDBStreamFetchTask, even MongoDBStreamFetchTask is closed, the executor is sitll running.Because nothing is done in MongoDBStreamFetchTask.close now.