### PR TITLE
[improve] Remove repeated dependency.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/pom.xml
@@ -42,13 +42,6 @@ limitations under the License.
         </dependency>
 
         <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-java</artifactId>
-            <version>${flink.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.15</version>

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/pom.xml
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/pom.xml
@@ -395,7 +395,7 @@ limitations under the License.
                         <goals>
                             <goal>wget</goal>
                         </goals>
-                        <phase>compile</phase>
+                        <phase>test</phase>
                         <configuration>
                             <skip>${flink.release.download.skip}</skip>
                             <url>${flink.release.mirror}/${flink.release.name}</url>
@@ -410,7 +410,7 @@ limitations under the License.
                 <executions>
                     <execution>
                         <id>copy-jars</id>
-                        <phase>package</phase>
+                        <phase>test</phase>
                         <goals>
                             <goal>copy</goal>
                         </goals>


### PR DESCRIPTION
Remove repeated dependency of maxcompute, and change the phase of "download-flink-release" in pipeline-e2e-test.