### PR TITLE
[FLINK-38685][cdc-connector-postgresql] Redact sensitive information like password from logs

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java
@@ -69,7 +69,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
-import java.util.Properties;
 
 import static io.debezium.connector.AbstractSourceInfo.SCHEMA_NAME_KEY;
 import static io.debezium.connector.AbstractSourceInfo.TABLE_NAME_KEY;


### PR DESCRIPTION
The Flink Postgres CDC connector, when initialising, logs the complete connector configuration, including the database.password property, in plain text to the TaskManager logs.
This fix redacts such sensitive information from being leaked in logs.

Current behaviour
`2025-11-14 11:04:29,954 INFO  org.apache.flink.cdc.connectors.postgres.source.fetch.PostgresSourceFetchTaskContext [] - PostgresConnectorConfig is {connector.class=io.debezium.connector.postgresql.PostgresConnector, slot.name=flink_cdh_sample_1_3, schema.include.list=public, provide.transaction.metadata=true, include.schema.changes=false, database.sslmode=require, database.history.skip.unparseable.ddl=true, database.sslfactory=org.postgresql.ssl.NonValidatingFactory, database.history.instance.name=6d5b0651-f15b-49f3-a210-32a4654158de_3, database.tcpKeepAlive=true, database.dbname=foo_sample, database.user=foo_user, slot.drop.on.stop=true, database.history.refer.ddl=true, database.server.name=postgres_cdc_source, heartbeat.interval.ms=0, plugin.name=pgoutput, database.port=5432, database.hostname=postgres, database.password=postgres, database.sslrootcert=, table.include.list=public.foo_sample_users, database.history=org.apache.flink.cdc.connectors.base.source.EmbeddedFlinkDatabaseHistory, snapshot.mode=never}`

After this fix
Log line removed