### PR TITLE
[FLINK-38847][Postgres-cdc] Fix ConnectionPoolId  to use username 

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresConnectionPoolFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresConnectionPoolFactory.java
@@ -47,7 +47,7 @@ public class PostgresConnectionPoolFactory extends JdbcConnectionPoolFactory {
         return new ConnectionPoolId(
                 config.getHostname(),
                 config.getPort(),
-                config.getHostname(),
+                config.getUser(),
                 config.getDatabase(),
                 dataSourcePoolFactoryIdentifier);
     }


### PR DESCRIPTION
When constructing the ConnectionPoolId, the hostname was mistakenly used as the user.