### PR TITLE
[hotfix] [docs] Fixed typo on Parameter name for OracleCDC Adapter

### DIFF
--- a/docs/content.zh/docs/faq/faq.md
+++ b/docs/content.zh/docs/faq/faq.md
@@ -322,7 +322,7 @@ ChangeStream 需要 MongoDB 以副本集或者分片模式运行，本地测试�
 
 ### Q3: Oracle CDC 如何切换成 XStream 的方式？
 
-添加 debezium 的配置项 'database.connection.adpter' = 'xstream'， 如果使用 SQL 的方式，则在表的 option 中添加配置项 'debezium.database.connection.adpter' = 'xstream'
+添加 debezium 的配置项 'database.connection.adapter' = 'xstream'， 如果使用 SQL 的方式，则在表的 option 中添加配置项 'debezium.database.connection.adapter' = 'xstream'
 
 ### Q4: Oracle CDC 的 database-name 和 schema-name 分别是什么?
 

--- a/docs/content/docs/faq/faq.md
+++ b/docs/content/docs/faq/faq.md
@@ -329,7 +329,7 @@ If it is the DataStream API, add the configuration item of debezium 'database.ta
 
 ### Q3: How does Oracle CDC switch to XStream?
 
-Add configuration item  'database.connection.adpter' = 'xstream', please use the configuration item 'debezium.database.connection.adpter' = 'xstream' if you're using SQL API.
+Add configuration item  'database.connection.adapter' = 'xstream', please use the configuration item 'debezium.database.connection.adapter' = 'xstream' if you're using SQL API.
 
 ### Q4: What are the database name and schema name of Oracle CDC?
 


### PR DESCRIPTION
In both English and Chinese FAQ pages, the parameter name for the XStream adapter for OracleCDC had typo, it has been fixed by changing from "adpter" to "adapter"