### PR TITLE
[FLINK-38310] Fix handling binary boundaries in FinishedSnapshotSplitInfo

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/pom.xml
@@ -27,6 +27,10 @@ limitations under the License.
 
     <artifactId>flink-cdc-base</artifactId>
 
+    <properties>
+        <mockito.version>3.4.6</mockito.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -145,5 +149,14 @@ limitations under the License.
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <type>jar</type>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/FinishedSnapshotSplitInfo.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/FinishedSnapshotSplitInfo.java
@@ -92,16 +92,16 @@ public class FinishedSnapshotSplitInfo implements OffsetDeserializerSerializer {
         FinishedSnapshotSplitInfo that = (FinishedSnapshotSplitInfo) o;
         return Objects.equals(tableId, that.tableId)
                 && Objects.equals(splitId, that.splitId)
-                && Arrays.equals(splitStart, that.splitStart)
-                && Arrays.equals(splitEnd, that.splitEnd)
+                && Arrays.deepEquals(splitStart, that.splitStart)
+                && Arrays.deepEquals(splitEnd, that.splitEnd)
                 && Objects.equals(highWatermark, that.highWatermark);
     }
 
     @Override
     public int hashCode() {
         int result = Objects.hash(tableId, splitId, highWatermark);
-        result = 31 * result + Arrays.hashCode(splitStart);
-        result = 31 * result + Arrays.hashCode(splitEnd);
+        result = 31 * result + Arrays.deepHashCode(splitStart);
+        result = 31 * result + Arrays.deepHashCode(splitEnd);
         return result;
     }
 
@@ -114,9 +114,9 @@ public class FinishedSnapshotSplitInfo implements OffsetDeserializerSerializer {
                 + splitId
                 + '\''
                 + ", splitStart="
-                + Arrays.toString(splitStart)
+                + Arrays.deepToString(splitStart)
                 + ", splitEnd="
-                + Arrays.toString(splitEnd)
+                + Arrays.deepToString(splitEnd)
                 + ", highWatermark="
                 + highWatermark
                 + '}';

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/source/meta/split/FinishedSnapshotSplitInfoTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/source/meta/split/FinishedSnapshotSplitInfoTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.source.meta.split;
+
+import org.apache.flink.cdc.connectors.base.source.meta.offset.OffsetFactory;
+
+import io.debezium.relational.TableId;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.function.Function;
+
+/** Unit tests for {@link FinishedSnapshotSplitInfo}. */
+class FinishedSnapshotSplitInfoTest {
+    @Test
+    void testInfosWithBinaryPrimaryKeyAreEqual() {
+        assertInfosWithBinaryPrimaryKeyAreEqual(Function.identity());
+    }
+
+    @Test
+    void testInfosWithBinaryPrimaryKeyHaveEqualHashCodes() {
+        assertInfosWithBinaryPrimaryKeyAreEqual(FinishedSnapshotSplitInfo::hashCode);
+    }
+
+    @Test
+    void testInfosWithBinaryPrimaryKeyHaveEqualStringRepresentations() {
+        assertInfosWithBinaryPrimaryKeyAreEqual(FinishedSnapshotSplitInfo::toString);
+    }
+
+    private <R> void assertInfosWithBinaryPrimaryKeyAreEqual(
+            Function<FinishedSnapshotSplitInfo, R> function) {
+        FinishedSnapshotSplitInfo original =
+                new FinishedSnapshotSplitInfo(
+                        TableId.parse("table"),
+                        "split-1",
+                        new Object[] {new byte[] {0x01, 0x02}},
+                        new Object[] {new byte[] {0x03, 0x04}},
+                        null,
+                        Mockito.mock(OffsetFactory.class));
+
+        FinishedSnapshotSplitInfo copy = original.deserialize(original.serialize());
+
+        Assertions.assertThat(function.apply(copy)).isEqualTo(function.apply(original));
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/split/FinishedSnapshotSplitInfo.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/split/FinishedSnapshotSplitInfo.java
@@ -89,16 +89,16 @@ public class FinishedSnapshotSplitInfo {
         FinishedSnapshotSplitInfo that = (FinishedSnapshotSplitInfo) o;
         return Objects.equals(tableId, that.tableId)
                 && Objects.equals(splitId, that.splitId)
-                && Arrays.equals(splitStart, that.splitStart)
-                && Arrays.equals(splitEnd, that.splitEnd)
+                && Arrays.deepEquals(splitStart, that.splitStart)
+                && Arrays.deepEquals(splitEnd, that.splitEnd)
                 && Objects.equals(highWatermark, that.highWatermark);
     }
 
     @Override
     public int hashCode() {
         int result = Objects.hash(tableId, splitId, highWatermark);
-        result = 31 * result + Arrays.hashCode(splitStart);
-        result = 31 * result + Arrays.hashCode(splitEnd);
+        result = 31 * result + Arrays.deepHashCode(splitStart);
+        result = 31 * result + Arrays.deepHashCode(splitEnd);
         return result;
     }
 
@@ -111,9 +111,9 @@ public class FinishedSnapshotSplitInfo {
                 + splitId
                 + '\''
                 + ", splitStart="
-                + Arrays.toString(splitStart)
+                + Arrays.deepToString(splitStart)
                 + ", splitEnd="
-                + Arrays.toString(splitEnd)
+                + Arrays.deepToString(splitEnd)
                 + ", highWatermark="
                 + highWatermark
                 + '}';

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/split/FinishedSnapshotSplitInfoTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/split/FinishedSnapshotSplitInfoTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.source.split;
+
+import org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffset;
+
+import io.debezium.relational.TableId;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Function;
+
+/** Unit tests for {@link FinishedSnapshotSplitInfo}. */
+class FinishedSnapshotSplitInfoTest {
+    @Test
+    void testInfosWithBinaryPrimaryKeyAreEqual() {
+        assertInfosWithBinaryPrimaryKeyAreEqual(Function.identity());
+    }
+
+    @Test
+    void testInfosWithBinaryPrimaryKeyHaveEqualHashCodes() {
+        assertInfosWithBinaryPrimaryKeyAreEqual(FinishedSnapshotSplitInfo::hashCode);
+    }
+
+    @Test
+    void testInfosWithBinaryPrimaryKeyHaveEqualStringRepresentations() {
+        assertInfosWithBinaryPrimaryKeyAreEqual(FinishedSnapshotSplitInfo::toString);
+    }
+
+    private <R> void assertInfosWithBinaryPrimaryKeyAreEqual(
+            Function<FinishedSnapshotSplitInfo, R> function) {
+        FinishedSnapshotSplitInfo original =
+                new FinishedSnapshotSplitInfo(
+                        TableId.parse("table"),
+                        "split-1",
+                        new Object[] {new byte[] {0x01, 0x02}},
+                        new Object[] {new byte[] {0x03, 0x04}},
+                        BinlogOffset.ofBinlogFilePosition("mysql-bin.000001", 12345L));
+
+        FinishedSnapshotSplitInfo copy =
+                FinishedSnapshotSplitInfo.deserialize(
+                        FinishedSnapshotSplitInfo.serialize(original));
+
+        Assertions.assertThat(function.apply(copy)).isEqualTo(function.apply(original));
+    }
+}


### PR DESCRIPTION
I believe this change is backward-compatible as `FinishedSnapshotSplitInfo` hashes are not used anywhere. Even if it was, the BC break would only impact the cases where the keys are binary (which are broken anyways).