### PR TITLE
[cdc-connector-mysql] Add MySQL 8.4+ compatibility for binlog status command

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlConnection.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlConnection.java
@@ -23,6 +23,7 @@ import io.debezium.relational.TableId;
 import io.debezium.relational.history.DatabaseHistory;
 import io.debezium.schema.DatabaseSchema;
 import io.debezium.util.Strings;
+import org.apache.flink.cdc.connectors.mysql.debezium.DebeziumUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -275,7 +276,7 @@ public class MySqlConnection extends JdbcConnection {
     public String knownGtidSet() {
         try {
             return queryAndMap(
-                    "SHOW MASTER STATUS",
+                    DebeziumUtils.getBinlogStatusCommand(this),
                     rs -> {
                         if (rs.next() && rs.getMetaData().getColumnCount() > 4) {
                             return rs.getString(


### PR DESCRIPTION
MySQL 8.4+ removed the SHOW MASTER STATUS command and replaced it with
  SHOW BINARY LOG STATUS. This change adds version detection to automatically
  use the appropriate command based on the MySQL server version.

  Changes:
  - Added getBinlogStatusCommand() method in DebeziumUtils to detect MySQL
    version and return the correct binlog status command
  - MySQL 8.4+ uses SHOW BINARY LOG STATUS
  - Earlier versions continue to use SHOW MASTER STATUS
  - Updated MySqlConnection to use the new version-aware method

  This ensures compatibility across MySQL 5.7, 8.0, 8.4+, and future versions.