### PR TITLE
[FLINK-38601][mongodb] Catch throwable errors when consuming from unbounded streams

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/reader/fetch/MongoDBStreamFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/reader/fetch/MongoDBStreamFetchTask.java
@@ -221,6 +221,10 @@ public class MongoDBStreamFetchTask implements FetchTask<SourceSplitBase> {
         } catch (Exception e) {
             LOG.error("Poll change stream records failed ", e);
             throw e;
+        } catch (Throwable t) {
+            // Handle error
+            LOG.error("Fatal error when polling change stream records: ", t);
+            throw new RuntimeException("Fatal error when polling change stream records", t);
         } finally {
             taskRunning = false;
             if (changeStreamCursor != null) {


### PR DESCRIPTION
This PR fixes a issue in the Flink MongoDB CDC connector where certain fatal errors (like OutOfMemoryError, StackOverflowError) were silently swallowed, causing the CDC pipeline to stop running without propagating the error or triggering any recovery mechanism.