### PR TITLE
[build] Automate property replacement in pom.xml and exclude the release directory from license checks.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -421,6 +421,8 @@ limitations under the License.
                     </licenseFamilies>
                     <excludes>
                         <!-- Additional files like .gitignore etc.-->
+                        <!-- Release files -->
+                        <exclude>**/release/**</exclude>
                         <exclude>**/README.md</exclude>
                         <exclude>**/.*/**</exclude>
                         <!-- Generated content -->
@@ -674,6 +676,16 @@ limitations under the License.
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+
+            <!-- Allow modification of pom.xml properties using Maven commands. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
                 </configuration>
             </plugin>
         </plugins>

--- a/tools/releasing/update_branch_version.sh
+++ b/tools/releasing/update_branch_version.sh
@@ -52,6 +52,7 @@ cd ${PROJECT_ROOT}
 
 # change version in all pom files
 mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${NEW_VERSION}
+mvn versions:set-property -Dproperty=revision -DnewVersion=${NEW_VERSION}
 
 git commit -am "[release] Update version to ${NEW_VERSION}"
 


### PR DESCRIPTION
Avoid the following manual operation mentioned in this release document https://cwiki.apache.org/confluence/display/FLINK/Creating+a+Flink+CDC+Release#CreatingaFlinkCDCRelease-Buildareleasecandidate, which is because the mvn versions:set command cannot modify the <properties> section in the pom.xml file.
```
# NOTE: Here manually change the value of <revision> property to $RELEASE_VERSION in root POM, and include the change into the latest commit using "--amend"
```


and some build artifacts are stored in the release directory. To continue with Maven builds, skip license checks for these files.