### PR TITLE
[FLINK-38620][pipeline-connector][iceberg] fixed iceberg metrics NullPointerException

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/main/java/org/apache/flink/cdc/connectors/iceberg/sink/v2/IcebergCommitter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/main/java/org/apache/flink/cdc/connectors/iceberg/sink/v2/IcebergCommitter.java
@@ -137,7 +137,9 @@ public class IcebergCommitter implements Committer<WriteResultWrapper> {
             }
             MetricGroup tableIdMetricGroup =
                     metricGroup
-                            .addGroup(NAMESPACE_GROUP_KEY, tableId.getNamespace())
+                            .addGroup(
+                                    NAMESPACE_GROUP_KEY,
+                                    tableId.getNamespace() == null ? "" : tableId.getNamespace())
                             .addGroup(SCHEMA_GROUP_KEY, tableId.getSchemaName())
                             .addGroup(TABLE_GROUP_KEY, tableId.getTableName());
             TableMetric tableMetric = new TableMetric(tableIdMetricGroup);


### PR DESCRIPTION
fixed [FLINK-38620](https://issues.apache.org/jira/browse/FLINK-38620)

iceberg **TableId.namespace** may be null, then 
```
Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null
Caught exception while executing runnable in main thread. java.lang.NullPointerException: null at org.apache.flink.runtime.metrics.dump.MetricQueryService.replaceInvalidChars(MetricQueryService.java:228) ~[flink-dist-1.20.2.jar:1.20.2] at org.apache.flink.runtime.metrics.dump.MetricQueryService.access$000(MetricQueryService.java:53) ~[flink-dist-1.20.2.jar:1.20.2] at
```

It will not affect the task. However, indicators cannot be seen in the metric