### PR TITLE
[hotfix] Fix build_docs GHA workflow not working after Java 11 upgrade

### DIFF
--- a/.github/workflows/docs.sh
+++ b/.github/workflows/docs.sh
@@ -18,6 +18,11 @@
 ################################################################################
 set -e
 
+# override env to use Java 11 to for build instead default Java 8
+# path to JDK is taken from https://github.com/apache/flink-connector-shared-utils/blob/ci_utils/docker/base/Dockerfile#L37-L40
+export JAVA_HOME=$JAVA_HOME_11_X64
+export PATH=$JAVA_HOME_11_X64/bin:$PATH
+
 mvn --version
 java -version
 javadoc -J-version


### PR DESCRIPTION
Specify default JDK version to resolve compilation failure like https://github.com/apache/flink-cdc/actions/runs/20563581361/job/59057922998?pr=4190.