### PR TITLE
infra: update markdown lint check

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check dead links
-        uses: gaurav-nelson/github-action-markdown-link-check@1.0.15
+        uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225
         with:
           config-file: '.dlc.json'
       - name: Build doc


### PR DESCRIPTION
use tcort/github-action-markdown-link-check, gaurav-nelson/github-action-markdown-link-check is deprecated

See https://github.com/apache/infrastructure-actions/issues/371