### PR TITLE
[FLINK-38275][Pipeline-connectors][doris]Cannot create a table when the upstream has no primary key and the first column is String

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplier.java
@@ -45,6 +45,7 @@ import org.apache.flink.util.CollectionUtil;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Sets;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.doris.flink.catalog.DorisTypeMapper;
 import org.apache.doris.flink.catalog.doris.DataModel;
 import org.apache.doris.flink.catalog.doris.FieldSchema;
@@ -149,16 +150,14 @@ public class DorisMetadataApplier implements MetadataApplier {
             TableSchema tableSchema = new TableSchema();
             tableSchema.setTable(tableId.getTableName());
             tableSchema.setDatabase(tableId.getSchemaName());
+            tableSchema.setModel(
+                    CollectionUtils.isEmpty(schema.primaryKeys())
+                            ? DataModel.DUPLICATE
+                            : DataModel.UNIQUE);
             tableSchema.setFields(buildFields(schema));
+            tableSchema.setKeys(buildKeys(schema));
             tableSchema.setDistributeKeys(buildDistributeKeys(schema));
             tableSchema.setTableComment(schema.comment());
-
-            if (CollectionUtil.isNullOrEmpty(schema.primaryKeys())) {
-                tableSchema.setModel(DataModel.DUPLICATE);
-            } else {
-                tableSchema.setKeys(schema.primaryKeys());
-                tableSchema.setModel(DataModel.UNIQUE);
-            }
 
             Map<String, String> tableProperties =
                     DorisDataSinkOptions.getPropertiesByPrefix(
@@ -205,6 +204,10 @@ public class DorisMetadataApplier implements MetadataApplier {
                             column.getComment()));
         }
         return fieldSchemaMap;
+    }
+
+    private List<String> buildKeys(Schema schema) {
+        return buildDistributeKeys(schema);
     }
 
     private List<String> buildDistributeKeys(Schema schema) {


### PR DESCRIPTION
If the upstream model lacks PrimaryKeys and the first column is a String, the Doris Sink will identify the model as a duplicate and will not set keys. In this case, an error message will be reported when creating the table: `errCode = 2, detailMessage = String Type should not be used in key column[name]`.

Doris-Flink-Connector handles table creation. https://github.com/apache/doris-flink-connector/blob/master/flink-doris-connector/src/main/java/org/apache/doris/flink/catalog/doris/DorisSchemaFactory.java#L226-L227 If the key is a String, the type is changed to Varchar(65535). Therefore, the first key set here can be used as the table key.

