### PR TITLE
[FLINK-37934][cdc-source-connectors] Get the case-sensitive variable names and method names of table id are not standardized, and need to be adjusted

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/utils/MySqlSchemaUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/utils/MySqlSchemaUtils.java
@@ -126,7 +126,7 @@ public class MySqlSchemaUtils {
             MySqlConnection jdbc) {
         // fetch table schemas
         try (MySqlSchema mySqlSchema =
-                new MySqlSchema(sourceConfig, jdbc.isTableIdCaseSensitive())) {
+                new MySqlSchema(sourceConfig, jdbc.isTableIdCaseInsensitive())) {
             TableChanges.TableChange tableSchema =
                     mySqlSchema.getTableSchema(partition, jdbc, toDbzTableId(tableId));
             return toSchema(tableSchema.getTable(), sourceConfig.isTreatTinyInt1AsBoolean());
@@ -160,7 +160,7 @@ public class MySqlSchemaUtils {
 
     public static boolean isTableIdCaseInsensitive(MySqlSourceConfig sourceConfig) {
         try (MySqlConnection jdbc = createMySqlConnection(sourceConfig)) {
-            return jdbc.isTableIdCaseSensitive();
+            return jdbc.isTableIdCaseInsensitive();
         } catch (Exception e) {
             throw new RuntimeException("Error to get table id caseSensitive: " + e.getMessage(), e);
         }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/dialect/DataSourceDialect.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/dialect/DataSourceDialect.java
@@ -67,7 +67,7 @@ public interface DataSourceDialect<C extends SourceConfig> extends Serializable,
     }
 
     /** Check if the CollectionId is case-sensitive or not. */
-    boolean isDataCollectionIdCaseSensitive(C sourceConfig);
+    boolean isDataCollectionIdCaseInsensitive(C sourceConfig);
 
     /** Returns the {@link ChunkSplitter} which used to split collection to splits. */
     @Deprecated

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/IncrementalSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/IncrementalSource.java
@@ -151,14 +151,14 @@ public class IncrementalSource<T, C extends SourceConfig>
             try {
                 final List<TableId> remainingTables =
                         dataSourceDialect.discoverDataCollections(sourceConfig);
-                boolean isTableIdCaseSensitive =
-                        dataSourceDialect.isDataCollectionIdCaseSensitive(sourceConfig);
+                boolean isTableIdCaseInsensitive =
+                        dataSourceDialect.isDataCollectionIdCaseInsensitive(sourceConfig);
                 splitAssigner =
                         new HybridSplitAssigner<>(
                                 sourceConfig,
                                 enumContext.currentParallelism(),
                                 remainingTables,
-                                isTableIdCaseSensitive,
+                                isTableIdCaseInsensitive,
                                 dataSourceDialect,
                                 offsetFactory,
                                 enumContext);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/HybridSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/HybridSplitAssigner.java
@@ -71,7 +71,7 @@ public class HybridSplitAssigner<C extends SourceConfig> implements SplitAssigne
             C sourceConfig,
             int currentParallelism,
             List<TableId> remainingTables,
-            boolean isTableIdCaseSensitive,
+            boolean isTableIdCaseInsensitive,
             DataSourceDialect<C> dialect,
             OffsetFactory offsetFactory,
             SplitEnumeratorContext<? extends SourceSplit> enumeratorContext) {
@@ -81,7 +81,7 @@ public class HybridSplitAssigner<C extends SourceConfig> implements SplitAssigne
                         sourceConfig,
                         currentParallelism,
                         remainingTables,
-                        isTableIdCaseSensitive,
+                        isTableIdCaseInsensitive,
                         dialect,
                         offsetFactory),
                 false,

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/SnapshotSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/SnapshotSplitAssigner.java
@@ -84,7 +84,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
     private final boolean isRemainingTablesCheckpointed;
 
     private ChunkSplitter chunkSplitter;
-    private boolean isTableIdCaseSensitive;
+    private boolean isTableIdCaseInsensitive;
 
     @Nullable private Long checkpointIdToFinish;
     private final DataSourceDialect<C> dialect;
@@ -102,7 +102,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
             C sourceConfig,
             int currentParallelism,
             List<TableId> remainingTables,
-            boolean isTableIdCaseSensitive,
+            boolean isTableIdCaseInsensitive,
             DataSourceDialect<C> dialect,
             OffsetFactory offsetFactory) {
         this(
@@ -115,7 +115,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
                 new HashMap<>(),
                 INITIAL_ASSIGNING,
                 remainingTables,
-                isTableIdCaseSensitive,
+                isTableIdCaseInsensitive,
                 true,
                 dialect,
                 offsetFactory,
@@ -139,7 +139,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
                 checkpoint.getSplitFinishedOffsets(),
                 checkpoint.getSnapshotAssignerStatus(),
                 checkpoint.getRemainingTables(),
-                checkpoint.isTableIdCaseSensitive(),
+                checkpoint.isTableIdCaseInsensitive(),
                 checkpoint.isRemainingTablesCheckpointed(),
                 dialect,
                 offsetFactory,
@@ -157,7 +157,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
             Map<String, Offset> splitFinishedOffsets,
             AssignerStatus assignerStatus,
             List<TableId> remainingTables,
-            boolean isTableIdCaseSensitive,
+            boolean isTableIdCaseInsensitive,
             boolean isRemainingTablesCheckpointed,
             DataSourceDialect<C> dialect,
             OffsetFactory offsetFactory,
@@ -183,7 +183,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
         this.assignerStatus = assignerStatus;
         this.remainingTables = new CopyOnWriteArrayList<>(remainingTables);
         this.isRemainingTablesCheckpointed = isRemainingTablesCheckpointed;
-        this.isTableIdCaseSensitive = isTableIdCaseSensitive;
+        this.isTableIdCaseInsensitive = isTableIdCaseInsensitive;
         this.dialect = dialect;
         this.offsetFactory = offsetFactory;
         this.splitFinishedCheckpointIds = splitFinishedCheckpointIds;
@@ -524,7 +524,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
                         splitFinishedOffsets,
                         assignerStatus,
                         remainingTables,
-                        isTableIdCaseSensitive,
+                        isTableIdCaseInsensitive,
                         true,
                         splitFinishedCheckpointIds,
                         chunkSplitter.snapshotState(checkpointId));

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/state/PendingSplitsStateSerializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/state/PendingSplitsStateSerializer.java
@@ -175,7 +175,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
         writeFinishedOffsets(state.getSplitFinishedOffsets(), out);
         out.writeInt(state.getSnapshotAssignerStatus().getStatusCode());
         writeTableIds(state.getRemainingTables(), out);
-        out.writeBoolean(state.isTableIdCaseSensitive());
+        out.writeBoolean(state.isTableIdCaseInsensitive());
         writeTableSchemas(state.getTableSchemas(), out);
 
         writeSplitFinishedCheckpointIds(state.getSplitFinishedCheckpointIds(), out);
@@ -283,7 +283,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
             }
         }
         List<TableId> remainingTableIds = readTableIds(version, in);
-        boolean isTableIdCaseSensitive = in.readBoolean();
+        boolean isTableIdCaseInsensitive = in.readBoolean();
         final List<SchemalessSnapshotSplit> remainingSchemalessSplits = new ArrayList<>();
         final Map<String, SchemalessSnapshotSplit> assignedSchemalessSnapshotSplits =
                 new HashMap<>();
@@ -333,7 +333,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
                 finishedOffsets,
                 assignerStatus,
                 remainingTableIds,
-                isTableIdCaseSensitive,
+                isTableIdCaseInsensitive,
                 true,
                 splitFinishedCheckpointIds,
                 chunkSplitterState);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/state/SnapshotPendingSplitsState.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/state/SnapshotPendingSplitsState.java
@@ -61,7 +61,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
     private final AssignerStatus assignerStatus;
 
     /** Whether the table identifier is case sensitive. */
-    private final boolean isTableIdCaseSensitive;
+    private final boolean isTableIdCaseInsensitive;
 
     /** Whether the remaining tables are keep when snapshot state. */
     private final boolean isRemainingTablesCheckpointed;
@@ -85,7 +85,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
             Map<String, Offset> splitFinishedOffsets,
             AssignerStatus assignerStatus,
             List<TableId> remainingTables,
-            boolean isTableIdCaseSensitive,
+            boolean isTableIdCaseInsensitive,
             boolean isRemainingTablesCheckpointed,
             Map<String, Long> splitFinishedCheckpointIds,
             ChunkSplitterState chunkSplitterState) {
@@ -95,7 +95,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
         this.splitFinishedOffsets = splitFinishedOffsets;
         this.assignerStatus = assignerStatus;
         this.remainingTables = remainingTables;
-        this.isTableIdCaseSensitive = isTableIdCaseSensitive;
+        this.isTableIdCaseInsensitive = isTableIdCaseInsensitive;
         this.isRemainingTablesCheckpointed = isRemainingTablesCheckpointed;
         this.tableSchemas = tableSchemas;
         this.chunkSplitterState = chunkSplitterState;
@@ -134,8 +134,8 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
         return remainingTables;
     }
 
-    public boolean isTableIdCaseSensitive() {
-        return isTableIdCaseSensitive;
+    public boolean isTableIdCaseInsensitive() {
+        return isTableIdCaseInsensitive;
     }
 
     public boolean isRemainingTablesCheckpointed() {
@@ -156,7 +156,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
         }
         SnapshotPendingSplitsState that = (SnapshotPendingSplitsState) o;
         return Objects.equals(assignerStatus, that.assignerStatus)
-                && isTableIdCaseSensitive == that.isTableIdCaseSensitive
+                && isTableIdCaseInsensitive == that.isTableIdCaseInsensitive
                 && isRemainingTablesCheckpointed == that.isRemainingTablesCheckpointed
                 && Objects.equals(remainingTables, that.remainingTables)
                 && Objects.equals(alreadyProcessedTables, that.alreadyProcessedTables)
@@ -176,7 +176,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
                 assignedSplits,
                 splitFinishedOffsets,
                 assignerStatus,
-                isTableIdCaseSensitive,
+                isTableIdCaseInsensitive,
                 isRemainingTablesCheckpointed,
                 splitFinishedCheckpointIds,
                 chunkSplitterState);
@@ -197,8 +197,8 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
                 + splitFinishedOffsets
                 + ", assignerStatus="
                 + assignerStatus
-                + ", isTableIdCaseSensitive="
-                + isTableIdCaseSensitive
+                + ", isTableIdCaseInsensitive="
+                + isTableIdCaseInsensitive
                 + ", isRemainingTablesCheckpointed="
                 + isRemainingTablesCheckpointed
                 + ", splitFinishedCheckpointIds="

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-db2-cdc/src/main/java/org/apache/flink/cdc/connectors/db2/source/dialect/Db2Dialect.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-db2-cdc/src/main/java/org/apache/flink/cdc/connectors/db2/source/dialect/Db2Dialect.java
@@ -76,7 +76,7 @@ public class Db2Dialect implements JdbcDataSourceDialect {
     }
 
     @Override
-    public boolean isDataCollectionIdCaseSensitive(JdbcSourceConfig sourceConfig) {
+    public boolean isDataCollectionIdCaseInsensitive(JdbcSourceConfig sourceConfig) {
         return true;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/dialect/MongoDBDialect.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/dialect/MongoDBDialect.java
@@ -165,7 +165,7 @@ public class MongoDBDialect implements DataSourceDialect<MongoDBSourceConfig> {
     }
 
     @Override
-    public boolean isDataCollectionIdCaseSensitive(MongoDBSourceConfig sourceConfig) {
+    public boolean isDataCollectionIdCaseInsensitive(MongoDBSourceConfig sourceConfig) {
         // MongoDB's database names and collection names are case-sensitive.
         return true;
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlConnection.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlConnection.java
@@ -496,7 +496,7 @@ public class MySqlConnection extends JdbcConnection {
         return OptionalLong.empty();
     }
 
-    public boolean isTableIdCaseSensitive() {
+    public boolean isTableIdCaseInsensitive() {
         return !"0"
                 .equals(
                         readMySqlSystemVariables()

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/DebeziumUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/DebeziumUtils.java
@@ -104,7 +104,7 @@ public class DebeziumUtils {
 
     /** Creates a new {@link MySqlDatabaseSchema} to monitor the latest MySql database schemas. */
     public static MySqlDatabaseSchema createMySqlDatabaseSchema(
-            MySqlConnectorConfig dbzMySqlConfig, boolean isTableIdCaseSensitive) {
+            MySqlConnectorConfig dbzMySqlConfig, boolean isTableIdCaseInsensitive) {
         TopicSelector<TableId> topicSelector = MySqlTopicSelector.defaultSelector(dbzMySqlConfig);
         SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create();
         MySqlValueConverters valueConverters = getValueConverters(dbzMySqlConfig);
@@ -113,7 +113,7 @@ public class DebeziumUtils {
                 valueConverters,
                 topicSelector,
                 schemaNameAdjuster,
-                isTableIdCaseSensitive);
+                isTableIdCaseInsensitive);
     }
 
     /** Fetch current binlog offsets in MySql Server. */
@@ -208,7 +208,7 @@ public class DebeziumUtils {
         return capturedTableIds;
     }
 
-    public static boolean isTableIdCaseSensitive(JdbcConnection connection) {
+    public static boolean isTableIdCaseInsensitive(JdbcConnection connection) {
         return !"0"
                 .equals(
                         readMySqlSystemVariables(connection)

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
@@ -111,7 +111,7 @@ public class StatefulTaskContext implements AutoCloseable {
 
     public void configure(MySqlSplit mySqlSplit) {
         // initial stateful objects
-        final boolean tableIdCaseInsensitive = connection.isTableIdCaseSensitive();
+        final boolean tableIdCaseInsensitive = connection.isTableIdCaseInsensitive();
         this.topicSelector = MySqlTopicSelector.defaultSelector(connectorConfig);
         EmbeddedFlinkDatabaseHistory.registerHistory(
                 sourceConfig

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/schema/MySqlSchema.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/schema/MySqlSchema.java
@@ -48,10 +48,10 @@ public class MySqlSchema implements AutoCloseable {
     private final MySqlDatabaseSchema databaseSchema;
     private final Map<TableId, TableChange> schemasByTableId;
 
-    public MySqlSchema(MySqlSourceConfig sourceConfig, boolean isTableIdCaseSensitive) {
+    public MySqlSchema(MySqlSourceConfig sourceConfig, boolean isTableIdCaseInsensitive) {
         this.connectorConfig = sourceConfig.getMySqlConnectorConfig();
         this.databaseSchema =
-                DebeziumUtils.createMySqlDatabaseSchema(connectorConfig, isTableIdCaseSensitive);
+                DebeziumUtils.createMySqlDatabaseSchema(connectorConfig, isTableIdCaseInsensitive);
         this.schemasByTableId = new HashMap<>();
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSource.java
@@ -204,13 +204,13 @@ public class MySqlSource<T>
         // In snapshot-only startup option, only split snapshots.
         if (sourceConfig.getStartupOptions().isSnapshotOnly()) {
             try (JdbcConnection jdbc = DebeziumUtils.openJdbcConnection(sourceConfig)) {
-                boolean isTableIdCaseSensitive = DebeziumUtils.isTableIdCaseSensitive(jdbc);
+                boolean isTableIdCaseInsensitive = DebeziumUtils.isTableIdCaseInsensitive(jdbc);
                 splitAssigner =
                         new MySqlSnapshotSplitAssigner(
                                 sourceConfig,
                                 enumContext.currentParallelism(),
                                 new ArrayList<>(),
-                                isTableIdCaseSensitive,
+                                isTableIdCaseInsensitive,
                                 enumContext);
             } catch (Exception e) {
                 throw new FlinkRuntimeException(
@@ -218,13 +218,13 @@ public class MySqlSource<T>
             }
         } else if (!sourceConfig.getStartupOptions().isStreamOnly()) {
             try (JdbcConnection jdbc = DebeziumUtils.openJdbcConnection(sourceConfig)) {
-                boolean isTableIdCaseSensitive = DebeziumUtils.isTableIdCaseSensitive(jdbc);
+                boolean isTableIdCaseInsensitive = DebeziumUtils.isTableIdCaseInsensitive(jdbc);
                 splitAssigner =
                         new MySqlHybridSplitAssigner(
                                 sourceConfig,
                                 enumContext.currentParallelism(),
                                 new ArrayList<>(),
-                                isTableIdCaseSensitive,
+                                isTableIdCaseInsensitive,
                                 enumContext);
             } catch (Exception e) {
                 throw new FlinkRuntimeException(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssigner.java
@@ -60,7 +60,7 @@ public class MySqlHybridSplitAssigner implements MySqlSplitAssigner {
             MySqlSourceConfig sourceConfig,
             int currentParallelism,
             List<TableId> remainingTables,
-            boolean isTableIdCaseSensitive,
+            boolean isTableIdCaseInsensitive,
             SplitEnumeratorContext<MySqlSplit> enumeratorContext) {
         this(
                 sourceConfig,
@@ -68,7 +68,7 @@ public class MySqlHybridSplitAssigner implements MySqlSplitAssigner {
                         sourceConfig,
                         currentParallelism,
                         remainingTables,
-                        isTableIdCaseSensitive,
+                        isTableIdCaseInsensitive,
                         enumeratorContext),
                 false,
                 sourceConfig.getSplitMetaGroupSize());

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/state/PendingSplitsStateSerializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/state/PendingSplitsStateSerializer.java
@@ -161,7 +161,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
         writeFinishedOffsets(state.getSplitFinishedOffsets(), out);
         out.writeInt(state.getSnapshotAssignerStatus().getStatusCode());
         writeTableIds(state.getRemainingTables(), out);
-        out.writeBoolean(state.isTableIdCaseSensitive());
+        out.writeBoolean(state.isTableIdCaseInsensitive());
         MySqlSplitSerializer.writeTableSchemas(state.getTableSchemas(), out);
 
         boolean hasTableIsSplitting =
@@ -265,7 +265,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
             }
         }
         List<TableId> remainingTableIds = readTableIds(in);
-        boolean isTableIdCaseSensitive = in.readBoolean();
+        boolean isTableIdCaseInsensitive = in.readBoolean();
         final List<MySqlSchemalessSnapshotSplit> remainingSchemalessSplits = new ArrayList<>();
         final Map<String, MySqlSchemalessSnapshotSplit> assignedSchemalessSnapshotSplits =
                 new HashMap<>();
@@ -306,7 +306,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
                 finishedOffsets,
                 assignerStatus,
                 remainingTableIds,
-                isTableIdCaseSensitive,
+                isTableIdCaseInsensitive,
                 true,
                 splittingTableId == null
                         ? ChunkSplitterState.NO_SPLITTING_TABLE_STATE

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/state/SnapshotPendingSplitsState.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/state/SnapshotPendingSplitsState.java
@@ -62,7 +62,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
     private final AssignerStatus assignerStatus;
 
     /** Whether the table identifier is case-sensitive. */
-    private final boolean isTableIdCaseSensitive;
+    private final boolean isTableIdCaseInsensitive;
 
     /** Whether the remaining tables are keep when snapshot state. */
     private final boolean isRemainingTablesCheckpointed;
@@ -80,7 +80,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
             Map<String, BinlogOffset> splitFinishedOffsets,
             AssignerStatus assignerStatus,
             List<TableId> remainingTables,
-            boolean isTableIdCaseSensitive,
+            boolean isTableIdCaseInsensitive,
             boolean isRemainingTablesCheckpointed,
             ChunkSplitterState chunkSplitterState) {
         this.alreadyProcessedTables = alreadyProcessedTables;
@@ -89,7 +89,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
         this.splitFinishedOffsets = splitFinishedOffsets;
         this.assignerStatus = assignerStatus;
         this.remainingTables = remainingTables;
-        this.isTableIdCaseSensitive = isTableIdCaseSensitive;
+        this.isTableIdCaseInsensitive = isTableIdCaseInsensitive;
         this.isRemainingTablesCheckpointed = isRemainingTablesCheckpointed;
         this.tableSchemas = tableSchemas;
         this.chunkSplitterState = chunkSplitterState;
@@ -123,8 +123,8 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
         return remainingTables;
     }
 
-    public boolean isTableIdCaseSensitive() {
-        return isTableIdCaseSensitive;
+    public boolean isTableIdCaseInsensitive() {
+        return isTableIdCaseInsensitive;
     }
 
     public boolean isRemainingTablesCheckpointed() {
@@ -145,7 +145,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
         }
         SnapshotPendingSplitsState that = (SnapshotPendingSplitsState) o;
         return assignerStatus == that.assignerStatus
-                && isTableIdCaseSensitive == that.isTableIdCaseSensitive
+                && isTableIdCaseInsensitive == that.isTableIdCaseInsensitive
                 && isRemainingTablesCheckpointed == that.isRemainingTablesCheckpointed
                 && Objects.equals(remainingTables, that.remainingTables)
                 && Objects.equals(alreadyProcessedTables, that.alreadyProcessedTables)
@@ -164,7 +164,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
                 assignedSplits,
                 splitFinishedOffsets,
                 assignerStatus,
-                isTableIdCaseSensitive,
+                isTableIdCaseInsensitive,
                 isRemainingTablesCheckpointed,
                 chunkSplitterState);
     }
@@ -184,8 +184,8 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
                 + splitFinishedOffsets
                 + ", assignerStatus="
                 + assignerStatus
-                + ", isTableIdCaseSensitive="
-                + isTableIdCaseSensitive
+                + ", isTableIdCaseInsensitive="
+                + isTableIdCaseInsensitive
                 + ", isRemainingTablesCheckpointed="
                 + isRemainingTablesCheckpointed
                 + ", chunkSplitterState="

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/utils/TableDiscoveryUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/utils/TableDiscoveryUtils.java
@@ -153,7 +153,7 @@ public class TableDiscoveryUtils {
 
         // fetch table schemas
         try (MySqlSchema mySqlSchema =
-                new MySqlSchema(sourceConfig, jdbc.isTableIdCaseSensitive())) {
+                new MySqlSchema(sourceConfig, jdbc.isTableIdCaseInsensitive())) {
             Map<TableId, TableChange> tableSchemas = new HashMap<>();
             for (TableId tableId : capturedTableIds) {
                 TableChange tableSchema = mySqlSchema.getTableSchema(partition, jdbc, tableId);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/OracleDialect.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/OracleDialect.java
@@ -73,7 +73,7 @@ public class OracleDialect implements JdbcDataSourceDialect {
     }
 
     @Override
-    public boolean isDataCollectionIdCaseSensitive(JdbcSourceConfig sourceConfig) {
+    public boolean isDataCollectionIdCaseInsensitive(JdbcSourceConfig sourceConfig) {
         try (JdbcConnection jdbcConnection = openJdbcConnection(sourceConfig)) {
             OracleConnection oracleConnection = (OracleConnection) jdbcConnection;
             return oracleConnection.getOracleVersion().getMajor() == 11;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresDialect.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresDialect.java
@@ -153,7 +153,7 @@ public class PostgresDialect implements JdbcDataSourceDialect {
     }
 
     @Override
-    public boolean isDataCollectionIdCaseSensitive(JdbcSourceConfig sourceConfig) {
+    public boolean isDataCollectionIdCaseInsensitive(JdbcSourceConfig sourceConfig) {
         // from Postgres docs:
         //
         // SQL is case insensitive about key words and identifiers,

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceBuilder.java
@@ -321,14 +321,14 @@ public class PostgresSourceBuilder<T> {
                 try {
                     final List<TableId> remainingTables =
                             dataSourceDialect.discoverDataCollections(sourceConfig);
-                    boolean isTableIdCaseSensitive =
-                            dataSourceDialect.isDataCollectionIdCaseSensitive(sourceConfig);
+                    boolean isTableIdCaseInsensitive =
+                            dataSourceDialect.isDataCollectionIdCaseInsensitive(sourceConfig);
                     splitAssigner =
                             new HybridSplitAssigner<>(
                                     sourceConfig,
                                     enumContext.currentParallelism(),
                                     remainingTables,
-                                    isTableIdCaseSensitive,
+                                    isTableIdCaseInsensitive,
                                     dataSourceDialect,
                                     offsetFactory,
                                     enumContext);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
@@ -381,7 +381,7 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
                         sourceConfig,
                         DEFAULT_PARALLELISM,
                         discoverTables,
-                        sourceDialect.isDataCollectionIdCaseSensitive(sourceConfig),
+                        sourceDialect.isDataCollectionIdCaseInsensitive(sourceConfig),
                         sourceDialect,
                         offsetFactory);
         snapshotSplitAssigner.initEnumeratorMetrics(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/dialect/SqlServerDialect.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/dialect/SqlServerDialect.java
@@ -75,7 +75,7 @@ public class SqlServerDialect implements JdbcDataSourceDialect {
     }
 
     @Override
-    public boolean isDataCollectionIdCaseSensitive(JdbcSourceConfig sourceConfig) {
+    public boolean isDataCollectionIdCaseInsensitive(JdbcSourceConfig sourceConfig) {
         return true;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/org/apache/flink/cdc/connectors/sqlserver/source/reader/fetch/SqlServerScanFetchTaskTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/org/apache/flink/cdc/connectors/sqlserver/source/reader/fetch/SqlServerScanFetchTaskTest.java
@@ -330,7 +330,7 @@ class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
                         sourceConfig,
                         DEFAULT_PARALLELISM,
                         discoverTables,
-                        sourceDialect.isDataCollectionIdCaseSensitive(sourceConfig),
+                        sourceDialect.isDataCollectionIdCaseInsensitive(sourceConfig),
                         sourceDialect,
                         offsetFactory);
         snapshotSplitAssigner.initEnumeratorMetrics(


### PR DESCRIPTION
[FLINK-37934][cdc-source-connectors] Get the case-sensitive variable names and method names of table id are not standardized, and need to be adjusted