### PR TITLE
[FLINK-38881][postgres] Support partition table routing for PostgreSQL CDC

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/PatternCache.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/PatternCache.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.utils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * LRU cache for compiled {@link Pattern} instances.
+ *
+ * <p>It avoids repeated {@link Pattern#compile(String)} calls for the same regex.
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ * Pattern pattern = PatternCache.getPattern("aia_t_icc_jjdb_\\d{6}");
+ * Matcher matcher = pattern.matcher(tableName);
+ * }</pre>
+ */
+public class PatternCache {
+
+    /** Maximum number of cached patterns. */
+    private static final int MAX_CACHE_SIZE = 100;
+
+    /** Pattern cache with LRU eviction. */
+    private static final Map<String, Pattern> CACHE =
+            new LinkedHashMap<String, Pattern>(16, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, Pattern> eldest) {
+                    return size() > MAX_CACHE_SIZE;
+                }
+            };
+
+    /**
+     * Returns a cached {@link Pattern} or compiles and caches it.
+     *
+     * @param regex regular expression
+     * @return compiled {@link Pattern}
+     */
+    public static synchronized Pattern getPattern(String regex) {
+        return CACHE.computeIfAbsent(regex, Pattern::compile);
+    }
+
+    /** Clears the cache (mainly for tests). */
+    public static synchronized void clear() {
+        CACHE.clear();
+    }
+
+    /** Returns the current cache size. */
+    public static synchronized int size() {
+        return CACHE.size();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/factory/PostgresDataSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/factory/PostgresDataSourceFactory.java
@@ -32,6 +32,8 @@ import org.apache.flink.cdc.connectors.base.options.StartupOptions;
 import org.apache.flink.cdc.connectors.postgres.source.PostgresDataSource;
 import org.apache.flink.cdc.connectors.postgres.source.PostgresSourceBuilder;
 import org.apache.flink.cdc.connectors.postgres.source.config.PostgresSourceConfigFactory;
+import org.apache.flink.cdc.connectors.postgres.source.utils.PostgresPartitionInclusionDecider;
+import org.apache.flink.cdc.connectors.postgres.source.utils.PostgresPartitionRouter;
 import org.apache.flink.cdc.connectors.postgres.table.PostgreSQLReadableMetadata;
 import org.apache.flink.cdc.connectors.postgres.utils.PostgresSchemaUtils;
 import org.apache.flink.table.api.ValidationException;
@@ -60,12 +62,15 @@ import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSource
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.CONNECTION_POOL_SIZE;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.CONNECT_MAX_RETRIES;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.CONNECT_TIMEOUT;
+import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.DATABASE;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.DECODING_PLUGIN_NAME;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.HEARTBEAT_INTERVAL;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.HOSTNAME;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.METADATA_LIST;
+import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.PARTITION_TABLES;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.PASSWORD;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.PG_PORT;
+import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.SCAN_INCLUDE_PARTITIONED_TABLES_ENABLED;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN;
@@ -74,6 +79,7 @@ import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSource
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.SCAN_LSN_COMMIT_CHECKPOINTS_DELAY;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.SCAN_SNAPSHOT_FETCH_SIZE;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.SCAN_STARTUP_MODE;
+import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.SCHEMA;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.SERVER_TIME_ZONE;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.SLOT_NAME;
 import static org.apache.flink.cdc.connectors.postgres.source.PostgresDataSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND;
@@ -109,6 +115,17 @@ public class PostgresDataSourceFactory implements DataSourceFactory {
         String password = config.get(PASSWORD);
         String chunkKeyColumn = config.get(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN);
         String tables = config.get(TABLES);
+        String partitionTables = config.get(PARTITION_TABLES);
+
+        // Validate: at least one of 'tables' or 'partition.tables' must be configured
+        if ((tables == null || tables.trim().isEmpty())
+                && (partitionTables == null || partitionTables.trim().isEmpty())) {
+            throw new IllegalArgumentException(
+                    "At least one of 'tables' or 'partition.tables' must be configured.");
+        }
+
+        String explicitDatabase = config.get(DATABASE);
+        String explicitSchema = config.get(SCHEMA);
         ZoneId serverTimeZone = getServerTimeZone(config);
         String tablesExclude = config.get(TABLES_EXCLUDE);
         Duration heartbeatInterval = config.get(HEARTBEAT_INTERVAL);
@@ -141,13 +158,53 @@ public class PostgresDataSourceFactory implements DataSourceFactory {
         validateDistributionFactorLower(distributionFactorLower);
 
         Map<String, String> configMap = config.toMap();
-        Optional<String> databaseName = getValidateDatabaseName(tables);
+        boolean includePartitionedTables = config.get(SCAN_INCLUDE_PARTITIONED_TABLES_ENABLED);
+        java.util.Properties dbzProps = new java.util.Properties();
+        dbzProps.putAll(getDebeziumProperties(configMap));
+        // Determine database: prefer explicit option, otherwise infer from tables
+        String databaseToUse;
+        Optional<String> databaseFromTables = getValidateDatabaseName(tables);
+        if (!StringUtils.isNullOrWhitespaceOnly(explicitDatabase)) {
+            checkState(
+                    isValidPostgresDbName(explicitDatabase),
+                    String.format("%s is not a valid PostgreSQL database name", explicitDatabase));
+            if (databaseFromTables.isPresent()) {
+                checkState(
+                        explicitDatabase.equals(databaseFromTables.get()),
+                        "The value of option `database` is `%s`, but not all table names have the same or matching database name in `tables` = %s",
+                        explicitDatabase,
+                        tables);
+            }
+            databaseToUse = explicitDatabase;
+        } else {
+            checkState(
+                    databaseFromTables.isPresent(),
+                    String.format(
+                            "Cannot determine database. Please set '%s' or include database in '%s' (format db.schema.table)",
+                            DATABASE.key(), TABLES.key()));
+            databaseToUse = databaseFromTables.get();
+        }
+
+        // Qualify tables/partitionTables/tablesExclude with default schema when provided
+        if (!StringUtils.isNullOrWhitespaceOnly(explicitSchema)) {
+            checkState(
+                    isValidPostgresDbName(explicitSchema),
+                    String.format("%s is not a valid PostgreSQL schema name", explicitSchema));
+            tables = qualifyWithDefaultSchemaForTables(tables, explicitSchema);
+            if (partitionTables != null) {
+                partitionTables =
+                        qualifyWithDefaultSchemaForPartitions(partitionTables, explicitSchema);
+            }
+            if (tablesExclude != null) {
+                tablesExclude = qualifyWithDefaultSchemaForTables(tablesExclude, explicitSchema);
+            }
+        }
 
         PostgresSourceConfigFactory configFactory =
                 PostgresSourceBuilder.PostgresIncrementalSource.<RowData>builder()
                         .hostname(hostname)
                         .port(port)
-                        .database(databaseName.get())
+                        .database(databaseToUse)
                         .schemaList(".*")
                         .tableList(".*")
                         .username(username)
@@ -155,7 +212,7 @@ public class PostgresDataSourceFactory implements DataSourceFactory {
                         .decodingPluginName(pluginName)
                         .slotName(slotName)
                         .serverTimeZone(serverTimeZone.getId())
-                        .debeziumProperties(getDebeziumProperties(configMap))
+                        .debeziumProperties(dbzProps)
                         .splitSize(splitSize)
                         .splitMetaGroupSize(splitMetaGroupSize)
                         .distributionFactorUpper(distributionFactorUpper)
@@ -171,12 +228,20 @@ public class PostgresDataSourceFactory implements DataSourceFactory {
                         .skipSnapshotBackfill(skipSnapshotBackfill)
                         .lsnCommitCheckpointsDelay(lsnCommitCheckpointsDelay)
                         .assignUnboundedChunkFirst(isAssignUnboundedChunkFirst)
+                        // Enable enumerator to track and discover newly added tables/partitions
+                        .scanNewlyAddedTableEnabled(true)
+                        .includePartitionedTables(includePartitionedTables)
+                        .partitionTables(partitionTables)
                         .includeDatabaseInTableId(tableIdIncludeDatabase)
                         .getConfigFactory();
 
+        // Always discover tables to validate user patterns, using a temporary wide-open config
         List<TableId> tableIds = PostgresSchemaUtils.listTables(configFactory.create(0), null);
-
-        Selectors selectors = new Selectors.SelectorsBuilder().includeTables(tables).build();
+        PostgresPartitionRouter postgresPartitionRouter =
+                new PostgresPartitionRouter(includePartitionedTables, tables, partitionTables);
+        PostgresPartitionInclusionDecider inclusionDecider =
+                new PostgresPartitionInclusionDecider(t -> true, postgresPartitionRouter);
+        Selectors selectors = inclusionDecider.getSelectors();
         List<String> capturedTables = getTableList(tableIds, selectors);
         if (capturedTables.isEmpty()) {
             throw new IllegalArgumentException(
@@ -196,12 +261,10 @@ public class PostgresDataSourceFactory implements DataSourceFactory {
             }
         }
         configFactory.tableList(capturedTables.toArray(new String[0]));
-
         String metadataList = config.get(METADATA_LIST);
         List<PostgreSQLReadableMetadata> readableMetadataList = listReadableMetadata(metadataList);
 
-        // Create a custom PostgresDataSource that passes the includeDatabaseInTableId flag
-        return new PostgresDataSource(configFactory, readableMetadataList);
+        return new PostgresDataSource(configFactory, readableMetadataList, postgresPartitionRouter);
     }
 
     private List<PostgreSQLReadableMetadata> listReadableMetadata(String metadataList) {
@@ -234,7 +297,6 @@ public class PostgresDataSourceFactory implements DataSourceFactory {
         options.add(HOSTNAME);
         options.add(USERNAME);
         options.add(PASSWORD);
-        options.add(TABLES);
         options.add(SLOT_NAME);
         return options;
     }
@@ -242,8 +304,12 @@ public class PostgresDataSourceFactory implements DataSourceFactory {
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(TABLES);
+        options.add(DATABASE);
+        options.add(SCHEMA);
         options.add(PG_PORT);
         options.add(TABLES_EXCLUDE);
+        options.add(PARTITION_TABLES);
         options.add(DECODING_PLUGIN_NAME);
         options.add(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE);
         options.add(SCAN_SNAPSHOT_FETCH_SIZE);
@@ -261,6 +327,7 @@ public class PostgresDataSourceFactory implements DataSourceFactory {
         options.add(SCAN_LSN_COMMIT_CHECKPOINTS_DELAY);
         options.add(METADATA_LIST);
         options.add(SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED);
+        options.add(SCAN_INCLUDE_PARTITIONED_TABLES_ENABLED);
         options.add(TABLE_ID_INCLUDE_DATABASE);
         return options;
     }
@@ -272,10 +339,151 @@ public class PostgresDataSourceFactory implements DataSourceFactory {
 
     private static List<String> getTableList(
             @Nullable List<TableId> tableIdList, Selectors selectors) {
-        return tableIdList.stream()
-                .filter(selectors::isMatch)
-                .map(TableId::toString)
-                .collect(Collectors.toList());
+        List<String> result = new ArrayList<>();
+        if (tableIdList == null || tableIdList.isEmpty()) {
+            return result;
+        }
+        for (TableId t : tableIdList) {
+            if (selectors.isMatch(t)) {
+                result.add(t.toString());
+            }
+        }
+        return result;
+    }
+
+    /** Return true if pattern contains an unescaped dot (.) character. */
+    private static boolean containsUnescapedDot(String s) {
+        if (s == null || s.isEmpty()) {
+            return false;
+        }
+        boolean escaped = false;
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (c == '\\') {
+                escaped = true;
+                continue;
+            }
+            if (c == '.') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsEscapedDotBetweenIdentifiers(String s) {
+        if (s == null || s.length() < 3) {
+            return false;
+        }
+        for (int i = 0; i + 1 < s.length(); i++) {
+            if (s.charAt(i) == '\\' && s.charAt(i + 1) == '.') {
+                char prev = i > 0 ? s.charAt(i - 1) : 0;
+                char next = i + 2 < s.length() ? s.charAt(i + 2) : 0;
+                if (isIdentifierLike(prev) && isIdentifierLike(next)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean isIdentifierLike(char c) {
+        return Character.isLetterOrDigit(c) || c == '_' || c == '"';
+    }
+
+    private static boolean hasSchemaOrNamespaceForTables(String pattern) {
+        if (pattern == null) {
+            return false;
+        }
+        // For `tables` and `tables.exclude`, Selectors split by unescaped dots only. For patterns
+        // containing escaped dots between identifier-like characters (e.g. "inventory\\.products"
+        // to match a literal dot in the table name), we avoid injecting default schema prefixes,
+        // because doing so would change matching semantics (table-only vs schema-qualified).
+        return containsUnescapedDot(pattern) || containsEscapedDotBetweenIdentifiers(pattern);
+    }
+
+    private static boolean hasSchemaOrNamespaceForPartitions(String pattern) {
+        if (pattern == null) {
+            return false;
+        }
+        // For `partition.tables`, routing supports both "schema.tableRegex" and
+        // "schema\\.tableRegex".
+        return pattern.contains("\\.") || containsUnescapedDot(pattern);
+    }
+
+    /**
+     * Qualify 'tables' patterns with default schema if missing. Comma-separated values.
+     *
+     * <p>Examples: orders -> public.orders (when defaultSchema=public) schema.orders -> unchanged
+     * db.schema.orders -> unchanged
+     */
+    private static String qualifyWithDefaultSchemaForTables(String tables, String defaultSchema) {
+        if (StringUtils.isNullOrWhitespaceOnly(tables)) {
+            return tables;
+        }
+        String[] parts = tables.split(",");
+        List<String> out = new ArrayList<>(parts.length);
+        for (String p : parts) {
+            if (p == null) {
+                continue;
+            }
+            String t = p.trim();
+            if (t.isEmpty()) {
+                continue;
+            }
+            // If no schema/namespace present, prefix with default schema
+            if (!hasSchemaOrNamespaceForTables(t)) {
+                out.add(defaultSchema + "." + t);
+            } else {
+                out.add(t);
+            }
+        }
+        return String.join(",", out);
+    }
+
+    /**
+     * Qualify 'partition.tables' entries with default schema when missing.
+     *
+     * <p>Handles formats: - parent:childRegex - childRegex
+     */
+    private static String qualifyWithDefaultSchemaForPartitions(
+            String partitionTables, String defaultSchema) {
+        if (StringUtils.isNullOrWhitespaceOnly(partitionTables)) {
+            return partitionTables;
+        }
+        String[] entries = partitionTables.split(",");
+        List<String> out = new ArrayList<>(entries.length);
+        for (String e : entries) {
+            if (e == null) {
+                continue;
+            }
+            String s = e.trim();
+            if (s.isEmpty()) {
+                continue;
+            }
+            int idx = s.indexOf(':');
+            if (idx >= 0) {
+                String parent = s.substring(0, idx).trim();
+                String child = s.substring(idx + 1).trim();
+                if (!parent.isEmpty() && !hasSchemaOrNamespaceForPartitions(parent)) {
+                    parent = defaultSchema + "." + parent;
+                }
+                if (!child.isEmpty() && !hasSchemaOrNamespaceForPartitions(child)) {
+                    child = defaultSchema + "." + child;
+                }
+                out.add(parent + ":" + child);
+            } else {
+                if (!hasSchemaOrNamespaceForPartitions(s)) {
+                    out.add(defaultSchema + "." + s);
+                } else {
+                    out.add(s);
+                }
+            }
+        }
+        return String.join(",", out);
     }
 
     /** Checks the value of given integer option is valid. */
@@ -370,16 +578,16 @@ public class PostgresDataSourceFactory implements DataSourceFactory {
                 continue; // Skip table names that do not match the expected format
             }
 
-            String[] tableNameParts =
-                    trimmedTableName.split(
-                            "(?<!\\\\)\\.", -1); // Use -1 to avoid ignoring trailing empty elements
-
-            checkState(
-                    tableNameParts.length == 3,
-                    String.format(
-                            "Tables format must db.schema.table, can not 'tables' = %s",
-                            TABLES.key()));
-            String currentDbName = tableNameParts[0];
+            List<String> tableNameParts = splitByUnescapedDot(trimmedTableName);
+            // Only patterns with an explicit database prefix participate in database inference.
+            // Supported formats:
+            //  - db.schema.table
+            //  - schema.table
+            //  - table
+            if (tableNameParts.size() != 3) {
+                continue;
+            }
+            String currentDbName = tableNameParts.get(0).trim();
 
             checkState(
                     isValidPostgresDbName(currentDbName),
@@ -404,14 +612,38 @@ public class PostgresDataSourceFactory implements DataSourceFactory {
         // PostgreSQL database name conventions:
         // 1. Length does not exceed 63 characters
         // 2. Can contain letters, numbers, underscores, and dollar signs
-        // 3. Cannot start with a dollar sign
+        // 3. Must start with a letter or underscore
         if (dbName == null || dbName.length() > 63) {
             return false;
         }
-        if (!dbName.matches("[a-zA-Z_$][a-zA-Z0-9_$]*")) {
-            return false;
+        return dbName.matches("[a-zA-Z_][a-zA-Z0-9_$]*");
+    }
+
+    private static List<String> splitByUnescapedDot(String identifier) {
+        List<String> parts = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean escaped = false;
+        for (int i = 0; i < identifier.length(); i++) {
+            char c = identifier.charAt(i);
+            if (escaped) {
+                current.append(c);
+                escaped = false;
+                continue;
+            }
+            if (c == '\\') {
+                current.append(c);
+                escaped = true;
+                continue;
+            }
+            if (c == '.') {
+                parts.add(current.toString());
+                current.setLength(0);
+                continue;
+            }
+            current.append(c);
         }
-        return true;
+        parts.add(current.toString());
+        return parts;
     }
 
     /** Replaces the default timezone placeholder with session timezone, if applicable. */

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresDataSource.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresDataSource.java
@@ -33,6 +33,7 @@ import org.apache.flink.cdc.connectors.postgres.source.config.PostgresSourceConf
 import org.apache.flink.cdc.connectors.postgres.source.config.PostgresSourceConfigFactory;
 import org.apache.flink.cdc.connectors.postgres.source.offset.PostgresOffsetFactory;
 import org.apache.flink.cdc.connectors.postgres.source.reader.PostgresPipelineRecordEmitter;
+import org.apache.flink.cdc.connectors.postgres.source.utils.PostgresPartitionRouter;
 import org.apache.flink.cdc.connectors.postgres.table.PostgreSQLReadableMetadata;
 import org.apache.flink.cdc.debezium.DebeziumDeserializationSchema;
 import org.apache.flink.cdc.debezium.event.DebeziumEventDeserializationSchema;
@@ -50,23 +51,28 @@ public class PostgresDataSource implements DataSource {
     private final PostgresSourceConfig postgresSourceConfig;
 
     private final List<PostgreSQLReadableMetadata> readableMetadataList;
+    private final PostgresPartitionRouter partitionSelector;
 
     public PostgresDataSource(PostgresSourceConfigFactory configFactory) {
-        this(configFactory, new ArrayList<>());
+        this(configFactory, new ArrayList<>(), null);
     }
 
     public PostgresDataSource(
             PostgresSourceConfigFactory configFactory,
-            List<PostgreSQLReadableMetadata> readableMetadataList) {
+            List<PostgreSQLReadableMetadata> readableMetadataList,
+            PostgresPartitionRouter partitionSelector) {
         this.configFactory = configFactory;
         this.postgresSourceConfig = configFactory.create(0);
         this.readableMetadataList = readableMetadataList;
+        this.partitionSelector = partitionSelector;
     }
 
     @Override
     public EventSourceProvider getEventSourceProvider() {
         String databaseName = postgresSourceConfig.getDatabaseList().get(0);
         boolean includeDatabaseInTableId = postgresSourceConfig.isIncludeDatabaseInTableId();
+        PostgresOffsetFactory postgresOffsetFactory = new PostgresOffsetFactory();
+        PostgresDialect postgresDialect = new PostgresDialect(postgresSourceConfig);
         DebeziumEventDeserializationSchema deserializer =
                 new PostgresEventDeserializer(
                         DebeziumChangelogMode.ALL,
@@ -74,16 +80,14 @@ public class PostgresDataSource implements DataSource {
                         includeDatabaseInTableId,
                         databaseName);
 
-        PostgresOffsetFactory postgresOffsetFactory = new PostgresOffsetFactory();
-        PostgresDialect postgresDialect = new PostgresDialect(postgresSourceConfig);
-
         PostgresSourceBuilder.PostgresIncrementalSource<Event> source =
                 new PostgresPipelineSource<>(
                         configFactory,
                         deserializer,
                         postgresOffsetFactory,
                         postgresDialect,
-                        postgresSourceConfig);
+                        postgresSourceConfig,
+                        partitionSelector);
 
         return FlinkSourceProvider.of(source);
     }
@@ -103,16 +107,19 @@ public class PostgresDataSource implements DataSource {
             extends PostgresSourceBuilder.PostgresIncrementalSource<T> {
         private final PostgresSourceConfig sourceConfig;
         private final PostgresDialect dataSourceDialect;
+        private final PostgresPartitionRouter partitionSelector;
 
         public PostgresPipelineSource(
                 PostgresSourceConfigFactory configFactory,
                 DebeziumDeserializationSchema<T> deserializationSchema,
                 PostgresOffsetFactory offsetFactory,
                 PostgresDialect dataSourceDialect,
-                PostgresSourceConfig sourceConfig) {
+                PostgresSourceConfig sourceConfig,
+                PostgresPartitionRouter partitionSelector) {
             super(configFactory, deserializationSchema, offsetFactory, dataSourceDialect);
             this.sourceConfig = sourceConfig;
             this.dataSourceDialect = dataSourceDialect;
+            this.partitionSelector = partitionSelector;
         }
 
         @Override

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresDataSourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresDataSourceOptions.java
@@ -53,6 +53,18 @@ public class PostgresDataSourceOptions {
                     .withDescription(
                             "Password to use when connecting to the PostgreSQL database server.");
 
+    /**
+     * Optional database name to connect. When provided, the database prefix in 'tables' can be
+     * omitted (e.g. use 'public.my_table' instead of 'db.public.my_table'). If both this option and
+     * a database prefix in 'tables' are provided, they must be consistent.
+     */
+    public static final ConfigOption<String> DATABASE =
+            ConfigOptions.key("database")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Name of the PostgreSQL database to connect to. If set, the database prefix in 'tables' may be omitted. When present, any database specified in 'tables' must match this value.");
+
     public static final ConfigOption<String> TABLES =
             ConfigOptions.key("tables")
                     .stringType()
@@ -63,6 +75,29 @@ public class PostgresDataSourceOptions {
                                     + "If there is a need to use a dot (.) in a regular expression to match any character, "
                                     + "it is necessary to escape the dot with a backslash."
                                     + "eg. db0.\\.*, db1.user_table_[0-9]+, db[1-2].[app|web]_order_\\.*");
+
+    /**
+     * Optional default schema. When provided, entries in 'tables' and 'partition.tables' that omit
+     * schema will be qualified with this schema. For example, 'orders' becomes 'public.orders'.
+     */
+    public static final ConfigOption<String> SCHEMA =
+            ConfigOptions.key("schema")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Default schema name. When set, patterns in 'tables' and 'partition.tables' without schema will be auto-qualified with this schema (e.g., 'orders' -> 'public.orders').");
+
+    public static final ConfigOption<String> PARTITION_TABLES =
+            ConfigOptions.key("partition.tables")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Table names of the PostgreSQL 10 partitioned tables to monitor. Regular expressions are supported. "
+                                    + "It is important to note that the dot (.) is treated as a delimiter for database and table names. "
+                                    + "If there is a need to use a dot (.) in a regular expression to match any character, "
+                                    + "it is necessary to escape the dot with a backslash."
+                                    + "eg. db0.\\.*, db1.user_table_[0-9]+, db[1-2].[app|web]_order_\\.*. "
+                                    + "When configured, partition table events will be automatically routed to their parent table.");
 
     public static final ConfigOption<String> DECODING_PLUGIN_NAME =
             ConfigOptions.key("decoding.plugin.name")
@@ -273,4 +308,14 @@ public class PostgresDataSourceOptions {
                             "Whether to include database in the generated Table ID. "
                                     + "If set to true, the Table ID will be in the format (database, schema, table). "
                                     + "If set to false, the Table ID will be in the format (schema, table). Defaults to false.");
+
+    public static final ConfigOption<Boolean> SCAN_INCLUDE_PARTITIONED_TABLES_ENABLED =
+            ConfigOptions.key("scan.include-partitioned-tables.enabled")
+                    .booleanType()
+                    .defaultValue(Boolean.FALSE)
+                    .withDescription(
+                            "Enable reading from partitioned table via partition root.\n"
+                                    + "If enabled:\n"
+                                    + "(1) PUBLICATION must be created beforehand with parameter publish_via_partition_root=true\n"
+                                    + "(2) Table list (regex or predefined list) should only match the parent table name, if table list matches both parent and child tables, snapshot data will be read twice.");
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/io/debezium/connector/postgresql/Utils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/io/debezium/connector/postgresql/Utils.java
@@ -58,7 +58,7 @@ public final class Utils {
                     "JDBC connection fails to commit: " + e.getMessage(), e);
         }
 
-        Map<String, String> offsetMap = new HashMap<>();
+        Map<String, String> offsetMap = new HashMap<>(8);
         offsetMap.put(SourceInfo.LSN_KEY, lsn.toString());
         if (txId != null) {
             offsetMap.put(SourceInfo.TXID_KEY, txId.toString());

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -859,6 +859,19 @@ public class PostgresConnection extends JdbcConnection {
         return readTableNames(catalogName, null, null, new String[] {"TABLE", "PARTITIONED TABLE"});
     }
 
+    /**
+     * Retrieves all non-partitioned {@code TableId}s in a given database catalog. This method
+     * excludes partition parent tables and is used for PostgreSQL 10 and earlier versions where
+     * logical replication (publications) cannot be created on partition parent tables.
+     *
+     * @param catalogName the catalog/database name
+     * @return set of non-partitioned table ids (excludes PARTITIONED TABLE type)
+     * @throws SQLException if a database exception occurred
+     */
+    public Set<TableId> getAllNonPartitionedTableIds(String catalogName) throws SQLException {
+        return readTableNames(catalogName, null, null, new String[] {"TABLE"});
+    }
+
     @FunctionalInterface
     public interface PostgresValueConverterBuilder {
         PostgresValueConverter build(TypeRegistry registry);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceBuilder.java
@@ -311,6 +311,11 @@ public class PostgresSourceBuilder<T> {
         return this;
     }
 
+    public PostgresSourceBuilder<T> partitionTables(String partitionTables) {
+        this.configFactory.setPartitionTables(partitionTables);
+        return this;
+    }
+
     /**
      * Build the {@link PostgresIncrementalSource}.
      *

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
@@ -36,10 +36,14 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
 
     private static final long serialVersionUID = 1L;
 
+    /** Debezium configuration key for partition tables. */
+    public static final String PARTITION_TABLES_CONFIG_KEY = "partition.tables";
+
     private final int subtaskId;
     private final int lsnCommitCheckpointsDelay;
     private final boolean includePartitionedTables;
     private final boolean includeDatabaseInTableId;
+    private final String partitionTables;
 
     public PostgresSourceConfig(
             int subtaskId,
@@ -71,7 +75,8 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
             int lsnCommitCheckpointsDelay,
             boolean assignUnboundedChunkFirst,
             boolean includePartitionedTables,
-            boolean includeDatabaseInTableId) {
+            boolean includeDatabaseInTableId,
+            String partitionTables) {
         super(
                 startupOptions,
                 databaseList,
@@ -102,6 +107,7 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
         this.subtaskId = subtaskId;
         this.lsnCommitCheckpointsDelay = lsnCommitCheckpointsDelay;
         this.includePartitionedTables = includePartitionedTables;
+        this.partitionTables = partitionTables;
         this.includeDatabaseInTableId = includeDatabaseInTableId;
     }
 
@@ -145,6 +151,11 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
     public String getJdbcUrl() {
         return String.format(
                 "jdbc:postgresql://%s:%d/%s", getHostname(), getPort(), getDatabaseList().get(0));
+    }
+
+    /** Returns the partition tables. */
+    public String getPartitionTables() {
+        return partitionTables;
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfigFactory.java
@@ -53,6 +53,7 @@ public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
     private int lsnCommitCheckpointsDelay;
 
     private boolean includePartitionedTables;
+    private String partitionTables;
 
     private boolean includeDatabaseInTableId =
             PostgresSourceOptions.TABLE_ID_INCLUDE_DATABASE.defaultValue();
@@ -100,6 +101,11 @@ public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
             props.setProperty("table.include.list", String.join(",", tableList));
         }
 
+        // Set partition.tables for PostgresPartitionRoutingSchema to read
+        if (partitionTables != null && !partitionTables.trim().isEmpty()) {
+            props.setProperty(PostgresSourceConfig.PARTITION_TABLES_CONFIG_KEY, partitionTables);
+        }
+
         // override the user-defined debezium properties
         if (dbzProperties != null) {
             props.putAll(dbzProperties);
@@ -140,7 +146,8 @@ public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
                 lsnCommitCheckpointsDelay,
                 assignUnboundedChunkFirst,
                 includePartitionedTables,
-                includeDatabaseInTableId);
+                includeDatabaseInTableId,
+                partitionTables);
     }
 
     /**
@@ -192,6 +199,11 @@ public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
     /** Enable include partitioned table. */
     public void setIncludePartitionedTables(boolean includePartitionedTables) {
         this.includePartitionedTables = includePartitionedTables;
+    }
+
+    /** Whether include partitioned table. */
+    public void setPartitionTables(String partitionTables) {
+        this.partitionTables = partitionTables;
     }
 
     /** Set whether to include database in the generated Table ID. */

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceOptions.java
@@ -98,6 +98,15 @@ public class PostgresSourceOptions extends JdbcSourceOptions {
                                     + "(1) PUBLICATION must be created beforehand with parameter publish_via_partition_root=true\n"
                                     + "(2) Table list (regex or predefined list) should only match the parent table name, if table list matches both parent and child tables, snapshot data will be read twice.");
 
+    public static final ConfigOption<String> PARTITION_TABLES =
+            ConfigOptions.key("partition.tables")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Partition table mapping patterns using colon format: parent:child_regex.\n"
+                                    + "Format: schema.parent:schema.child_regex (e.g., public.orders:public.orders_\\d{6}).\n"
+                                    + "When configured, child partition events will be routed to their parent table.");
+
     public static final ConfigOption<Boolean> TABLE_ID_INCLUDE_DATABASE =
             ConfigOptions.key("table-id.include-database")
                     .booleanType()

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTask.java
@@ -58,7 +58,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static io.debezium.connector.postgresql.PostgresObjectUtils.waitForReplicationSlotReady;
-import static io.debezium.connector.postgresql.Utils.refreshSchema;
 
 /** A {@link FetchTask} implementation for Postgres to read snapshot split. */
 public class PostgresScanFetchTask extends AbstractScanFetchTask {
@@ -250,8 +249,11 @@ public class PostgresScanFetchTask extends AbstractScanFetchTask {
                 throws Exception {
             final PostgresSnapshotContext ctx = (PostgresSnapshotContext) snapshotContext;
             ctx.offset = offsetContext;
-
-            refreshSchema(databaseSchema, jdbcConnection, true);
+            // It's not necessary to refresh schema again, which is very time-consuming.
+            // The databaseSchema is the reference of PostgresSourceFetchTaskContext#schema, and has
+            // been initialized when submit SnapshotSplit fetch task by
+            // IncrementalSourceScanFetcher#submitTask -> PostgresSourceFetchTaskContext#configure.
+            // refreshSchema(databaseSchema, jdbcConnection, true);
             createDataEvents(ctx, snapshotSplit.getTableId());
 
             return SnapshotResult.completed(ctx.offset);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresStreamFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresStreamFetchTask.java
@@ -153,7 +153,7 @@ public class PostgresStreamFetchTask implements FetchTask<SourceSplitBase> {
                             || Lsn.valueOf(commitLsn).compareTo(Lsn.valueOf(lastCommitLsn)) > 0)) {
                 lastCommitLsn = commitLsn;
 
-                Map<String, Object> offsets = new HashMap<>();
+                Map<String, Object> offsets = new HashMap<>(4);
                 offsets.put(PostgresOffsetContext.LAST_COMMIT_LSN_KEY, lastCommitLsn);
                 LOG.debug(
                         "Committing offset {} for {}",

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/handler/PostgresSchemaChangeEventHandler.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/handler/PostgresSchemaChangeEventHandler.java
@@ -32,6 +32,6 @@ public class PostgresSchemaChangeEventHandler implements SchemaChangeEventHandle
 
     @Override
     public Map<String, Object> parseSource(SchemaChangeEvent event) {
-        return new HashMap<>();
+        return new HashMap<>(4);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/offset/PostgresOffset.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/offset/PostgresOffset.java
@@ -47,7 +47,7 @@ public class PostgresOffset extends Offset {
     }
 
     PostgresOffset(Long lsn, Long txId, Instant lastCommitTs) {
-        Map<String, String> offsetMap = new HashMap<>();
+        Map<String, String> offsetMap = new HashMap<>(8);
         // keys are from io.debezium.connector.postgresql.PostgresOffsetContext.Loader.load
         offsetMap.put(SourceInfo.LSN_KEY, lsn.toString());
         if (txId != null) {
@@ -66,7 +66,7 @@ public class PostgresOffset extends Offset {
     }
 
     public static PostgresOffset of(Map<String, ?> offsetMap) {
-        Map<String, String> offsetStrMap = new HashMap<>();
+        Map<String, String> offsetStrMap = new HashMap<>(8);
         for (Map.Entry<String, ?> entry : offsetMap.entrySet()) {
             offsetStrMap.put(
                     entry.getKey(), entry.getValue() == null ? null : entry.getValue().toString());

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/offset/PostgresOffsetUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/offset/PostgresOffsetUtils.java
@@ -34,7 +34,7 @@ public class PostgresOffsetUtils {
                 Objects.requireNonNull(offset, "offset is null for the sourceSplitBase")
                         .getOffset();
         // all the keys happen to be long type for PostgresOffsetContext.Loader.load
-        Map<String, Object> offsetMap = new HashMap<>();
+        Map<String, Object> offsetMap = new HashMap<>(8);
         for (String key : offsetStrMap.keySet()) {
             String value = offsetStrMap.get(key);
             if (value != null) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/utils/CustomPostgresSchema.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/utils/CustomPostgresSchema.java
@@ -21,16 +21,21 @@ import org.apache.flink.cdc.connectors.postgres.source.config.PostgresSourceConf
 import org.apache.flink.util.FlinkRuntimeException;
 
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.PostgresObjectUtils;
 import io.debezium.connector.postgresql.PostgresOffsetContext;
 import io.debezium.connector.postgresql.PostgresPartition;
+import io.debezium.connector.postgresql.PostgresSchema;
+import io.debezium.connector.postgresql.PostgresTopicSelector;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
-import io.debezium.relational.Tables;
 import io.debezium.relational.history.TableChanges;
 import io.debezium.relational.history.TableChanges.TableChange;
 import io.debezium.schema.SchemaChangeEvent;
+import io.debezium.schema.TopicSelector;
 import io.debezium.util.Clock;
+
+import javax.annotation.Nullable;
 
 import java.sql.SQLException;
 import java.time.Instant;
@@ -39,27 +44,45 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
-/** A CustomPostgresSchema similar to PostgresSchema with customization. */
+/**
+ * A CustomPostgresSchema similar to PostgresSchema with customization.
+ *
+ * <p>This class caches table schemas and creates PostgresSchema instances on-demand using the
+ * provided connection. Each query method accepts a connection parameter to ensure fresh connections
+ * are used.
+ */
 public class CustomPostgresSchema {
 
     // cache the schema for each table
-    private final Map<TableId, TableChange> schemasByTableId = new HashMap<>();
-    private final PostgresConnection jdbcConnection;
+    private final Map<TableId, TableChange> schemasByTableId = new HashMap<>(32);
     private final PostgresConnectorConfig dbzConfig;
 
+    @Nullable private final PostgresPartitionRouter partitionRouter;
+
+    /**
+     * Creates a CustomPostgresSchema.
+     *
+     * @param sourceConfig the source configuration
+     * @param partitionRouter the partition router (nullable)
+     */
     public CustomPostgresSchema(
-            PostgresConnection jdbcConnection, PostgresSourceConfig sourceConfig) {
-        this.jdbcConnection = jdbcConnection;
+            PostgresSourceConfig sourceConfig, @Nullable PostgresPartitionRouter partitionRouter) {
         this.dbzConfig = sourceConfig.getDbzConnectorConfig();
+        this.partitionRouter = partitionRouter;
     }
 
-    public TableChange getTableSchema(TableId tableId) {
-        // read schema from cache first
+    /**
+     * Gets the table schema for a single table.
+     *
+     * @param jdbcConnection the connection to use for querying
+     * @param tableId the table ID
+     * @return the table change containing schema information
+     */
+    public TableChange getTableSchema(PostgresConnection jdbcConnection, TableId tableId) {
         if (!schemasByTableId.containsKey(tableId)) {
             try {
-                readTableSchema(Collections.singletonList(tableId));
+                readTableSchema(jdbcConnection, Collections.singletonList(tableId));
             } catch (SQLException e) {
                 throw new FlinkRuntimeException("Failed to read table schema", e);
             }
@@ -67,26 +90,33 @@ public class CustomPostgresSchema {
         return schemasByTableId.get(tableId);
     }
 
-    public Map<TableId, TableChange> getTableSchema(List<TableId> tableIds) {
-        // read schema from cache first
-        Map<TableId, TableChange> tableChanges = new HashMap();
+    /**
+     * Gets the table schemas for multiple tables.
+     *
+     * @param jdbcConnection the connection to use for querying
+     * @param tableIds the list of table IDs
+     * @return map of table ID to table change
+     */
+    public Map<TableId, TableChange> getTableSchema(
+            PostgresConnection jdbcConnection, List<TableId> tableIds) {
+        Map<TableId, TableChange> tableChanges = new HashMap<>(32);
 
-        List<TableId> unMatchTableIds = new ArrayList<>();
+        List<TableId> uncachedTableIds = new ArrayList<>();
         for (TableId tableId : tableIds) {
             if (schemasByTableId.containsKey(tableId)) {
                 tableChanges.put(tableId, schemasByTableId.get(tableId));
             } else {
-                unMatchTableIds.add(tableId);
+                uncachedTableIds.add(tableId);
             }
         }
 
-        if (!unMatchTableIds.isEmpty()) {
+        if (!uncachedTableIds.isEmpty()) {
             try {
-                readTableSchema(tableIds);
+                readTableSchema(jdbcConnection, uncachedTableIds);
             } catch (SQLException e) {
                 throw new FlinkRuntimeException("Failed to read table schema", e);
             }
-            for (TableId tableId : unMatchTableIds) {
+            for (TableId tableId : uncachedTableIds) {
                 if (schemasByTableId.containsKey(tableId)) {
                     tableChanges.put(tableId, schemasByTableId.get(tableId));
                 } else {
@@ -98,33 +128,25 @@ public class CustomPostgresSchema {
         return tableChanges;
     }
 
-    private List<TableChange> readTableSchema(List<TableId> tableIds) throws SQLException {
-        List<TableChange> tableChanges = new ArrayList<>();
+    private void readTableSchema(PostgresConnection jdbcConnection, List<TableId> tableIds)
+            throws SQLException {
+        // Create PostgresSchema using the provided connection
+        PostgresSchema postgresSchema = createPostgresSchema(jdbcConnection);
 
         final PostgresOffsetContext offsetContext =
                 PostgresOffsetContext.initialContext(dbzConfig, jdbcConnection, Clock.SYSTEM);
 
         PostgresPartition partition = new PostgresPartition(dbzConfig.getLogicalName());
 
-        Tables tables = new Tables();
-        try {
-            jdbcConnection.readSchema(
-                    tables,
-                    dbzConfig.databaseName(),
-                    null,
-                    dbzConfig.getTableFilters().dataCollectionFilter(),
-                    null,
-                    false);
-        } catch (SQLException e) {
-            throw new FlinkRuntimeException("Failed to read schema", e);
-        }
-
         for (TableId tableId : tableIds) {
-            Table table = Objects.requireNonNull(tables.forTable(tableId));
-            // set the events to populate proper sourceInfo into offsetContext
+            Table table = postgresSchema.tableFor(tableId);
+            if (table == null) {
+                throw new FlinkRuntimeException(
+                        String.format("Failed to read table schema for table %s", tableId));
+            }
+
             offsetContext.event(tableId, Instant.now());
 
-            // TODO: check whether we always set isFromSnapshot = true
             SchemaChangeEvent schemaChangeEvent =
                     SchemaChangeEvent.ofCreate(
                             partition,
@@ -138,8 +160,27 @@ public class CustomPostgresSchema {
             for (TableChanges.TableChange tableChange : schemaChangeEvent.getTableChanges()) {
                 this.schemasByTableId.put(tableId, tableChange);
             }
-            tableChanges.add(this.schemasByTableId.get(tableId));
         }
-        return tableChanges;
+    }
+
+    /**
+     * Creates a PostgresSchema instance using the provided connection.
+     *
+     * @param jdbcConnection the connection to use
+     * @return a new PostgresSchema instance
+     */
+    private PostgresSchema createPostgresSchema(PostgresConnection jdbcConnection)
+            throws SQLException {
+        TopicSelector<TableId> topicSelector = PostgresTopicSelector.create(dbzConfig);
+        PostgresConnection.PostgresValueConverterBuilder valueConverterBuilder =
+                PostgresObjectUtils.newPostgresValueConverterBuilder(dbzConfig);
+
+        return new PostgresPartitionRoutingSchema(
+                jdbcConnection,
+                dbzConfig,
+                jdbcConnection.getTypeRegistry(),
+                topicSelector,
+                valueConverterBuilder.build(jdbcConnection.getTypeRegistry()),
+                partitionRouter);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/utils/ParentKey.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/utils/ParentKey.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.postgres.source.utils;
+
+import org.apache.flink.cdc.common.utils.Predicates;
+
+/**
+ * Helper class for parent table matching.
+ *
+ * <p>This class represents a parent table identifier with optional schema, used for matching and
+ * excluding parent tables in partition-aware filtering.
+ */
+class ParentKey {
+    private final String schema;
+    private final String table;
+
+    ParentKey(String schema, String table) {
+        this.schema = schema;
+        this.table = table;
+    }
+
+    /**
+     * Creates a ParentKey from an array of string parts.
+     *
+     * <p>Supports various formats:
+     *
+     * <ul>
+     *   <li>Single part: table only (schema = null)
+     *   <li>Two parts: schema.table
+     *   <li>Three parts: catalog.schema.table (uses schema.table)
+     * </ul>
+     *
+     * @param parts the array of string parts
+     * @return a ParentKey instance, or null if parts is null or empty
+     */
+    static ParentKey from(String[] parts) {
+        if (parts == null || parts.length == 0) {
+            return null;
+        }
+        if (parts.length == 1) {
+            return new ParentKey(null, parts[0]);
+        }
+        if (parts.length == 2) {
+            return new ParentKey(parts[0], parts[1]);
+        }
+        if (parts.length == 3) {
+            return new ParentKey(parts[1], parts[2]);
+        }
+        return null;
+    }
+
+    /**
+     * Creates a ParentKey from a table pattern string.
+     *
+     * @param pattern the table pattern string (e.g., "public.orders" or "orders")
+     * @return a ParentKey instance
+     */
+    static ParentKey fromPattern(String pattern) {
+        if (pattern == null || pattern.trim().isEmpty()) {
+            return null;
+        }
+        String[] parts = Predicates.RegExSplitterByDot.split(pattern.trim());
+        return from(parts);
+    }
+
+    /**
+     * Checks if this ParentKey matches another ParentKey.
+     *
+     * <p>Matching rules:
+     *
+     * <ul>
+     *   <li>If this schema is null or empty, matches any schema (table-only match)
+     *   <li>Otherwise, requires both schema and table to match exactly
+     * </ul>
+     *
+     * @param other the other ParentKey to match against
+     * @return true if the keys match, false otherwise
+     */
+    boolean matches(ParentKey other) {
+        if (other == null) {
+            return false;
+        }
+        if (schema == null || schema.isEmpty()) {
+            return table.equals(other.table);
+        }
+        return schema.equals(other.schema) && table.equals(other.table);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ParentKey parentKey = (ParentKey) o;
+        return table.equals(parentKey.table)
+                && (schema == null ? parentKey.schema == null : schema.equals(parentKey.schema));
+    }
+
+    @Override
+    public int hashCode() {
+        int result = schema != null ? schema.hashCode() : 0;
+        result = 31 * result + table.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ParentKey{" + "schema='" + schema + '\'' + ", table='" + table + '\'' + '}';
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionConnectorConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionConnectorConfig.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.postgres.source.utils;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.relational.RelationalTableFilters;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+/**
+ * Extended PostgresConnectorConfig that wraps TableFilter to include partition parent tables.
+ *
+ * <p>This ensures that partition parent tables pass the filter check in
+ * RelationalDatabaseSchema.buildAndRegisterSchema(), even when they are not explicitly listed in
+ * table.include.list.
+ */
+public class PostgresPartitionConnectorConfig extends PostgresConnectorConfig {
+
+    private final RelationalTableFilters wrappedTableFilters;
+
+    /**
+     * Creates a PostgresPartitionConnectorConfig with a pre-configured router.
+     *
+     * <p>This constructor reuses the router's parsed rules, avoiding duplicate parsing.
+     *
+     * @param config the Debezium configuration
+     * @param router the partition router (nullable)
+     */
+    public PostgresPartitionConnectorConfig(
+            Configuration config, @Nullable PostgresPartitionRouter router) {
+        super(config);
+        this.wrappedTableFilters = createWrappedTableFilters(config, router);
+    }
+
+    public PostgresPartitionConnectorConfig(Configuration config) {
+        this(config, null);
+    }
+
+    @Override
+    public RelationalTableFilters getTableFilters() {
+        return wrappedTableFilters;
+    }
+
+    private RelationalTableFilters createWrappedTableFilters(
+            Configuration config, @Nullable PostgresPartitionRouter router) {
+        RelationalTableFilters baseFilters = super.getTableFilters();
+
+        // Apply partition-aware filtering if router is provided and routing is enabled
+        if (router != null && router.isRoutingEnabled()) {
+            PostgresPartitionRules rules = router.getRules();
+            Set<TableId> configuredParents = rules.getConfiguredParents();
+            List<Pattern> childPatterns = rules.getChildTablePatterns();
+            return new PartitionAwareTableFilters(baseFilters, configuredParents, childPatterns);
+        }
+
+        // If routing is not enabled, return base filters without partition filtering
+        return baseFilters;
+    }
+
+    /**
+     * Wrapper for RelationalTableFilters that includes partition parent tables and excludes
+     * partition child tables from the filter.
+     *
+     * <p>This ensures that:
+     *
+     * <ul>
+     *   <li>Partition parent tables pass the filter even if not in table.include.list
+     *   <li>Partition child tables are excluded so super.refresh() only loads main tables
+     * </ul>
+     */
+    private static class PartitionAwareTableFilters extends RelationalTableFilters {
+
+        private final RelationalTableFilters delegate;
+        private final Set<TableId> configuredParents;
+        private final List<Pattern> childPatterns;
+        private final Tables.TableFilter wrappedDataCollectionFilter;
+
+        PartitionAwareTableFilters(
+                RelationalTableFilters delegate,
+                Set<TableId> configuredParents,
+                List<Pattern> childPatterns) {
+            // Call super with dummy config - we'll delegate all methods
+            super(
+                    Configuration.empty(),
+                    tableId -> true,
+                    tableId -> tableId.catalog() + "." + tableId.schema() + "." + tableId.table());
+            this.delegate = delegate;
+            this.configuredParents = configuredParents;
+            this.childPatterns = childPatterns;
+            this.wrappedDataCollectionFilter = createWrappedFilter();
+        }
+
+        private Tables.TableFilter createWrappedFilter() {
+            Tables.TableFilter baseFilter = delegate.dataCollectionFilter();
+            return tableId -> {
+                // Exclude partition child tables (they will be loaded on-demand)
+                if (isPartitionChild(tableId)) {
+                    return false;
+                }
+                // Include configured partition parents
+                if (configuredParents.contains(tableId)) {
+                    return true;
+                }
+                // Delegate to base filter for other tables
+                return baseFilter.isIncluded(tableId);
+            };
+        }
+
+        /** Checks if the table matches any child partition pattern. */
+        private boolean isPartitionChild(TableId tableId) {
+            if (childPatterns.isEmpty()) {
+                return false;
+            }
+            String fullName = tableId.schema() + "." + tableId.table();
+            for (Pattern pattern : childPatterns) {
+                if (pattern.matcher(fullName).matches()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public Tables.TableFilter dataCollectionFilter() {
+            return wrappedDataCollectionFilter;
+        }
+
+        @Override
+        public Tables.TableFilter eligibleDataCollectionFilter() {
+            return delegate.eligibleDataCollectionFilter();
+        }
+
+        @Override
+        public Tables.TableFilter eligibleForSchemaDataCollectionFilter() {
+            return delegate.eligibleForSchemaDataCollectionFilter();
+        }
+
+        @Override
+        public Predicate<String> databaseFilter() {
+            return delegate.databaseFilter();
+        }
+
+        @Override
+        public String getExcludeColumns() {
+            return delegate.getExcludeColumns();
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionInclusionDecider.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionInclusionDecider.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.postgres.source.utils;
+
+import org.apache.flink.cdc.common.schema.Selectors;
+import org.apache.flink.cdc.common.utils.Predicates;
+
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.LinkedHashSet;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Policy layer for partition table inclusion decisions and selector building.
+ *
+ * <p>This class centralizes the inclusion semantics for PostgreSQL partitioned tables:
+ *
+ * <ul>
+ *   <li><b>Rule 1:</b> Parent included/configured → include all partitions
+ *   <li><b>Rule 2:</b> Partitions are included based on parent, not direct child match
+ * </ul>
+ *
+ * <p><b>Architecture:</b> This class is part of a layered architecture:
+ *
+ * <ul>
+ *   <li>Layer 1: {@link PostgresPartitionRules} - Configuration parsing
+ *   <li>Layer 2: {@link PostgresPartitionRouter} - Routing mechanism
+ *   <li>Layer 3: PostgresPartitionInclusionDecider - Filtering decisions (this class)
+ *   <li>Layer 4: Integration classes (Schema, Dialect, etc.)
+ * </ul>
+ */
+public class PostgresPartitionInclusionDecider implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Tables.TableFilter filters;
+    @Nullable private final PostgresPartitionRouter router;
+
+    /** Cached selectors for table matching (thread-safe lazy initialization). */
+    private transient AtomicReference<Selectors> selectorsRef;
+
+    /**
+     * Creates a new PostgresPartitionInclusionDecider.
+     *
+     * @param filters the table filters for inclusion decisions
+     * @param router the partition router for physical→logical mapping
+     */
+    public PostgresPartitionInclusionDecider(
+            Tables.TableFilter filters, PostgresPartitionRouter router) {
+        this.filters = filters;
+        this.router = router;
+    }
+
+    /**
+     * Determines if a table should be included based on partition semantics.
+     *
+     * <p>Implementation of semantic rules:
+     *
+     * <ul>
+     *   <li>Rule 1: If parent is included, all partitions are included
+     *   <li>Rule 2: If partition is explicitly included but parent is excluded, do not capture
+     *   <li>Rule 3: Always route to parent table name
+     *   <li>Rule 4: Exclude configured partition parent tables (data resides in child partitions)
+     * </ul>
+     *
+     * @param tableId the table to check
+     * @return true if the table should be included
+     */
+    public boolean isIncluded(TableId tableId) {
+        if (tableId == null) {
+            return false;
+        }
+
+        // Exclude configured partition parent tables when routing is enabled
+        // Parent tables don't store data - all data is in child partitions
+        if (router != null && router.isRoutingEnabled() && router.isConfiguredParent(tableId)) {
+            return false;
+        }
+
+        // Child partitions are included based on their parent.
+        if (router != null && router.isChildTable(tableId)) {
+            TableId parent = router.getPartitionParent(tableId).orElse(null);
+            if (parent == null) {
+                return false;
+            }
+            return isParentIncluded(parent);
+        }
+
+        // Non-partition tables fall back to direct filter match.
+        return filters.isIncluded(tableId);
+    }
+
+    private boolean isParentIncluded(TableId parent) {
+        if (filters.isIncluded(parent)) {
+            return true;
+        }
+        return router != null && router.isConfiguredParent(parent);
+    }
+
+    /**
+     * Gets the selectors for table matching in CDC pipeline.
+     *
+     * <p>This method uses thread-safe lazy initialization via AtomicReference.
+     *
+     * @return the Selectors instance for matching TableIds
+     */
+    public Selectors getSelectors() {
+        // Handle deserialization: transient field may be null
+        if (selectorsRef == null) {
+            selectorsRef = new AtomicReference<>();
+        }
+        Selectors cached = selectorsRef.get();
+        if (cached != null) {
+            return cached;
+        }
+        // Build new selectors
+        String pattern = buildPartitionAwareSelectorsPattern();
+        // Use ".*" wildcard for "capture all" mode when no table pattern is configured
+        if (pattern == null || pattern.trim().isEmpty()) {
+            pattern = ".*";
+        }
+        Selectors newSelectors = new Selectors.SelectorsBuilder().includeTables(pattern).build();
+        // CAS to ensure only one thread wins
+        if (selectorsRef.compareAndSet(null, newSelectors)) {
+            return newSelectors;
+        }
+        // Another thread won, return their result
+        return selectorsRef.get();
+    }
+
+    /**
+     * Builds a partition-aware selector pattern string.
+     *
+     * <p>This method generates patterns that include both child partition tables and non-partition
+     * parent tables, while excluding partition parents that have child patterns defined.
+     */
+    private String buildPartitionAwareSelectorsPattern() {
+        if (router == null) {
+            throw new IllegalStateException("Router is required for building selectors");
+        }
+
+        PostgresPartitionRules rules = router.getRules();
+        String tablesPattern = rules.getTablesPattern();
+        String partitionTablesPattern = rules.getPartitionTablesPattern();
+
+        // If no partition routing, return original tables pattern (may be null for "capture all")
+        if (!router.isRoutingEnabled()
+                || partitionTablesPattern == null
+                || partitionTablesPattern.trim().isEmpty()) {
+            return tablesPattern;
+        }
+
+        LinkedHashSet<String> selectorPatterns = new LinkedHashSet<>();
+        LinkedHashSet<ParentKey> excludedParents = new LinkedHashSet<>();
+
+        // Step 1: Add child patterns from partition.tables
+        addChildPartitionPatterns(partitionTablesPattern, selectorPatterns, excludedParents);
+
+        // Step 2: Add leftover tables from 'tables' that are not partition parents
+        addNonPartitionParentPatterns(tablesPattern, excludedParents, selectorPatterns);
+
+        if (selectorPatterns.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Invalid table inclusion pattern cannot be null or empty");
+        }
+        return String.join(",", selectorPatterns);
+    }
+
+    /**
+     * Validates and returns the tables pattern.
+     *
+     * @param tablesPattern the tables pattern to validate
+     * @return the validated tables pattern
+     * @throws IllegalArgumentException if the pattern is null or empty
+     */
+    private String validateTablesPattern(String tablesPattern) {
+        if (tablesPattern == null || tablesPattern.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Invalid table inclusion pattern cannot be null or empty");
+        }
+        return tablesPattern;
+    }
+
+    /**
+     * Adds child partition patterns to the selector patterns set.
+     *
+     * @param partitionTablesPattern the partition tables pattern string
+     * @param selectorPatterns the set to add selector patterns to
+     * @param excludedParents the set to track excluded parent tables
+     */
+    private void addChildPartitionPatterns(
+            String partitionTablesPattern,
+            LinkedHashSet<String> selectorPatterns,
+            LinkedHashSet<ParentKey> excludedParents) {
+        for (String entry : Predicates.RegExSplitterByComma.split(partitionTablesPattern)) {
+            if (entry == null || entry.trim().isEmpty()) {
+                continue;
+            }
+
+            String childPart = extractChildPartFromEntry(entry.trim());
+            if (childPart == null || childPart.isEmpty()) {
+                continue;
+            }
+
+            String normalized = PostgresPartitionRules.normalizePatternIgnoreCatalog(childPart);
+            PostgresPartitionRules.SchemaAndTable schemaAndTable =
+                    PostgresPartitionRules.splitSchemaAndTable(normalized);
+
+            String schema = schemaAndTable.schema;
+            String tableRegex = schemaAndTable.tableOrRegex;
+            if (tableRegex == null || tableRegex.isEmpty()) {
+                continue;
+            }
+
+            // Add selector patterns for this child partition
+            addSelectorPatternsForChild(schema, tableRegex, selectorPatterns);
+
+            // Track the parent table to exclude it later
+            String derivedParentTable =
+                    PostgresPartitionRules.deriveParentTableNameFromChildRegex(tableRegex);
+            if (!derivedParentTable.isEmpty()) {
+                excludedParents.add(new ParentKey(schema, derivedParentTable));
+            }
+        }
+    }
+
+    /**
+     * Extracts the child part from a partition table entry.
+     *
+     * @param entry the entry string (e.g., "public.orders:public.orders_\\d+")
+     * @return the child part, or null if invalid
+     */
+    private String extractChildPartFromEntry(String entry) {
+        int colonIndex = entry.indexOf(':');
+        if (colonIndex >= 0) {
+            return entry.substring(colonIndex + 1).trim();
+        }
+        return entry;
+    }
+
+    /**
+     * Adds selector patterns for a child partition table.
+     *
+     * @param schema the schema name (may be null)
+     * @param tableRegex the table regex pattern
+     * @param selectorPatterns the set to add patterns to
+     */
+    private void addSelectorPatternsForChild(
+            String schema, String tableRegex, LinkedHashSet<String> selectorPatterns) {
+        if (schema == null || schema.isEmpty()) {
+            // Schema-less patterns: match any catalog
+            selectorPatterns.add("\\.*." + tableRegex);
+            selectorPatterns.add("\\.*.\\.*." + tableRegex);
+        } else {
+            // Schema-specific patterns
+            selectorPatterns.add(schema + "." + tableRegex);
+            selectorPatterns.add("\\.*." + schema + "." + tableRegex);
+        }
+    }
+
+    /**
+     * Adds non-partition parent patterns to the selector patterns set.
+     *
+     * @param tablesPattern the tables pattern string
+     * @param excludedParents the set of excluded parent tables
+     * @param selectorPatterns the set to add selector patterns to
+     */
+    private void addNonPartitionParentPatterns(
+            String tablesPattern,
+            LinkedHashSet<ParentKey> excludedParents,
+            LinkedHashSet<String> selectorPatterns) {
+        if (tablesPattern == null || tablesPattern.trim().isEmpty()) {
+            return;
+        }
+
+        for (String entry : Predicates.RegExSplitterByComma.split(tablesPattern)) {
+            if (entry == null || entry.trim().isEmpty()) {
+                continue;
+            }
+
+            String trimmed = entry.trim();
+            String[] parts = Predicates.RegExSplitterByDot.split(trimmed);
+            ParentKey key = ParentKey.from(parts);
+
+            // Skip if this is an excluded partition parent
+            if (key != null && isExcludedParent(excludedParents, key)) {
+                continue;
+            }
+
+            // Add the original pattern
+            selectorPatterns.add(trimmed);
+
+            // Add variations for different catalog formats
+            addSelectorPatternVariations(parts, selectorPatterns);
+        }
+    }
+
+    /**
+     * Adds selector pattern variations for different catalog formats.
+     *
+     * @param parts the split parts of the table pattern
+     * @param selectorPatterns the set to add patterns to
+     */
+    private void addSelectorPatternVariations(
+            String[] parts, LinkedHashSet<String> selectorPatterns) {
+        if (parts.length == 2) {
+            // schema.table format: add catalog.schema.table variation
+            selectorPatterns.add("\\.*." + String.join(".", parts));
+        } else if (parts.length == 3) {
+            // catalog.schema.table format: add schema.table variation
+            selectorPatterns.add(parts[1] + "." + parts[2]);
+        }
+    }
+
+    private static boolean isExcludedParent(
+            LinkedHashSet<ParentKey> excludedParents, ParentKey candidate) {
+        for (ParentKey excluded : excludedParents) {
+            if (excluded.matches(candidate)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionRouter.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionRouter.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.postgres.source.utils;
+
+import org.apache.flink.cdc.connectors.postgres.source.config.PostgresSourceConfig;
+
+import io.debezium.relational.TableId;
+
+import java.io.Serializable;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * PostgresPartitionRouter handles routing of PostgreSQL partitioned tables.
+ *
+ * <p>This class is responsible for mapping child partition tables to their parent tables using
+ * pattern-based matching configured via {@code partition.tables}.
+ *
+ * <p><b>Architecture:</b> This class is part of a layered architecture:
+ *
+ * <ul>
+ *   <li>Layer 1: {@link PostgresPartitionRules} - Configuration parsing
+ *   <li>Layer 2: PostgresPartitionRouter - Routing mechanism (this class)
+ *   <li>Layer 3: {@link PostgresPartitionInclusionDecider} - Filtering decisions
+ *   <li>Layer 4: Integration classes (Schema, Dialect, etc.)
+ * </ul>
+ */
+public class PostgresPartitionRouter implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Whether partition routing is enabled. */
+    private final boolean routingEnabled;
+
+    /** Parsed partition routing rules. */
+    private final PostgresPartitionRules rules;
+
+    /**
+     * Creates a new PostgresPartitionRouter with pre-parsed rules.
+     *
+     * <p>This is the primary constructor that accepts already-parsed rules, enabling reuse of
+     * parsing results across multiple components (e.g., Router, ConnectorConfig, RoutingSchema).
+     *
+     * @param routingEnabled whether partition routing is enabled
+     * @param rules the pre-parsed partition rules
+     */
+    public PostgresPartitionRouter(boolean routingEnabled, PostgresPartitionRules rules) {
+        this.routingEnabled = routingEnabled;
+        this.rules = rules;
+    }
+
+    /**
+     * Creates a new PostgresPartitionRouter by parsing configuration strings.
+     *
+     * <p>This is a convenience constructor that parses the configuration internally. For better
+     * reuse of parsed rules, consider using {@link #PostgresPartitionRouter(boolean,
+     * PostgresPartitionRules)} or the factory method {@link #fromConfig}.
+     *
+     * @param routingEnabled whether partition routing is enabled
+     * @param tables comma-separated list of parent table patterns
+     * @param partitionTables comma-separated list of partition table patterns
+     */
+    public PostgresPartitionRouter(boolean routingEnabled, String tables, String partitionTables) {
+        this(routingEnabled, PostgresPartitionRules.parse(tables, partitionTables, null));
+    }
+
+    /**
+     * Creates a PostgresPartitionRouter from a PostgresSourceConfig.
+     *
+     * <p>This factory method extracts the necessary configuration and creates a router with
+     * properly parsed rules. This is the recommended way to create a router as it ensures
+     * consistent configuration parsing.
+     *
+     * @param sourceConfig the Postgres source configuration
+     * @return a new PostgresPartitionRouter instance
+     */
+    public static PostgresPartitionRouter fromConfig(PostgresSourceConfig sourceConfig) {
+        boolean routingEnabled = sourceConfig.includePartitionedTables();
+        String tablesPattern = null;
+        if (sourceConfig.getTableList() != null && !sourceConfig.getTableList().isEmpty()) {
+            tablesPattern = String.join(",", sourceConfig.getTableList());
+        }
+        String partitionTables = sourceConfig.getPartitionTables();
+
+        PostgresPartitionRules rules =
+                PostgresPartitionRules.parse(tablesPattern, partitionTables, null);
+        return new PostgresPartitionRouter(routingEnabled, rules);
+    }
+
+    /** Returns the parsed partition rules. */
+    public PostgresPartitionRules getRules() {
+        return rules;
+    }
+
+    /** Returns whether routing is enabled. */
+    public boolean isRoutingEnabled() {
+        return routingEnabled;
+    }
+
+    /**
+     * Routes child partition tables to their parent tables.
+     *
+     * <p>This method returns only parent tables and non-partitioned tables in a deduplicated and
+     * order-preserving manner.
+     *
+     * @param capturedTableIds list of captured table IDs
+     * @return iterable of routed table IDs (parents and non-partitioned tables)
+     */
+    public Iterable<TableId> routeRepresentativeTables(List<TableId> capturedTableIds) {
+        // Short-circuit if routing is disabled - return original list as-is
+        if (!routingEnabled) {
+            return new LinkedHashSet<>(capturedTableIds);
+        }
+        LinkedHashSet<TableId> routedTables = new LinkedHashSet<>();
+        for (TableId tableId : capturedTableIds) {
+            routedTables.add(getPartitionParent(tableId).orElse(tableId));
+        }
+        return routedTables;
+    }
+
+    /**
+     * Gets the parent table for a given partition table using pattern matching.
+     *
+     * <p>Note: This is a low-level query method that does NOT check routingEnabled. Callers should
+     * use {@link #route(TableId)} or {@link #isChildTable(TableId)} for routing-aware behavior.
+     *
+     * @param tableId the partition table ID
+     * @return Optional containing the parent TableId if this is a child partition, empty otherwise
+     */
+    public Optional<TableId> getPartitionParent(TableId tableId) {
+        String schemaTable =
+                (tableId.schema() != null ? tableId.schema() : "") + "." + tableId.table();
+        String tableOnly = tableId.table();
+
+        for (Map.Entry<Pattern, TableId> entry : rules.getChildToParentMappings().entrySet()) {
+            Pattern pattern = entry.getKey();
+            if (pattern.matcher(schemaTable).matches()
+                    || (tableOnly != null && pattern.matcher(tableOnly).matches())) {
+                TableId mappedParent = entry.getValue();
+                if (mappedParent != null
+                        && mappedParent.schema() == null
+                        && tableId.schema() != null) {
+                    mappedParent =
+                            PostgresPartitionRules.createTableId(
+                                    tableId.schema(), mappedParent.table());
+                }
+                return Optional.ofNullable(mappedParent);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Checks if the given table is a child partition table.
+     *
+     * <p>Note: This method respects the routingEnabled flag. When routing is disabled, it always
+     * returns false to treat partitions as regular tables.
+     *
+     * @param tableId the table ID to check
+     * @return true if routing is enabled and the table is a child partition, false otherwise
+     */
+    public boolean isChildTable(TableId tableId) {
+        if (!routingEnabled) {
+            return false;
+        }
+        return getPartitionParent(tableId).isPresent();
+    }
+
+    /**
+     * Routes a table to its parent if routing is enabled and a parent exists. Otherwise returns
+     * itself.
+     *
+     * @param tableId the table ID to route
+     * @return the parent table ID if this is a child partition, otherwise the original table ID
+     */
+    public TableId route(TableId tableId) {
+        if (!routingEnabled) {
+            return tableId;
+        }
+        return getPartitionParent(tableId).orElse(tableId);
+    }
+
+    /**
+     * Checks whether the given tableId is one of the configured parent tables.
+     *
+     * @param tableId the table ID to check
+     * @return true if this is a configured parent table
+     */
+    public boolean isConfiguredParent(TableId tableId) {
+        Set<TableId> parents = rules.getConfiguredParents();
+        return parents != null
+                && parents.contains(PostgresPartitionRules.toComparableTableId(tableId));
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionRoutingSchema.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionRoutingSchema.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.postgres.source.utils;
+
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.PostgresSchema;
+import io.debezium.connector.postgresql.PostgresValueConverter;
+import io.debezium.connector.postgresql.TypeRegistry;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableEditor;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import io.debezium.schema.TopicSelector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A PostgresSchema wrapper that routes partition table events to their parent tables.
+ *
+ * <p>For PostgreSQL 10+ partitioned tables, this class provides:
+ *
+ * <ul>
+ *   <li>Child-to-parent routing: All partition child events are routed to parent table
+ *   <li>Schema optimization: Loads one representative child per parent (to get primary keys)
+ *   <li>Two-tier resolution: DB-derived mapping at startup, pattern matching for new partitions
+ * </ul>
+ *
+ * <p>Note: In PostgreSQL 10, primary keys are defined on child partitions, not parent tables.
+ * Therefore, we must load at least one child partition's schema to get the complete table
+ * definition including primary keys.
+ *
+ * <p>This is particularly useful for PostgreSQL 10 where the 'publish_via_partition_root' parameter
+ * is not available.
+ */
+public class PostgresPartitionRoutingSchema extends PostgresSchema {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PostgresPartitionRoutingSchema.class);
+
+    private final PostgresConnectorConfig dbzConfig;
+    private final PostgresConnection jdbcConnection;
+    private final boolean routeToParent;
+
+    /** Parent tables parsed from {@code partition.tables} config. */
+    private final Set<TableId> configuredParents;
+
+    /** SQL to query one child for a given parent table. */
+    private static final String SQL_QUERY_ONE_CHILD_FOR_PARENT =
+            "SELECT cn.nspname AS child_schema, cc.relname AS child_table "
+                    + "FROM pg_inherits "
+                    + "JOIN pg_class cc ON inhrelid = cc.oid "
+                    + "JOIN pg_namespace cn ON cc.relnamespace = cn.oid "
+                    + "JOIN pg_class pc ON inhparent = pc.oid "
+                    + "JOIN pg_namespace pn ON pc.relnamespace = pn.oid "
+                    + "WHERE pn.nspname = ? AND pc.relname = ? "
+                    + "LIMIT 1";
+
+    /** Pattern-based router for fallback when child not in DB-derived mapping. */
+    @Nullable private final PostgresPartitionRouter patternRouter;
+
+    // ==================== Helper Methods ====================
+
+    /** Checks if the given table is a configured partition parent. */
+    private boolean isPartitionParent(TableId tableId) {
+        return configuredParents.contains(tableId);
+    }
+
+    /**
+     * Returns the data collection filter used for filtering tables.
+     *
+     * <p>This filter is consistent with the partition routing logic. WAL events from child tables
+     * are routed to parent tables before filtering, so this filter only needs to include parent
+     * tables.
+     *
+     * @return the table filter for data collection filtering
+     */
+    public Tables.TableFilter getDataCollectionFilter() {
+        return this.getTableFilter();
+    }
+
+    public PostgresPartitionRoutingSchema(
+            PostgresConnection jdbcConnection,
+            PostgresConnectorConfig config,
+            TypeRegistry typeRegistry,
+            TopicSelector<TableId> topicSelector,
+            PostgresValueConverter valueConverter,
+            PostgresPartitionRouter router)
+            throws SQLException {
+        super(
+                new PostgresPartitionConnectorConfig(config.getConfig(), router),
+                typeRegistry,
+                jdbcConnection.getDefaultValueConverter(),
+                topicSelector,
+                valueConverter);
+        this.dbzConfig = config;
+        this.jdbcConnection = jdbcConnection;
+
+        // Use router directly - all callers should provide a valid router
+        this.patternRouter = router;
+        this.routeToParent = router != null && router.isRoutingEnabled();
+
+        // Get configuredParents from router's rules
+        if (routeToParent && patternRouter != null) {
+            this.configuredParents =
+                    Collections.unmodifiableSet(patternRouter.getRules().getConfiguredParents());
+        } else {
+            this.configuredParents = Collections.emptySet();
+        }
+
+        LOG.info(
+                "PostgresPartitionRoutingSchema initialized. routeToParent={}, db={}, configuredParents={}",
+                this.routeToParent,
+                config.databaseName(),
+                this.configuredParents);
+        // Load main tables and partition parents via super.refresh().
+        // Partition child tables are excluded by PostgresPartitionConnectorConfig filter.
+        refresh(jdbcConnection, false);
+        if (routeToParent) {
+            // Build child-to-parent mapping and fix parent table PKs from representative children
+            preloadParentTables();
+        }
+    }
+
+    @Override
+    public Table tableFor(TableId id) {
+        if (!routeToParent || id == null) {
+            return super.tableFor(id);
+        }
+        return super.tableFor(resolveToParentOrSelf(id));
+    }
+
+    @Override
+    public void applySchemaChangesForTable(int relationId, Table table) {
+        if (!routeToParent || table == null) {
+            super.applySchemaChangesForTable(relationId, table);
+            return;
+        }
+        TableId originalId = table.id();
+        if (originalId == null) {
+            super.applySchemaChangesForTable(relationId, table);
+            return;
+        }
+        TableId parentId = resolveToParentOrSelf(originalId);
+        if (!Objects.equals(originalId, parentId)) {
+            Table rewritten = table.edit().tableId(parentId).create();
+            super.applySchemaChangesForTable(relationId, rewritten);
+        } else {
+            super.applySchemaChangesForTable(relationId, table);
+        }
+    }
+
+    @Override
+    public io.debezium.relational.TableSchema schemaFor(TableId id) {
+        if (!routeToParent || id == null) {
+            return super.schemaFor(id);
+        }
+        return super.schemaFor(resolveToParentOrSelf(id));
+    }
+
+    /**
+     * Resolves child table to parent, or returns itself if not a partition child.
+     *
+     * <p>Uses pattern matching via Router for resolution.
+     */
+    public TableId resolveToParentOrSelf(TableId tableId) {
+        if (!routeToParent || tableId == null || patternRouter == null) {
+            return tableId;
+        }
+        return patternRouter.route(tableId);
+    }
+
+    /**
+     * Returns the partition router used for pattern-based routing.
+     *
+     * @return the partition router, or null if routing is disabled
+     */
+    @Nullable
+    public PostgresPartitionRouter getPartitionRouter() {
+        return patternRouter;
+    }
+
+    /**
+     * Fixes parent table PKs from representative children.
+     *
+     * <p>PostgreSQL 10 defines PKs on child partitions, not parent tables.
+     */
+    private void preloadParentTables() throws SQLException {
+        if (configuredParents.isEmpty()) {
+            LOG.warn("No parent tables parsed from partition.tables config");
+            return;
+        }
+
+        long start = System.currentTimeMillis();
+        // Fix PKs for each parent from one representative child
+        for (TableId parentId : configuredParents) {
+            Table existingParent = tables().forTable(parentId);
+            if (existingParent == null || !needsPrimaryKeyRefresh(parentId, existingParent)) {
+                continue;
+            }
+            fixParentPrimaryKey(parentId);
+        }
+
+        LOG.info(
+                "PostgresPartitionRoutingSchema preloaded {} parents in {} ms",
+                configuredParents.size(),
+                System.currentTimeMillis() - start);
+    }
+
+    /** Fix PK for a parent table by loading one child's schema. */
+    private void fixParentPrimaryKey(TableId parentId) throws SQLException {
+        TableId childId = queryOneChildForParent(parentId);
+        if (childId == null) {
+            LOG.debug("No child found for parent {}", parentId);
+            return;
+        }
+
+        Tables childTables = new Tables();
+        jdbcConnection.readSchema(
+                childTables, dbzConfig.databaseName(), null, t -> t.equals(childId), null, false);
+
+        Table childTable = childTables.forTable(childId);
+        if (childTable != null) {
+            Table parentWithPK = cloneTableWithId(childTable, parentId);
+            tables().overwriteTable(parentWithPK);
+            buildAndRegisterSchema(parentWithPK);
+            LOG.debug("Fixed PK for parent {} from child {}", parentId, childId);
+        }
+    }
+
+    /** Query one child for a given parent table. */
+    private TableId queryOneChildForParent(TableId parentId) throws SQLException {
+        final TableId[] childHolder = new TableId[1];
+        jdbcConnection.prepareQuery(
+                SQL_QUERY_ONE_CHILD_FOR_PARENT,
+                st -> {
+                    st.setString(1, parentId.schema());
+                    st.setString(2, parentId.table());
+                },
+                rs -> {
+                    if (rs.next()) {
+                        childHolder[0] =
+                                PostgresPartitionRules.createTableId(
+                                        rs.getString("child_schema"), rs.getString("child_table"));
+                    }
+                });
+        return childHolder[0];
+    }
+
+    private boolean needsPrimaryKeyRefresh(TableId resolvedId, Table existingTable) {
+        if (existingTable == null) {
+            return true;
+        }
+        // Only partition parents need PK fixup via representative child
+        return isPartitionParent(resolvedId)
+                && (existingTable.primaryKeyColumnNames() == null
+                        || existingTable.primaryKeyColumnNames().isEmpty());
+    }
+
+    /**
+     * Clones a table structure with a new table ID.
+     *
+     * <p>This is used to create partition child table definitions from parent table schemas,
+     * allowing Debezium to process child partition events using the parent's schema.
+     *
+     * @param source the source table to clone
+     * @param newId the new table ID for the cloned table
+     * @return a new Table instance with the new ID and same schema as source
+     */
+    private Table cloneTableWithId(Table source, TableId newId) {
+        TableEditor editor = Table.editor().tableId(newId);
+        if (source.defaultCharsetName() != null) {
+            editor.setDefaultCharsetName(source.defaultCharsetName());
+        }
+        for (io.debezium.relational.Column col : source.columns()) {
+            editor.addColumn(col);
+        }
+
+        editor.setPrimaryKeyNames(source.primaryKeyColumnNames());
+        return editor.create();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionRules.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionRules.java
@@ -1,0 +1,664 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.postgres.source.utils;
+
+import org.apache.flink.cdc.common.utils.PatternCache;
+import org.apache.flink.cdc.common.utils.Predicates;
+
+import io.debezium.relational.TableId;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Immutable configuration object that encapsulates parsed partition routing rules.
+ *
+ * <p>This class serves as the single source of truth for partition table configuration parsing,
+ * eliminating duplication across PostgresPartitionRouter, PostgresPartitionConnectorConfig, and
+ * PostgresPartitionRoutingSchema.
+ *
+ * <p><b>Design Principles:</b>
+ *
+ * <ul>
+ *   <li><b>Immutability:</b> All fields are final and collections are unmodifiable
+ *   <li><b>Single Responsibility:</b> Only handles configuration parsing, not routing decisions
+ *   <li><b>Thread-Safe:</b> Can be safely shared across multiple components
+ * </ul>
+ *
+ * <p><b>Usage Example:</b>
+ *
+ * <pre>{@code
+ * PostgresPartitionRules rules = PostgresPartitionRules.parse(
+ *     "parent1:child1_.*,parent2:child2_.*",
+ *     "public"
+ * );
+ * Set<TableId> parents = rules.getConfiguredParents();
+ * Map<Pattern, TableId> mappings = rules.getChildToParentMappings();
+ * }</pre>
+ */
+public final class PostgresPartitionRules implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String DEFAULT_SCHEMA = "public";
+
+    private static final char[] PARENT_DERIVE_STOP_CHARS =
+            new char[] {'\\', '[', '(', '{', '*', '+', '?', '|', '.'};
+
+    /** Set of explicitly configured parent table IDs. */
+    private transient Set<TableId> configuredParents;
+
+    /** Mapping from child partition patterns to their parent TableId. */
+    private transient Map<Pattern, TableId> childToParentMappings;
+
+    /** Child table patterns used for excluding partition children in table filters. */
+    private transient List<Pattern> childTablePatterns;
+
+    /** Original tables pattern string (for backward compatibility). */
+    private final String tablesPattern;
+
+    /** Original partition tables pattern string (for backward compatibility). */
+    private final String partitionTablesPattern;
+
+    /** Private constructor. Use {@link #parse(String, String, String)} to create instances. */
+    private PostgresPartitionRules(
+            Set<TableId> configuredParents,
+            Map<Pattern, TableId> childToParentMappings,
+            List<Pattern> childTablePatterns,
+            String tablesPattern,
+            String partitionTablesPattern) {
+        this.configuredParents = Collections.unmodifiableSet(configuredParents);
+        this.childToParentMappings = Collections.unmodifiableMap(childToParentMappings);
+        this.childTablePatterns = Collections.unmodifiableList(childTablePatterns);
+        this.tablesPattern = tablesPattern;
+        this.partitionTablesPattern = partitionTablesPattern;
+    }
+
+    /**
+     * Gets the set of configured parent table IDs.
+     *
+     * @return unmodifiable set of parent tables
+     */
+    public Set<TableId> getConfiguredParents() {
+        return configuredParents;
+    }
+
+    /**
+     * Gets the mapping from child partition patterns to parent table IDs.
+     *
+     * @return unmodifiable map of pattern to parent mappings
+     */
+    public Map<Pattern, TableId> getChildToParentMappings() {
+        return childToParentMappings;
+    }
+
+    /**
+     * Gets the compiled child table patterns for filtering.
+     *
+     * @return unmodifiable list of patterns
+     */
+    public List<Pattern> getChildTablePatterns() {
+        return childTablePatterns;
+    }
+
+    /**
+     * Gets the original tables pattern string.
+     *
+     * @return tables pattern, may be null
+     */
+    public String getTablesPattern() {
+        return tablesPattern;
+    }
+
+    /**
+     * Gets the original partition tables pattern string.
+     *
+     * @return partition tables pattern, may be null
+     */
+    public String getPartitionTablesPattern() {
+        return partitionTablesPattern;
+    }
+
+    /**
+     * Checks if there are any configured partition rules.
+     *
+     * @return true if partition rules exist
+     */
+    public boolean hasPartitionRules() {
+        return !childToParentMappings.isEmpty();
+    }
+
+    /**
+     * Normalizes a regex pattern to ignore catalog prefix during matching.
+     *
+     * @param pattern the original pattern
+     * @return normalized pattern without catalog prefix
+     */
+    static String normalizePatternIgnoreCatalog(String pattern) {
+        if (pattern == null || pattern.isEmpty()) {
+            return pattern;
+        }
+
+        String trimmedPattern = pattern.trim();
+        if (!trimmedPattern.contains(".")) {
+            return trimmedPattern;
+        }
+
+        // Try to handle escaped dots first (catalog\.schema\.table)
+        String escapedResult = handleEscapedDots(trimmedPattern);
+        if (escapedResult != null) {
+            return escapedResult;
+        }
+
+        // Handle unescaped dots (catalog.schema.table)
+        return handleUnescapedDots(trimmedPattern);
+    }
+
+    /**
+     * Handles patterns with escaped dots (catalog\.schema\.table).
+     *
+     * @param pattern the pattern to process
+     * @return normalized pattern, or null if no escaped dots found
+     */
+    private static String handleEscapedDots(String pattern) {
+        int firstEscapedDot = pattern.indexOf("\\.");
+        if (firstEscapedDot < 0) {
+            return null;
+        }
+
+        int secondEscapedDot = pattern.indexOf("\\.", firstEscapedDot + 2);
+        if (secondEscapedDot > firstEscapedDot) {
+            // Found two "\." occurrences - this is a three-segment pattern
+            // Remove the leading "catalog\." part
+            return pattern.substring(firstEscapedDot + 2);
+        }
+
+        // Only one "\." found - this is a two-segment pattern, return as-is
+        return pattern;
+    }
+
+    /**
+     * Handles patterns with unescaped dots (catalog.schema.table).
+     *
+     * <p>This method counts dots that are NOT part of regex patterns (like .*) and strips the
+     * catalog prefix if there are 2 or more separator dots.
+     *
+     * @param pattern the pattern to process
+     * @return normalized pattern without catalog prefix
+     */
+    private static String handleUnescapedDots(String pattern) {
+        int dotCount = 0;
+        int firstDotIndex = -1;
+
+        for (int i = 0; i < pattern.length(); i++) {
+            if (pattern.charAt(i) == '.') {
+                // Skip regex quantifier dots (followed by * + ? {)
+                if (i + 1 < pattern.length()) {
+                    char next = pattern.charAt(i + 1);
+                    if (next == '*' || next == '+' || next == '?' || next == '{') {
+                        continue;
+                    }
+                }
+                dotCount++;
+                if (firstDotIndex < 0) {
+                    firstDotIndex = i;
+                }
+            }
+        }
+
+        // If we have 2 or more separator dots, strip the first segment (catalog)
+        if (dotCount >= 2 && firstDotIndex > 0) {
+            return pattern.substring(firstDotIndex + 1);
+        }
+        return pattern;
+    }
+
+    /**
+     * Parses partition configuration and creates an immutable PostgresPartitionRules instance.
+     *
+     * @param tables comma-separated list of parent table patterns
+     * @param partitionTables comma-separated list of partition table patterns
+     * @param defaultSchema default schema name (e.g., "public")
+     * @return parsed PostgresPartitionRules instance
+     */
+    public static PostgresPartitionRules parse(
+            String tables, String partitionTables, String defaultSchema) {
+        String resolvedDefaultSchema =
+                (defaultSchema == null || defaultSchema.trim().isEmpty())
+                        ? DEFAULT_SCHEMA
+                        : defaultSchema.trim();
+        Map<Pattern, TableId> childToParentMap = new LinkedHashMap<>();
+        Set<TableId> configuredParents = new LinkedHashSet<>();
+        List<Pattern> childTablePatterns = new ArrayList<>();
+
+        if (partitionTables == null || partitionTables.trim().isEmpty()) {
+            return new PostgresPartitionRules(
+                    configuredParents,
+                    childToParentMap,
+                    childTablePatterns,
+                    tables,
+                    partitionTables);
+        }
+
+        String[] partitionEntries = Predicates.RegExSplitterByComma.split(partitionTables);
+
+        for (int i = 0; i < partitionEntries.length; i++) {
+            String raw = partitionEntries[i];
+            if (raw == null) {
+                continue;
+            }
+            String entry = raw.trim();
+            if (entry.isEmpty()) {
+                continue;
+            }
+
+            int colonIndex = entry.indexOf(':');
+            if (colonIndex <= 0) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Invalid partition.tables entry '%s': must use colon format 'parent:child_regex' "
+                                        + "(e.g., 'public.orders:public.orders_\\d{6}')",
+                                entry));
+            }
+            String parentPart = entry.substring(0, colonIndex).trim();
+            String childPart = entry.substring(colonIndex + 1).trim();
+
+            if (childPart == null || childPart.isEmpty()) {
+                continue;
+            }
+
+            String fallbackSchemaFromChild =
+                    splitSchemaAndTable(normalizePatternIgnoreCatalog(childPart)).schema;
+
+            // Configured parents: for schema refresh and parent PK fixups.
+            TableId configuredParent =
+                    parseParentTableId(
+                            parentPart, resolvedDefaultSchema, fallbackSchemaFromChild, false);
+            if (configuredParent != null) {
+                configuredParents.add(configuredParent);
+            }
+
+            TableId derivedConfiguredParent =
+                    deriveParentTableIdFromChildPattern(childPart, resolvedDefaultSchema, false);
+            if (derivedConfiguredParent != null) {
+                configuredParents.add(derivedConfiguredParent);
+            }
+
+            // Mapping parent: for routing. Use explicit parent from colon format.
+            TableId mappingParent =
+                    parseParentTableId(
+                            parentPart, resolvedDefaultSchema, fallbackSchemaFromChild, true);
+
+            String routerPatternStr = buildChildPatternString(childPart, null, false);
+            if (routerPatternStr != null) {
+                childToParentMap.put(PatternCache.getPattern(routerPatternStr), mappingParent);
+            }
+
+            String filterPatternStr =
+                    buildChildPatternString(childPart, resolvedDefaultSchema, true);
+            if (filterPatternStr != null) {
+                childTablePatterns.add(PatternCache.getPattern(filterPatternStr));
+            }
+        }
+
+        return new PostgresPartitionRules(
+                configuredParents, childToParentMap, childTablePatterns, tables, partitionTables);
+    }
+
+    /**
+     * Extracts the default schema from a schema include list configuration.
+     *
+     * <p>If the schema list is null or empty, returns "public". Otherwise, returns the first schema
+     * from the comma-separated list.
+     *
+     * <p>This method is used to extract the default schema from Debezium configuration.
+     *
+     * @param schemaIncludeList comma-separated list of schemas (e.g., "public,my_schema")
+     * @return the first schema from the list, or "public" if the list is null or empty
+     */
+    public static String extractDefaultSchemaFromConfig(String schemaIncludeList) {
+        if (schemaIncludeList == null || schemaIncludeList.isEmpty()) {
+            return DEFAULT_SCHEMA;
+        }
+
+        String[] schemas = schemaIncludeList.split(",");
+        if (schemas.length > 0 && !schemas[0].trim().isEmpty()) {
+            return schemas[0].trim();
+        }
+
+        return DEFAULT_SCHEMA;
+    }
+
+    /**
+     * Creates a TableId with null catalog, using the provided schema and table.
+     *
+     * <p>This is a convenience method for creating TableId objects without catalog, which is the
+     * common pattern in PostgreSQL CDC.
+     *
+     * @param schema the schema name (may be null)
+     * @param table the table name (must not be null)
+     * @return a new TableId with null catalog
+     */
+    public static TableId createTableId(String schema, String table) {
+        return new TableId(null, schema, table);
+    }
+
+    /**
+     * Gets the schema.table string representation of a TableId.
+     *
+     * <p>This returns "schema.table" format, ignoring the catalog component.
+     *
+     * @param tableId the table ID
+     * @return the schema.table string, or null if tableId is null
+     */
+    public static String getSchemaTableName(TableId tableId) {
+        if (tableId == null) {
+            return null;
+        }
+        return tableId.schema() + "." + tableId.table();
+    }
+
+    /**
+     * Creates a comparison TableId with null catalog for matching purposes.
+     *
+     * <p>This is useful when comparing TableId objects where the catalog should be ignored.
+     *
+     * @param tableId the original table ID
+     * @return a new TableId with null catalog, same schema and table
+     */
+    public static TableId toComparableTableId(TableId tableId) {
+        if (tableId == null) {
+            return null;
+        }
+        return new TableId(null, tableId.schema(), tableId.table());
+    }
+
+    /**
+     * Builds a child table pattern string.
+     *
+     * @param childPattern the child table pattern
+     * @param defaultSchema default schema to use when schema is not specified
+     * @param requireSchema whether to require a schema
+     * @return pattern string, or null if table part is empty
+     */
+    private static String buildChildPatternString(
+            String childPattern, String defaultSchema, boolean requireSchema) {
+        String normalized = normalizePatternIgnoreCatalog(childPattern);
+        SchemaAndTable schemaAndTable = splitSchemaAndTable(normalized);
+        String tablePart = schemaAndTable.tableOrRegex;
+        if (tablePart == null || tablePart.isEmpty()) {
+            return null;
+        }
+
+        String cleanedTableRegex = stripAnchors(tablePart);
+        String schema = schemaAndTable.schema;
+
+        if (schema == null || schema.isEmpty()) {
+            if (requireSchema) {
+                schema = defaultSchema;
+            } else {
+                return "^" + cleanedTableRegex + "$";
+            }
+        }
+
+        return "^" + Pattern.quote(schema) + "\\." + cleanedTableRegex + "$";
+    }
+
+    private static String stripAnchors(String tablePart) {
+        if (tablePart == null || tablePart.isEmpty()) {
+            return tablePart;
+        }
+
+        // Only strip if they are actual anchors, not escaped literals (e.g., \$ or \^)
+        boolean hasStartAnchor = tablePart.startsWith("^") && !tablePart.startsWith("\\^");
+        boolean hasEndAnchor =
+                tablePart.endsWith("$")
+                        && !tablePart.endsWith("\\$")
+                        && !tablePart.endsWith("\\\\$");
+        String tableRegex = tablePart;
+        if (hasStartAnchor) {
+            tableRegex = tableRegex.substring(1);
+        }
+        if (hasEndAnchor && !tableRegex.isEmpty()) {
+            tableRegex = tableRegex.substring(0, tableRegex.length() - 1);
+        }
+        return tableRegex;
+    }
+
+    /**
+     * Derives parent table ID from child pattern by removing regex suffix.
+     *
+     * @param childPattern the child table pattern
+     * @param defaultSchema default schema to use when schema is not specified
+     * @param allowNullSchema whether to allow null schema in the result
+     * @return derived parent TableId, or null if parent table name is empty
+     */
+    private static TableId deriveParentTableIdFromChildPattern(
+            String childPattern, String defaultSchema, boolean allowNullSchema) {
+        String normalized = normalizePatternIgnoreCatalog(childPattern);
+        SchemaAndTable schemaAndTable = splitSchemaAndTable(normalized);
+        String parentTable = deriveParentTableNameFromChildRegex(schemaAndTable.tableOrRegex);
+        if (parentTable.isEmpty()) {
+            return null;
+        }
+
+        String schema = schemaAndTable.schema;
+        if (schema == null || schema.isEmpty()) {
+            if (allowNullSchema) {
+                return createTableId(null, parentTable);
+            }
+            schema = defaultSchema;
+        }
+        return createTableId(schema, parentTable);
+    }
+
+    /**
+     * Parses a schema.table pattern into a TableId with null catalog.
+     *
+     * @param schemaTablePattern the schema.table pattern to parse
+     * @param defaultSchema default schema to use when schema is not specified
+     * @param fallbackSchema fallback schema to use (may be null)
+     * @param allowNullSchema whether to allow null schema in the result
+     * @return parsed TableId, or null if table part is empty
+     */
+    private static TableId parseParentTableId(
+            String schemaTablePattern,
+            String defaultSchema,
+            String fallbackSchema,
+            boolean allowNullSchema) {
+        String normalized = normalizePatternIgnoreCatalog(schemaTablePattern);
+        SchemaAndTable schemaAndTable = splitSchemaAndTable(normalized);
+        String schema = schemaAndTable.schema;
+        String table = schemaAndTable.tableOrRegex;
+        if (table == null || table.isEmpty()) {
+            return null;
+        }
+        if (schema == null || schema.isEmpty()) {
+            schema = fallbackSchema != null ? fallbackSchema : defaultSchema;
+        }
+        if (allowNullSchema && (schema == null || schema.isEmpty())) {
+            return createTableId(null, table);
+        }
+        return createTableId(schema, table);
+    }
+
+    static String deriveParentTableNameFromChildRegex(String childTableRegex) {
+        if (childTableRegex == null || childTableRegex.isEmpty()) {
+            return "";
+        }
+
+        // Find first occurrence of any stop character
+        int cut = childTableRegex.length();
+        for (char stop : PARENT_DERIVE_STOP_CHARS) {
+            int idx = childTableRegex.indexOf(stop);
+            if (idx >= 0 && idx < cut) {
+                cut = idx;
+            }
+        }
+
+        // Trim trailing underscores and hyphens
+        while (cut > 0
+                && (childTableRegex.charAt(cut - 1) == '_'
+                        || childTableRegex.charAt(cut - 1) == '-')) {
+            cut--;
+        }
+        return cut == childTableRegex.length()
+                ? childTableRegex
+                : childTableRegex.substring(0, cut);
+    }
+
+    static SchemaAndTable splitSchemaAndTable(String normalized) {
+        if (normalized == null) {
+            return new SchemaAndTable(null, null);
+        }
+
+        String trimmed = normalized.trim();
+        if (trimmed.isEmpty()) {
+            return new SchemaAndTable(null, "");
+        }
+
+        // Support both "schema.tableRegex" and "schema\\.tableRegex"
+        int escapedDot = trimmed.indexOf("\\.");
+        if (escapedDot >= 0) {
+            String schema = trimmed.substring(0, escapedDot);
+            String table = trimmed.substring(escapedDot + 2);
+            return new SchemaAndTable(schema.isEmpty() ? null : schema, table);
+        }
+
+        int dot = indexOfSeparatorDot(trimmed);
+        if (dot >= 0) {
+            String schema = trimmed.substring(0, dot);
+            String table = trimmed.substring(dot + 1);
+            return new SchemaAndTable(schema.isEmpty() ? null : schema, table);
+        }
+
+        return new SchemaAndTable(null, trimmed);
+    }
+
+    private static int indexOfSeparatorDot(String s) {
+        boolean escaped = false;
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (c == '\\') {
+                escaped = true;
+                continue;
+            }
+            if (c != '.') {
+                continue;
+            }
+            if (i + 1 < s.length()) {
+                char next = s.charAt(i + 1);
+                if (next == '*' || next == '+' || next == '?' || next == '{') {
+                    continue;
+                }
+            }
+            return i;
+        }
+        return -1;
+    }
+
+    // ==================== Custom Serialization ====================
+
+    /** Custom serialization: write Pattern and TableId as strings. */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+
+        // Write configuredParents as strings
+        out.writeInt(configuredParents.size());
+        for (TableId tableId : configuredParents) {
+            out.writeObject(tableId.schema());
+            out.writeObject(tableId.table());
+        }
+
+        // Write childToParentMappings as strings
+        out.writeInt(childToParentMappings.size());
+        for (Map.Entry<Pattern, TableId> entry : childToParentMappings.entrySet()) {
+            out.writeObject(entry.getKey().pattern());
+            TableId parent = entry.getValue();
+            out.writeObject(parent != null ? parent.schema() : null);
+            out.writeObject(parent != null ? parent.table() : null);
+        }
+
+        // Write childTablePatterns as strings
+        out.writeInt(childTablePatterns.size());
+        for (Pattern pattern : childTablePatterns) {
+            out.writeObject(pattern.pattern());
+        }
+    }
+
+    /** Custom deserialization: rebuild Pattern and TableId from strings. */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+
+        // Read configuredParents
+        int parentsSize = in.readInt();
+        Set<TableId> parents = new LinkedHashSet<>();
+        for (int i = 0; i < parentsSize; i++) {
+            String schema = (String) in.readObject();
+            String table = (String) in.readObject();
+            parents.add(createTableId(schema, table));
+        }
+        this.configuredParents = Collections.unmodifiableSet(parents);
+
+        // Read childToParentMappings
+        int mappingsSize = in.readInt();
+        Map<Pattern, TableId> mappings = new LinkedHashMap<>();
+        for (int i = 0; i < mappingsSize; i++) {
+            String patternStr = (String) in.readObject();
+            String parentSchema = (String) in.readObject();
+            String parentTable = (String) in.readObject();
+            Pattern pattern = PatternCache.getPattern(patternStr);
+            TableId parent = parentTable != null ? createTableId(parentSchema, parentTable) : null;
+            mappings.put(pattern, parent);
+        }
+        this.childToParentMappings = Collections.unmodifiableMap(mappings);
+
+        // Read childTablePatterns
+        int patternsSize = in.readInt();
+        List<Pattern> patterns = new ArrayList<>();
+        for (int i = 0; i < patternsSize; i++) {
+            String patternStr = (String) in.readObject();
+            patterns.add(PatternCache.getPattern(patternStr));
+        }
+        this.childTablePatterns = Collections.unmodifiableList(patterns);
+    }
+
+    static class SchemaAndTable {
+        final String schema;
+        final String tableOrRegex;
+
+        SchemaAndTable(String schema, String tableOrRegex) {
+            this.schema = schema;
+            this.tableOrRegex = tableOrRegex;
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionConnectorConfigTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionConnectorConfigTest.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.postgres.source.utils;
+
+import org.apache.flink.cdc.connectors.postgres.source.config.PostgresSourceConfig;
+import org.apache.flink.cdc.connectors.postgres.testutils.TestHelper;
+
+import io.debezium.config.Configuration;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link PostgresPartitionConnectorConfig}. */
+class PostgresPartitionConnectorConfigTest {
+
+    /** Creates a PostgresPartitionConnectorConfig with a valid router from config. */
+    private PostgresPartitionConnectorConfig createConfigWithRouter(Configuration config) {
+        String partitionTables = config.getString(PostgresSourceConfig.PARTITION_TABLES_CONFIG_KEY);
+        PostgresPartitionRules rules = PostgresPartitionRules.parse(null, partitionTables, null);
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, rules);
+        return new PostgresPartitionConnectorConfig(config, router);
+    }
+
+    @Test
+    void testChildPatternWithAnchorIsProperlyHandled() {
+        // Config with anchored pattern: ^orders_\d+$
+        Configuration config =
+                TestHelper.defaultConfig()
+                        .with(
+                                PostgresSourceConfig.PARTITION_TABLES_CONFIG_KEY,
+                                "public.orders:^orders_\\d+$")
+                        .with("table.include.list", "public.orders")
+                        .build();
+
+        PostgresPartitionConnectorConfig connectorConfig = createConfigWithRouter(config);
+        Tables.TableFilter filter = connectorConfig.getTableFilters().dataCollectionFilter();
+
+        // Child table should be excluded (matched by anchored pattern)
+        TableId childTable = new TableId(null, "public", "orders_202401");
+        assertThat(filter.isIncluded(childTable)).isFalse();
+
+        // Parent table should be included
+        TableId parentTable = new TableId(null, "public", "orders");
+        assertThat(filter.isIncluded(parentTable)).isTrue();
+
+        // Non-matching table should not be excluded by child pattern
+        TableId otherTable = new TableId(null, "public", "users");
+        // This depends on base filter, but should not match child pattern
+        assertThat(filter.isIncluded(otherTable)).isFalse();
+    }
+
+    @Test
+    void testChildPatternWithLeadingAnchorOnly() {
+        Configuration config =
+                TestHelper.defaultConfig()
+                        .with(
+                                PostgresSourceConfig.PARTITION_TABLES_CONFIG_KEY,
+                                "public.orders:^orders_\\d{6}")
+                        .with("table.include.list", "public.orders")
+                        .build();
+
+        PostgresPartitionConnectorConfig connectorConfig = createConfigWithRouter(config);
+        Tables.TableFilter filter = connectorConfig.getTableFilters().dataCollectionFilter();
+
+        // Child table should be excluded
+        TableId childTable = new TableId(null, "public", "orders_202401");
+        assertThat(filter.isIncluded(childTable)).isFalse();
+    }
+
+    @Test
+    void testChildPatternWithTrailingAnchorOnly() {
+        Configuration config =
+                TestHelper.defaultConfig()
+                        .with(
+                                PostgresSourceConfig.PARTITION_TABLES_CONFIG_KEY,
+                                "public:orders_\\d+$")
+                        .with("table.include.list", "public.orders")
+                        .build();
+
+        PostgresPartitionConnectorConfig connectorConfig = createConfigWithRouter(config);
+        Tables.TableFilter filter = connectorConfig.getTableFilters().dataCollectionFilter();
+
+        // Child table should be excluded
+        TableId childTable = new TableId(null, "public", "orders_202401");
+        assertThat(filter.isIncluded(childTable)).isFalse();
+    }
+
+    @Test
+    void testChildOnlyPatternGeneratesExclusionFilter() {
+        // Use colon format: parent:child_regex
+        Configuration config =
+                TestHelper.defaultConfig()
+                        .with(
+                                PostgresSourceConfig.PARTITION_TABLES_CONFIG_KEY,
+                                "public.orders:public.orders_\\d{6}")
+                        .with("table.include.list", "public.orders,public.orders_.*")
+                        .build();
+
+        PostgresPartitionConnectorConfig connectorConfig = createConfigWithRouter(config);
+        Tables.TableFilter filter = connectorConfig.getTableFilters().dataCollectionFilter();
+
+        // Child table matching pattern should be excluded
+        TableId childTable = new TableId(null, "public", "orders_202401");
+        assertThat(filter.isIncluded(childTable)).isFalse();
+
+        // Parent table should be included
+        TableId parentTable = new TableId(null, "public", "orders");
+        assertThat(filter.isIncluded(parentTable)).isTrue();
+    }
+
+    @Test
+    void testEscapedDotInSchemaIsHandled() {
+        // Use colon format with schema
+        Configuration config =
+                TestHelper.defaultConfig()
+                        .with(
+                                PostgresSourceConfig.PARTITION_TABLES_CONFIG_KEY,
+                                "my_schema.orders:my_schema.orders_\\d{6}")
+                        .with("table.include.list", "my_schema.orders,my_schema.orders_.*")
+                        .build();
+
+        PostgresPartitionConnectorConfig connectorConfig = createConfigWithRouter(config);
+        Tables.TableFilter filter = connectorConfig.getTableFilters().dataCollectionFilter();
+
+        // Child table should be excluded
+        TableId childTable = new TableId(null, "my_schema", "orders_202401");
+        assertThat(filter.isIncluded(childTable)).isFalse();
+
+        // Parent table should be included
+        TableId parentTable = new TableId(null, "my_schema", "orders");
+        assertThat(filter.isIncluded(parentTable)).isTrue();
+    }
+
+    @Test
+    void testMultiplePartitionTablesWithMixedFormats() {
+        // Multiple partition tables with colon format
+        Configuration config =
+                TestHelper.defaultConfig()
+                        .with(
+                                PostgresSourceConfig.PARTITION_TABLES_CONFIG_KEY,
+                                "public.orders:public.orders_\\d{6},"
+                                        + "public.vouchers:public.vouchers_\\d{6},"
+                                        + "sales.invoices:sales.invoices_\\d+")
+                        .with(
+                                "table.include.list",
+                                "public.orders,public.vouchers,sales.invoices,"
+                                        + "public.orders_.*,public.vouchers_.*,sales.invoices_.*")
+                        .build();
+
+        PostgresPartitionConnectorConfig connectorConfig = createConfigWithRouter(config);
+        Tables.TableFilter filter = connectorConfig.getTableFilters().dataCollectionFilter();
+
+        // All child tables should be excluded
+        assertThat(filter.isIncluded(new TableId(null, "public", "orders_202401"))).isFalse();
+        assertThat(filter.isIncluded(new TableId(null, "public", "vouchers_202401"))).isFalse();
+        assertThat(filter.isIncluded(new TableId(null, "sales", "invoices_12345"))).isFalse();
+
+        // All parent tables should be included
+        assertThat(filter.isIncluded(new TableId(null, "public", "orders"))).isTrue();
+        assertThat(filter.isIncluded(new TableId(null, "public", "vouchers"))).isTrue();
+        assertThat(filter.isIncluded(new TableId(null, "sales", "invoices"))).isTrue();
+    }
+
+    @Test
+    void testEscapedDollarSignIsNotTreatedAsAnchor() {
+        // Pattern with escaped dollar sign (literal $) should not be stripped
+        // e.g., orders_\$ matches table names ending with literal $
+        Configuration config =
+                TestHelper.defaultConfig()
+                        .with(PostgresSourceConfig.PARTITION_TABLES_CONFIG_KEY, "public:orders_\\$")
+                        .with("table.include.list", "public.orders")
+                        .build();
+
+        // Should not throw PatternSyntaxException
+        PostgresPartitionConnectorConfig connectorConfig = createConfigWithRouter(config);
+        Tables.TableFilter filter = connectorConfig.getTableFilters().dataCollectionFilter();
+
+        // Table with literal $ should be excluded
+        TableId childTable = new TableId(null, "public", "orders_$");
+        assertThat(filter.isIncluded(childTable)).isFalse();
+
+        // Parent table should be included
+        TableId parentTable = new TableId(null, "public", "orders");
+        assertThat(filter.isIncluded(parentTable)).isTrue();
+    }
+
+    @Test
+    void testEscapedCaretIsNotTreatedAsAnchor() {
+        // Pattern with escaped caret (literal ^) should not be stripped
+        Configuration config =
+                TestHelper.defaultConfig()
+                        .with(
+                                PostgresSourceConfig.PARTITION_TABLES_CONFIG_KEY,
+                                "public:\\^orders_\\d+")
+                        .with("table.include.list", "public.orders")
+                        .build();
+
+        // Should not throw PatternSyntaxException
+        PostgresPartitionConnectorConfig connectorConfig = createConfigWithRouter(config);
+        Tables.TableFilter filter = connectorConfig.getTableFilters().dataCollectionFilter();
+
+        // Table starting with literal ^ should be excluded
+        TableId childTable = new TableId(null, "public", "^orders_123");
+        assertThat(filter.isIncluded(childTable)).isFalse();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionRouterTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionRouterTest.java
@@ -1,0 +1,652 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.postgres.source.utils;
+
+import io.debezium.relational.TableId;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link PostgresPartitionRouter}.
+ *
+ * <p>This test class focuses on verifying partition routing logic, particularly the behavior needed
+ * for PostgreSQL 10's partition tables where child partitions must be routed to their parent
+ * tables.
+ */
+class PostgresPartitionRouterTest {
+
+    // =====================================================================================
+    // Test: Basic Partition Routing with Pattern Matching
+    // =====================================================================================
+
+    @Test
+    void testBasicPartitionRouting_WithColonFormat() {
+        // Test the "parent:childPattern" format introduced for PG10 support
+        String tables = "public.orders,public.products_by_category";
+        String partitionTables =
+                "public.orders:public\\.orders_\\d+_q\\d+,public.products_by_category:public\\.products_.*";
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+
+        // Test child partition routing to parent
+        TableId childOrder = new TableId(null, "public", "orders_2023_q1");
+        TableId parentOrder = router.route(childOrder);
+        assertThat(parentOrder.schema()).isEqualTo("public");
+        assertThat(parentOrder.table()).isEqualTo("orders");
+
+        // Test another child partition
+        TableId childProduct = new TableId(null, "public", "products_electronics");
+        TableId parentProduct = router.route(childProduct);
+        assertThat(parentProduct.schema()).isEqualTo("public");
+        assertThat(parentProduct.table()).isEqualTo("products_by_category");
+    }
+
+    @Test
+    void testBasicPartitionRouting_WithColonFormat_MultipleParents() {
+        // Test the colon format with multiple parent:child mappings
+        String tables = "public.orders,public.products_by_category";
+        String partitionTables =
+                "public.orders:public\\.orders_.*,public.products_by_category:public\\.products_.*";
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+
+        // Child partitions should route to corresponding parent
+        TableId childOrder = new TableId(null, "public", "orders_2023_q1");
+        TableId parentOrder = router.route(childOrder);
+        assertThat(parentOrder.table()).isEqualTo("orders");
+
+        TableId childProduct = new TableId(null, "public", "products_electronics");
+        TableId parentProduct = router.route(childProduct);
+        assertThat(parentProduct.table()).isEqualTo("products_by_category");
+    }
+
+    @Test
+    void testNonPartitionTablePassThrough() {
+        // Non-partition tables should pass through unchanged
+        String tables = "public.orders,public.customers";
+        String partitionTables = "public.orders:public\\.orders_.*";
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+
+        // Regular table should not be routed
+        TableId customers = new TableId(null, "public", "customers");
+        TableId routed = router.route(customers);
+        assertThat(routed).isEqualTo(customers);
+        assertThat(router.isChildTable(customers)).isFalse();
+    }
+
+    @Test
+    void testRoutingDisabled() {
+        // When includePartitionedTables is false, no routing should occur
+        String tables = "public.orders";
+        String partitionTables = "public.orders:public\\.orders_.*";
+
+        PostgresPartitionRouter router =
+                new PostgresPartitionRouter(false, tables, partitionTables);
+
+        TableId childOrder = new TableId(null, "public", "orders_2023_q1");
+        TableId routed = router.route(childOrder);
+        // Should return the original table ID when routing is disabled
+        assertThat(routed).isEqualTo(childOrder);
+    }
+
+    // =====================================================================================
+    // Test: Representative Tables Routing (Batch Processing)
+    // =====================================================================================
+
+    @Test
+    void testRouteRepresentativeTables() {
+        String tables = "partition.orders,partition.products_by_category";
+        String partitionTables =
+                "partition.orders:partition\\.orders_.*,partition.products_by_category:partition\\.products_.*";
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+
+        // Input: Mix of parent, child, and regular tables
+        List<TableId> capturedTables =
+                Arrays.asList(
+                        new TableId(null, "partition", "orders_2023_q1"),
+                        new TableId(null, "partition", "orders_2023_q2"),
+                        new TableId(null, "partition", "products_electronics"),
+                        new TableId(null, "partition", "products_clothing"),
+                        new TableId(null, "partition", "customers") // non-partition table
+                        );
+
+        Iterable<TableId> routed = router.routeRepresentativeTables(capturedTables);
+
+        // Expected: Parent tables + non-partition tables (deduplicated)
+        Set<TableId> routedSet = new LinkedHashSet<>();
+        routed.forEach(routedSet::add);
+
+        assertThat(routedSet).hasSize(3);
+        assertThat(routedSet)
+                .containsExactlyInAnyOrder(
+                        new TableId(null, "partition", "orders"),
+                        new TableId(null, "partition", "products_by_category"),
+                        new TableId(null, "partition", "customers"));
+    }
+
+    @Test
+    void testRouteRepresentativeTables_OrderPreserved() {
+        String tables = "public.orders";
+        String partitionTables = "public.orders:public\\.orders_.*";
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+
+        List<TableId> capturedTables =
+                Arrays.asList(
+                        new TableId(null, "public", "orders_2023_q1"),
+                        new TableId(null, "public", "orders_2023_q2"),
+                        new TableId(null, "public", "orders_2023_q3"));
+
+        Iterable<TableId> routed = router.routeRepresentativeTables(capturedTables);
+
+        // Result should be deduplicated but first occurrence order preserved
+        Set<TableId> routedSet = new LinkedHashSet<>();
+        routed.forEach(routedSet::add);
+
+        assertThat(routedSet).hasSize(1);
+        assertThat(routedSet.iterator().next().table()).isEqualTo("orders");
+    }
+
+    // =====================================================================================
+    // Test: Parent Table Detection
+    // =====================================================================================
+
+    @Test
+    void testIsConfiguredParent() {
+        String tables = "partition.orders,partition.products_by_category";
+        String partitionTables =
+                "partition.orders:partition\\.orders_.*,partition.products_by_category:partition\\.products_.*";
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+
+        // Parent tables should be recognized
+        TableId orders = new TableId(null, "partition", "orders");
+        assertThat(router.isConfiguredParent(orders)).isTrue();
+
+        TableId products = new TableId(null, "partition", "products_by_category");
+        assertThat(router.isConfiguredParent(products)).isTrue();
+
+        // Child and non-partition tables should not be parents
+        TableId childOrder = new TableId(null, "partition", "orders_2023_q1");
+        assertThat(router.isConfiguredParent(childOrder)).isFalse();
+
+        TableId customers = new TableId(null, "partition", "customers");
+        assertThat(router.isConfiguredParent(customers)).isFalse();
+    }
+
+    // =====================================================================================
+    // Test: Pattern Normalization (Catalog Handling)
+    // Note: normalizePatternIgnoreCatalog moved to PostgresPartitionRules
+    // =====================================================================================
+
+    @Test
+    void testNormalizePatternIgnoreCatalog() {
+        // Three-segment pattern: catalog.schema.table -> schema.table
+        String pattern1 = "mydb.public.orders_.*";
+        String normalized1 = PostgresPartitionRules.normalizePatternIgnoreCatalog(pattern1);
+        assertThat(normalized1).isEqualTo("public.orders_.*");
+
+        // Escaped dots: catalog\.schema\.table -> schema\.table
+        String pattern2 = "mydb\\.public\\.orders_.*";
+        String normalized2 = PostgresPartitionRules.normalizePatternIgnoreCatalog(pattern2);
+        assertThat(normalized2).isEqualTo("public\\.orders_.*");
+
+        // Two-segment pattern should remain unchanged
+        String pattern3 = "public.orders_.*";
+        String normalized3 = PostgresPartitionRules.normalizePatternIgnoreCatalog(pattern3);
+        assertThat(normalized3).isEqualTo("public.orders_.*");
+
+        // No dots should remain unchanged
+        String pattern4 = "orders";
+        String normalized4 = PostgresPartitionRules.normalizePatternIgnoreCatalog(pattern4);
+        assertThat(normalized4).isEqualTo("orders");
+    }
+
+    // =====================================================================================
+    // Test: Cache Behavior and Performance
+    // =====================================================================================
+
+    @Test
+    void testCachingBehavior() {
+        String tables = "public.orders";
+        String partitionTables = "public.orders:public\\.orders_.*";
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+
+        TableId child = new TableId(null, "public", "orders_2023_q1");
+
+        // First call should populate cache
+        Optional<TableId> parent1 = router.getPartitionParent(child);
+        assertThat(parent1).isPresent();
+        assertThat(parent1.get().table()).isEqualTo("orders");
+
+        // Second call should use cached result (same object)
+        Optional<TableId> parent2 = router.getPartitionParent(child);
+        assertThat(parent2).isEqualTo(parent1);
+    }
+
+    // =====================================================================================
+    // Test: Edge Cases
+    // =====================================================================================
+
+    @Test
+    void testEmptyPartitionTables() {
+        String tables = "public.orders";
+        String partitionTables = null;
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+
+        // Without partition tables configured, no routing should occur
+        TableId anyTable = new TableId(null, "public", "orders_2023_q1");
+        assertThat(router.route(anyTable)).isEqualTo(anyTable);
+        assertThat(router.isChildTable(anyTable)).isFalse();
+    }
+
+    @Test
+    void testMultipleSchemas() {
+        // Test routing across different schemas
+        String tables = "schema1.orders,schema2.orders";
+        String partitionTables =
+                "schema1.orders:schema1\\.orders_.*,schema2.orders:schema2\\.orders_.*";
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+
+        TableId child1 = new TableId(null, "schema1", "orders_2023_q1");
+        assertThat(router.route(child1).schema()).isEqualTo("schema1");
+        assertThat(router.route(child1).table()).isEqualTo("orders");
+
+        TableId child2 = new TableId(null, "schema2", "orders_2023_q1");
+        assertThat(router.route(child2).schema()).isEqualTo("schema2");
+        assertThat(router.route(child2).table()).isEqualTo("orders");
+    }
+
+    @Test
+    void testComplexRegexPatterns() {
+        // Test various regex patterns commonly used for partition tables
+        String tables = "public.events";
+        String partitionTables = "public.events:public\\.events_\\d{4}_\\d{2}"; // YYYY_MM format
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+
+        TableId child1 = new TableId(null, "public", "events_2023_01");
+        assertThat(router.isChildTable(child1)).isTrue();
+        assertThat(router.route(child1).table()).isEqualTo("events");
+
+        TableId child2 = new TableId(null, "public", "events_2023_12");
+        assertThat(router.isChildTable(child2)).isTrue();
+
+        // Non-matching pattern should not be routed
+        TableId nonMatch = new TableId(null, "public", "events_q1");
+        assertThat(router.isChildTable(nonMatch)).isFalse();
+        assertThat(router.route(nonMatch)).isEqualTo(nonMatch);
+    }
+
+    // =====================================================================================
+    // Test: Parent/Child With Table-Only Names (no schema)
+    // =====================================================================================
+
+    @Test
+    void testRoutingWithTableOnlyParentAndChildPattern() {
+        // Parent only provides table name; child pattern only provides table name
+        String tables = "orders";
+        String partitionTables = "orders:orders_\\d{6}";
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+
+        // Child captured under a specific schema should inherit schema to parent
+        TableId child = new TableId(null, "public", "orders_202401");
+        TableId routed = router.route(child);
+
+        assertThat(router.isChildTable(child)).isTrue();
+        assertThat(routed.schema()).isEqualTo("public");
+        assertThat(routed.table()).isEqualTo("orders");
+    }
+
+    // =====================================================================================
+    // Test: Mixed Formats (catalog.schema.table, schema.table, and table-only)
+    // =====================================================================================
+
+    @Test
+    void testRoutingWithMixedPatternFormats() {
+        String tables = String.join(",", "aia_test.public.a", "public.b", "c");
+
+        String partitionTables =
+                String.join(
+                        ",",
+                        // three-segment (catalog.schema.table)
+                        "aia_test.public.a:aia_test.public.a_\\d{6}",
+                        // two-segment (schema.table)
+                        "public.b:public.b_\\d{6}",
+                        // table-only
+                        "c:c_\\d{6}");
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+
+        // a: catalog present in config; child in schema "public"
+        TableId aChild = new TableId(null, "public", "a_202401");
+        TableId aParent = router.route(aChild);
+        assertThat(aParent.schema()).isEqualTo("public");
+        assertThat(aParent.table()).isEqualTo("a");
+
+        // b: two-segment in config
+        TableId bChild = new TableId(null, "public", "b_202402");
+        TableId bParent = router.route(bChild);
+        assertThat(bParent.schema()).isEqualTo("public");
+        assertThat(bParent.table()).isEqualTo("b");
+
+        // c: table-only in config
+        TableId cChild = new TableId(null, "public", "c_202403");
+        TableId cParent = router.route(cChild);
+        assertThat(cParent.schema()).isEqualTo("public");
+        assertThat(cParent.table()).isEqualTo("c");
+    }
+
+    // =====================================================================================
+    // Test: getSelectors should accept escaped three-segment patterns and match children
+    // Note: getSelectors moved to PostgresPartitionInclusionDecider
+    // =====================================================================================
+
+    @Test
+    void testGetSelectorsWithEscapedThreeSegmentPatterns() {
+        String tables = "aia_test.public.aia_t_icc_jjdb";
+        String partitionTables =
+                "aia_test.public.aia_t_icc_jjdb:aia_test\\.public\\.aia_t_icc_jjdb_\\d{6}";
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+        PostgresPartitionInclusionDecider decider =
+                new PostgresPartitionInclusionDecider(t -> true, router);
+
+        org.apache.flink.cdc.common.schema.Selectors selectors = decider.getSelectors();
+
+        // Child with namespace/schema/table
+        org.apache.flink.cdc.common.event.TableId child =
+                org.apache.flink.cdc.common.event.TableId.tableId(
+                        "aia_test", "public", "aia_t_icc_jjdb_202401");
+
+        // Must match via child pattern after normalization and un-escaping for selectors
+        assertThat(selectors.isMatch(child)).isTrue();
+    }
+
+    // =====================================================================================
+    // Test: getReg/selectors composition (colon patterns with leftover parent)
+    // Expect: child regex patterns + leftover parent tables only
+    // =====================================================================================
+
+    @Test
+    void testGetSelectors_Colon_WithLeftoverParent() {
+        String tables =
+                String.join(
+                        ",",
+                        "aia_test.public.aia_t_icc_jjdb",
+                        "aia_test.public.aia_t_icc_jjdb_extend",
+                        "aia_test.public.aia_t_vcs_fkdb",
+                        "aia_test.public.aia_t_dsrb");
+
+        // Use colon format for partition tables
+        String partitionTables =
+                String.join(
+                        ",",
+                        "public.aia_t_icc_jjdb:public.aia_t_icc_jjdb_\\d{6}",
+                        "public.aia_t_icc_jjdb_extend:public.aia_t_icc_jjdb_extend_\\d{6}",
+                        "public.aia_t_vcs_fkdb:public.aia_t_vcs_fkdb_\\d{6}");
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+        PostgresPartitionInclusionDecider decider =
+                new PostgresPartitionInclusionDecider(t -> true, router);
+        org.apache.flink.cdc.common.schema.Selectors selectors = decider.getSelectors();
+
+        // Matches (child partitions and leftover parent dsrb)
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "public", "aia_t_icc_jjdb_202401")))
+                .isTrue();
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "public", "aia_t_icc_jjdb_extend_202402")))
+                .isTrue();
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "public", "aia_t_vcs_fkdb_202403")))
+                .isTrue();
+
+        // Non-matches: base parents that have child patterns
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "public", "aia_t_icc_jjdb")))
+                .isFalse();
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "public", "aia_t_icc_jjdb_extend")))
+                .isFalse();
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "public", "aia_t_vcs_fkdb")))
+                .isFalse();
+    }
+
+    // =====================================================================================
+    // Test: getReg/selectors composition (colon patterns)
+    // Expect: child regex patterns + leftover parent tables only
+    // =====================================================================================
+
+    @Test
+    void testGetSelectors_Colon_PrioritizeChildPatternsAndKeepOnlyLeftoverParents() {
+        String tables =
+                String.join(
+                        ",",
+                        "aia_test.public.aia_t_icc_jjdb",
+                        "aia_test.public.aia_t_icc_jjdb_extend",
+                        "aia_test.public.aia_t_vcs_fkdb",
+                        "aia_test.public.aia_t_dsrb");
+
+        String partitionTables =
+                String.join(
+                        ",",
+                        "aia_test.public.aia_t_icc_jjdb:aia_test.public.aia_t_icc_jjdb_\\d{6}",
+                        "aia_test.public.aia_t_icc_jjdb_extend:aia_test.public.aia_t_icc_jjdb_extend_\\d{6}",
+                        "aia_test.public.aia_t_vcs_fkdb:aia_test.public.aia_t_vcs_fkdb_\\d{6}");
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+        PostgresPartitionInclusionDecider decider =
+                new PostgresPartitionInclusionDecider(t -> true, router);
+        org.apache.flink.cdc.common.schema.Selectors selectors = decider.getSelectors();
+
+        // Matches
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "aia_test", "public", "aia_t_icc_jjdb_202401")))
+                .isTrue();
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "aia_test", "public", "aia_t_icc_jjdb_extend_202402")))
+                .isTrue();
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "aia_test", "public", "aia_t_vcs_fkdb_202403")))
+                .isTrue();
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "aia_test", "public", "aia_t_dsrb")))
+                .isTrue();
+
+        // Non-matches
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "aia_test", "public", "aia_t_icc_jjdb")))
+                .isFalse();
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "aia_test", "public", "aia_t_icc_jjdb_extend")))
+                .isFalse();
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "aia_test", "public", "aia_t_vcs_fkdb")))
+                .isFalse();
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "aia_test", "public", "other")))
+                .isFalse();
+    }
+
+    // =====================================================================================
+    // Test: Canonical exclude (ignore catalog) — no-colon, mixed segments
+    // tables uses 2-seg, partition.tables uses 3-seg; parent should be excluded
+    // =====================================================================================
+
+    @Test
+    void testGetSelectors_NoColon_ThrowsException() {
+        String tables = String.join(",", "public.orders", "public.dsrb");
+
+        // child regex without colon format should throw exception
+        String partitionTables = "aia_test.public.orders_\\d{6}";
+
+        assertThatThrownBy(() -> new PostgresPartitionRouter(true, tables, partitionTables))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must use colon format");
+    }
+
+    // =====================================================================================
+    // Test: Canonical exclude (ignore catalog) — colon, mixed segments
+    // =====================================================================================
+
+    @Test
+    void testGetSelectors_Canonical_Colon_MixedSegments() {
+        String tables = String.join(",", "public.orders", "public.dsrb");
+
+        // colon with 3-seg parent:child; tables only 2-seg
+        String partitionTables = "aia_test.public.orders:aia_test.public.orders_\\d{6}";
+
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, tables, partitionTables);
+        PostgresPartitionInclusionDecider decider =
+                new PostgresPartitionInclusionDecider(t -> true, router);
+        org.apache.flink.cdc.common.schema.Selectors selectors = decider.getSelectors();
+
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "public", "orders_202401")))
+                .isTrue();
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "public", "dsrb")))
+                .isTrue();
+
+        // base parent should be excluded
+        assertThat(
+                        selectors.isMatch(
+                                org.apache.flink.cdc.common.event.TableId.tableId(
+                                        "public", "orders")))
+                .isFalse();
+    }
+
+    // =====================================================================================
+    // Test: Table-only child regex excludes parents across schemas
+    // =====================================================================================
+
+    @Test
+    void testGetSelectors_TableOnlyChildRegex_ThrowsException() {
+        String tables = String.join(",", "schema1.orders", "schema2.orders", "public.dsrb");
+
+        // table-only child regex without colon should throw exception
+        String partitionTables = "orders_\\d{6}";
+
+        assertThatThrownBy(() -> new PostgresPartitionRouter(true, tables, partitionTables))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must use colon format");
+    }
+
+    // =====================================================================================
+    // Test: Constructor with PostgresPartitionRules
+    // =====================================================================================
+
+    @Test
+    void testConstructorWithRules() {
+        // Parse rules once
+        PostgresPartitionRules rules =
+                PostgresPartitionRules.parse(
+                        "public.orders,public.products",
+                        "public.orders:public\\.orders_.*,public.products:public\\.products_.*",
+                        null);
+
+        // Create router with pre-parsed rules
+        PostgresPartitionRouter router = new PostgresPartitionRouter(true, rules);
+
+        // Verify routing works correctly
+        TableId childOrder = new TableId(null, "public", "orders_2023_q1");
+        assertThat(router.route(childOrder).table()).isEqualTo("orders");
+
+        TableId childProduct = new TableId(null, "public", "products_electronics");
+        assertThat(router.route(childProduct).table()).isEqualTo("products");
+
+        // Verify rules are accessible
+        assertThat(router.getRules()).isSameAs(rules);
+        assertThat(router.getRules().getConfiguredParents())
+                .isEqualTo(rules.getConfiguredParents());
+    }
+
+    @Test
+    void testConstructorWithRules_BehaviorConsistentWithStringConstructor() {
+        String tables = "public.orders";
+        String partitionTables = "public.orders:public\\.orders_.*";
+
+        // Create router using string constructor
+        PostgresPartitionRouter routerFromStrings =
+                new PostgresPartitionRouter(true, tables, partitionTables);
+
+        // Create router using rules constructor
+        PostgresPartitionRules rules = PostgresPartitionRules.parse(tables, partitionTables, null);
+        PostgresPartitionRouter routerFromRules = new PostgresPartitionRouter(true, rules);
+
+        // Both should behave identically
+        TableId child = new TableId(null, "public", "orders_2023_q1");
+
+        assertThat(routerFromRules.isChildTable(child))
+                .isEqualTo(routerFromStrings.isChildTable(child));
+        assertThat(routerFromRules.route(child).table())
+                .isEqualTo(routerFromStrings.route(child).table());
+        assertThat(routerFromRules.isRoutingEnabled())
+                .isEqualTo(routerFromStrings.isRoutingEnabled());
+        assertThat(routerFromRules.getRules().getConfiguredParents())
+                .isEqualTo(routerFromStrings.getRules().getConfiguredParents());
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionRulesTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/utils/PostgresPartitionRulesTest.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.postgres.source.utils;
+
+import io.debezium.relational.TableId;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link PostgresPartitionRules}. */
+class PostgresPartitionRulesTest {
+
+    @Test
+    void testParseColonFormat() {
+        String tables = "public.orders";
+        String partitionTables = "public.orders:public.orders_\\d+";
+
+        PostgresPartitionRules rules =
+                PostgresPartitionRules.parse(tables, partitionTables, "public");
+
+        assertThat(rules.hasPartitionRules()).isTrue();
+        assertThat(rules.getConfiguredParents()).hasSize(1);
+        assertThat(rules.getChildToParentMappings()).hasSize(1);
+    }
+
+    @Test
+    void testParseWithoutColonThrowsException() {
+        String tables = "public.orders,public.products";
+        String partitionTables = "public.orders_\\d+";
+
+        assertThatThrownBy(() -> PostgresPartitionRules.parse(tables, partitionTables, "public"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must use colon format");
+    }
+
+    @Test
+    void testEmptyPartitionTables() {
+        PostgresPartitionRules rules =
+                PostgresPartitionRules.parse("public.orders", null, "public");
+
+        assertThat(rules.hasPartitionRules()).isFalse();
+        assertThat(rules.getConfiguredParents()).isEmpty();
+        assertThat(rules.getChildToParentMappings()).isEmpty();
+    }
+
+    @Test
+    void testParseColonFormatDetailed() {
+        String tables = "public.orders,public.products_by_category";
+        String partitionTables =
+                "public.orders:public\\.orders_.*,public.products:public\\.products_.*";
+
+        PostgresPartitionRules rules = PostgresPartitionRules.parse(tables, partitionTables, null);
+
+        assertThat(rules.hasPartitionRules()).isTrue();
+        // configuredParents includes:
+        // - explicit from colon left side: public.orders, public.products
+        // - derived from child patterns: public.orders, public.products
+        // Total unique: 2
+        assertThat(rules.getConfiguredParents()).hasSize(2);
+        assertThat(rules.getChildToParentMappings()).hasSize(2);
+    }
+
+    @Test
+    void testNormalizePatternIgnoreCatalogWithCatalog() {
+        String pattern = "mydb.public.orders_\\d+";
+        String normalized = PostgresPartitionRules.normalizePatternIgnoreCatalog(pattern);
+
+        assertThat(normalized).isEqualTo("public.orders_\\d+");
+    }
+
+    @Test
+    void testNormalizePatternIgnoreCatalogWithoutCatalog() {
+        String pattern = "public.orders_\\d+";
+        String normalized = PostgresPartitionRules.normalizePatternIgnoreCatalog(pattern);
+
+        assertThat(normalized).isEqualTo("public.orders_\\d+");
+    }
+
+    @Test
+    void testNormalizePatternIgnoreCatalogWithEscapedDots() {
+        String pattern = "catalog\\.public\\.orders_\\d+";
+        String normalized = PostgresPartitionRules.normalizePatternIgnoreCatalog(pattern);
+
+        assertThat(normalized).isEqualTo("public\\.orders_\\d+");
+    }
+
+    @Test
+    void testNormalizePatternIgnoreCatalogWithRegexQuantifier() {
+        String pattern = "mydb.public.orders.*";
+        String normalized = PostgresPartitionRules.normalizePatternIgnoreCatalog(pattern);
+
+        assertThat(normalized).isEqualTo("public.orders.*");
+    }
+
+    @Test
+    void testNormalizePatternIgnoreCatalogWithNullInput() {
+        String normalized = PostgresPartitionRules.normalizePatternIgnoreCatalog(null);
+
+        assertThat(normalized).isNull();
+    }
+
+    @Test
+    void testNormalizePatternIgnoreCatalogWithEmptyInput() {
+        String normalized = PostgresPartitionRules.normalizePatternIgnoreCatalog("");
+
+        assertThat(normalized).isEmpty();
+    }
+
+    @Test
+    void testExtractDefaultSchemaFromConfigWithSingleSchema() {
+        String schemaList = "public";
+        String defaultSchema = PostgresPartitionRules.extractDefaultSchemaFromConfig(schemaList);
+
+        assertThat(defaultSchema).isEqualTo("public");
+    }
+
+    @Test
+    void testExtractDefaultSchemaFromConfigWithMultipleSchemas() {
+        String schemaList = "public,my_schema,another_schema";
+        String defaultSchema = PostgresPartitionRules.extractDefaultSchemaFromConfig(schemaList);
+
+        assertThat(defaultSchema).isEqualTo("public");
+    }
+
+    @Test
+    void testExtractDefaultSchemaFromConfigWithNullInput() {
+        String defaultSchema = PostgresPartitionRules.extractDefaultSchemaFromConfig(null);
+
+        assertThat(defaultSchema).isEqualTo("public");
+    }
+
+    @Test
+    void testExtractDefaultSchemaFromConfigWithEmptyInput() {
+        String defaultSchema = PostgresPartitionRules.extractDefaultSchemaFromConfig("");
+
+        assertThat(defaultSchema).isEqualTo("public");
+    }
+
+    @Test
+    void testCreateTableId() {
+        TableId tableId = PostgresPartitionRules.createTableId("public", "orders");
+
+        assertThat(tableId.catalog()).isNull();
+        assertThat(tableId.schema()).isEqualTo("public");
+        assertThat(tableId.table()).isEqualTo("orders");
+    }
+
+    @Test
+    void testCreateTableIdWithNullSchema() {
+        TableId tableId = PostgresPartitionRules.createTableId(null, "orders");
+
+        assertThat(tableId.catalog()).isNull();
+        assertThat(tableId.schema()).isNull();
+        assertThat(tableId.table()).isEqualTo("orders");
+    }
+
+    @Test
+    void testGetSchemaTableName() {
+        TableId tableId = new TableId("mydb", "public", "orders");
+        String schemaTable = PostgresPartitionRules.getSchemaTableName(tableId);
+
+        assertThat(schemaTable).isEqualTo("public.orders");
+    }
+
+    @Test
+    void testGetSchemaTableNameWithNullInput() {
+        String schemaTable = PostgresPartitionRules.getSchemaTableName(null);
+
+        assertThat(schemaTable).isNull();
+    }
+
+    @Test
+    void testToComparableTableId() {
+        TableId original = new TableId("mydb", "public", "orders");
+        TableId comparable = PostgresPartitionRules.toComparableTableId(original);
+
+        assertThat(comparable.catalog()).isNull();
+        assertThat(comparable.schema()).isEqualTo("public");
+        assertThat(comparable.table()).isEqualTo("orders");
+    }
+
+    @Test
+    void testToComparableTableIdWithNullInput() {
+        TableId comparable = PostgresPartitionRules.toComparableTableId(null);
+
+        assertThat(comparable).isNull();
+    }
+
+    @Test
+    void testParseWithComplexPattern() {
+        String tables = "public.orders";
+        String partitionTables = "public.orders:public\\.orders_\\d{4}_\\d{2}";
+
+        PostgresPartitionRules rules =
+                PostgresPartitionRules.parse(tables, partitionTables, "public");
+
+        assertThat(rules.hasPartitionRules()).isTrue();
+        assertThat(rules.getConfiguredParents()).hasSize(1);
+        assertThat(rules.getChildToParentMappings()).hasSize(1);
+
+        Set<TableId> parents = rules.getConfiguredParents();
+        TableId parent = parents.iterator().next();
+        assertThat(parent.schema()).isEqualTo("public");
+        assertThat(parent.table()).isEqualTo("orders");
+    }
+
+    @Test
+    void testParseWithMultipleParentsAndChildren() {
+        String tables = "public.orders,public.products,public.customers";
+        String partitionTables =
+                "public.orders:public\\.orders_\\d+,public.products:public\\.products_\\d+,public.customers:public\\.customers_\\d+";
+
+        PostgresPartitionRules rules =
+                PostgresPartitionRules.parse(tables, partitionTables, "public");
+
+        assertThat(rules.hasPartitionRules()).isTrue();
+        assertThat(rules.getConfiguredParents()).hasSize(3);
+        assertThat(rules.getChildToParentMappings()).hasSize(3);
+    }
+
+    @Test
+    void testGetChildTablePatterns() {
+        String tables = "public.orders";
+        String partitionTables = "public.orders:public.orders_\\d+";
+
+        PostgresPartitionRules rules =
+                PostgresPartitionRules.parse(tables, partitionTables, "public");
+
+        assertThat(rules.getChildTablePatterns()).isNotEmpty();
+    }
+
+    @Test
+    void testGetTablesPattern() {
+        String tables = "public.orders,public.products";
+        String partitionTables = "public.orders:public.orders_\\d+";
+
+        PostgresPartitionRules rules =
+                PostgresPartitionRules.parse(tables, partitionTables, "public");
+
+        assertThat(rules.getTablesPattern()).isEqualTo(tables);
+    }
+
+    @Test
+    void testGetPartitionTablesPattern() {
+        String tables = "public.orders";
+        String partitionTables = "public.orders:public.orders_\\d+";
+
+        PostgresPartitionRules rules =
+                PostgresPartitionRules.parse(tables, partitionTables, "public");
+
+        assertThat(rules.getPartitionTablesPattern()).isEqualTo(partitionTables);
+    }
+
+    @Test
+    void testSerializationAndDeserialization() throws Exception {
+        String tables = "public.orders,public.products";
+        String partitionTables =
+                "public.orders:public.orders_\\d+,public.products:public.products_\\d+";
+
+        PostgresPartitionRules original =
+                PostgresPartitionRules.parse(tables, partitionTables, "public");
+
+        // Verify original works
+        assertThat(original.hasPartitionRules()).isTrue();
+        assertThat(original.getConfiguredParents()).hasSize(2);
+        assertThat(original.getChildToParentMappings()).hasSize(2);
+
+        // Serialize
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(baos);
+        oos.writeObject(original);
+        oos.close();
+
+        // Deserialize
+        java.io.ByteArrayInputStream bais = new java.io.ByteArrayInputStream(baos.toByteArray());
+        java.io.ObjectInputStream ois = new java.io.ObjectInputStream(bais);
+        PostgresPartitionRules deserialized = (PostgresPartitionRules) ois.readObject();
+        ois.close();
+
+        // Verify deserialized object works correctly
+        assertThat(deserialized.hasPartitionRules()).isTrue();
+        assertThat(deserialized.getConfiguredParents()).hasSize(2);
+        assertThat(deserialized.getChildToParentMappings()).hasSize(2);
+        assertThat(deserialized.getChildTablePatterns()).hasSize(2);
+        assertThat(deserialized.getTablesPattern()).isEqualTo(tables);
+        assertThat(deserialized.getPartitionTablesPattern()).isEqualTo(partitionTables);
+
+        // Verify pattern matching still works after deserialization
+        java.util.regex.Pattern firstPattern =
+                deserialized.getChildToParentMappings().keySet().iterator().next();
+        // Pattern format is "^\Qpublic\E\.orders_\d+$" - matches schema.table format
+        assertThat(firstPattern.matcher("public.orders_123").matches()).isTrue();
+        assertThat(firstPattern.matcher("public.orders_999").matches()).isTrue();
+        assertThat(firstPattern.matcher("orders_123").matches()).isFalse();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/table/MockPostgreSQLTableSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/table/MockPostgreSQLTableSource.java
@@ -68,7 +68,8 @@ public class MockPostgreSQLTableSource extends PostgreSQLTableSource {
                 (int) get(postgreSQLTableSource, "lsnCommitCheckpointsDelay"),
                 (boolean) get(postgreSQLTableSource, "assignUnboundedChunkFirst"),
                 (boolean) get(postgreSQLTableSource, "appendOnly"),
-                (boolean) get(postgreSQLTableSource, "includePartitionedTables"));
+                (boolean) get(postgreSQLTableSource, "includePartitionedTables"),
+                (String) get(postgreSQLTableSource, "partitionTables"));
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLPartitionTablesConfigITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLPartitionTablesConfigITCase.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.postgres.table;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.cdc.connectors.postgres.PostgresTestBase;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.types.RowUtils;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
+
+/**
+ * Integration tests for {@code partition.tables} configuration on PostgreSQL 10.
+ *
+ * <p>This test specifically targets PostgreSQL 10 where:
+ *
+ * <ul>
+ *   <li>Parent tables do NOT have primary keys (unlike PG11+)
+ *   <li>publish_via_partition_root is NOT available
+ *   <li>partition.tables config is required for routing child tables to parent
+ * </ul>
+ *
+ * <p>For PostgreSQL 11+ with native partition support using publish_via_partition_root, see {@link
+ * PostgreSQLConnectorITCase#testConsumingAllEventsForPartitionedTable}.
+ */
+class PostgreSQLPartitionTablesConfigITCase extends PostgresTestBase {
+
+    /**
+     * Tests partition.tables configuration on PG10. This verifies that child partition tables are
+     * correctly routed to parent table.
+     */
+    @Test
+    void testPartitionTablesConfigOnPG10() throws Exception {
+        PostgreSQLContainer<?> container = getPg10Container();
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv =
+                StreamTableEnvironment.create(
+                        env, EnvironmentSettings.newInstance().inStreamingMode().build());
+
+        boolean useLegacyToString = RowUtils.USE_LEGACY_TO_STRING;
+        RowUtils.USE_LEGACY_TO_STRING = true;
+        TableResult result = null;
+        try {
+            TestValuesTableFactory.clearAllData();
+            env.setRestartStrategy(RestartStrategies.noRestart());
+            env.setParallelism(1);
+            env.enableCheckpointing(200);
+
+            initializePostgresTable(container, "inventory_partitioned_pg10");
+            String publicationName = "dbz_publication_" + new Random().nextInt(1000);
+            String slotName = getSlotName();
+
+            try (Connection connection = getJdbcConnection(container);
+                    Statement statement = connection.createStatement()) {
+                statement.execute(
+                        String.format(
+                                "CREATE PUBLICATION %s FOR TABLE "
+                                        + "inventory_partitioned.products_us, "
+                                        + "inventory_partitioned.products_uk",
+                                publicationName));
+                statement.execute(
+                        String.format(
+                                "select pg_create_logical_replication_slot('%s','pgoutput');",
+                                slotName));
+            }
+
+            String sourceDDL = buildSourceDDL(container, publicationName, slotName);
+            String sinkDDL = buildSinkDDL();
+
+            tEnv.executeSql(sourceDDL);
+            tEnv.executeSql(sinkDDL);
+
+            result =
+                    tEnv.executeSql(
+                            "INSERT INTO sink SELECT id, name, description, weight, country "
+                                    + "FROM debezium_source");
+
+            // Wait for snapshot to start
+            waitForSnapshotStarted("sink");
+
+            // Wait a bit to make sure the replication slot is ready for WAL streaming
+            Thread.sleep(5000);
+
+            // Generate WAL events
+            try (Connection connection = getJdbcConnection(container);
+                    Statement statement = connection.createStatement()) {
+                statement.execute(
+                        "INSERT INTO inventory_partitioned.products "
+                                + "VALUES (default,'jacket','water resistent white wind breaker',0.2,'us');");
+                statement.execute(
+                        "INSERT INTO inventory_partitioned.products "
+                                + "VALUES (default,'scooter','Big 2-wheel scooter ',5.18,'uk');");
+            }
+
+            // Wait for all data (9 snapshot + 2 WAL = 11 total)
+            List<String> expected =
+                    Arrays.asList(
+                            "101,scooter,Small 2-wheel scooter,3.140,us",
+                            "102,car battery,12V car battery,8.100,us",
+                            "103,12-pack drill bits,12-pack of drill bits with sizes ranging from #40 to #3,0.800,us",
+                            "104,hammer,12oz carpenter's hammer,0.750,us",
+                            "105,hammer,14oz carpenter's hammer,0.875,us",
+                            "106,hammer,16oz carpenter's hammer,1.000,uk",
+                            "107,rocks,box of assorted rocks,5.300,uk",
+                            "108,jacket,water resistent black wind breaker,0.100,uk",
+                            "109,spare tire,24 inch spare tire,22.200,uk",
+                            "110,jacket,water resistent white wind breaker,0.200,us",
+                            "111,scooter,Big 2-wheel scooter ,5.180,uk");
+            waitForSinkResult("sink", expected);
+        } finally {
+            if (result != null) {
+                try {
+                    result.getJobClient().get().cancel().get();
+                } catch (Exception e) {
+                    // Job may have already finished with SuccessException
+                }
+            }
+            RowUtils.USE_LEGACY_TO_STRING = useLegacyToString;
+        }
+    }
+
+    private String buildSourceDDL(
+            PostgreSQLContainer<?> container, String publicationName, String slotName) {
+        return String.format(
+                "CREATE TABLE debezium_source ("
+                        + " id INT NOT NULL,"
+                        + " name STRING,"
+                        + " description STRING,"
+                        + " weight DECIMAL(10,3),"
+                        + " country STRING"
+                        + ") WITH ("
+                        + " 'connector' = 'postgres-cdc',"
+                        + " 'hostname' = '%s',"
+                        + " 'port' = '%s',"
+                        + " 'username' = '%s',"
+                        + " 'password' = '%s',"
+                        + " 'database-name' = '%s',"
+                        + " 'schema-name' = '%s',"
+                        + " 'table-name' = '%s',"
+                        + " 'scan.startup.mode' = 'initial',"
+                        + " 'scan.incremental.snapshot.enabled' = 'true',"
+                        + " 'scan.incremental.snapshot.chunk.key-column' = 'id',"
+                        + " 'decoding.plugin.name' = 'pgoutput',"
+                        + " 'debezium.publication.name' = '%s',"
+                        + " 'partition.tables' = '%s',"
+                        + " 'slot.name' = '%s'"
+                        + ")",
+                container.getHost(),
+                container.getMappedPort(POSTGRESQL_PORT),
+                container.getUsername(),
+                container.getPassword(),
+                container.getDatabaseName(),
+                "inventory_partitioned",
+                "products",
+                publicationName,
+                "inventory_partitioned.products:inventory_partitioned.products_.*",
+                slotName);
+    }
+
+    private String buildSinkDDL() {
+        return "CREATE TABLE sink ("
+                + " id INT NOT NULL,"
+                + " name STRING,"
+                + " description STRING,"
+                + " weight DECIMAL(10,3),"
+                + " country STRING,"
+                + " PRIMARY KEY (id, country) NOT ENFORCED"
+                + ") WITH ("
+                + " 'connector' = 'values',"
+                + " 'sink-insert-only' = 'false',"
+                + " 'sink-expected-messages-num' = '20'"
+                + ")";
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLTableFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLTableFactoryTest.java
@@ -157,7 +157,8 @@ class PostgreSQLTableFactoryTest {
                         SCAN_LSN_COMMIT_CHECKPOINTS_DELAY.defaultValue(),
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue(),
                         SCAN_READ_CHANGELOG_AS_APPEND_ONLY_ENABLED.defaultValue(),
-                        SCAN_INCLUDE_PARTITIONED_TABLES_ENABLED.defaultValue());
+                        SCAN_INCLUDE_PARTITIONED_TABLES_ENABLED.defaultValue(),
+                        null);
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
 
@@ -207,7 +208,8 @@ class PostgreSQLTableFactoryTest {
                         SCAN_LSN_COMMIT_CHECKPOINTS_DELAY.defaultValue(),
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue(),
                         true,
-                        SCAN_INCLUDE_PARTITIONED_TABLES_ENABLED.defaultValue());
+                        SCAN_INCLUDE_PARTITIONED_TABLES_ENABLED.defaultValue(),
+                        null);
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
 
@@ -254,7 +256,8 @@ class PostgreSQLTableFactoryTest {
                         SCAN_LSN_COMMIT_CHECKPOINTS_DELAY.defaultValue(),
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue(),
                         SCAN_READ_CHANGELOG_AS_APPEND_ONLY_ENABLED.defaultValue(),
-                        SCAN_INCLUDE_PARTITIONED_TABLES_ENABLED.defaultValue());
+                        SCAN_INCLUDE_PARTITIONED_TABLES_ENABLED.defaultValue(),
+                        null);
         expectedSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
         expectedSource.metadataKeys =
                 Arrays.asList("row_kind", "op_ts", "database_name", "schema_name", "table_name");
@@ -311,7 +314,8 @@ class PostgreSQLTableFactoryTest {
                         SCAN_LSN_COMMIT_CHECKPOINTS_DELAY.defaultValue(),
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue(),
                         SCAN_READ_CHANGELOG_AS_APPEND_ONLY_ENABLED.defaultValue(),
-                        SCAN_INCLUDE_PARTITIONED_TABLES_ENABLED.defaultValue());
+                        SCAN_INCLUDE_PARTITIONED_TABLES_ENABLED.defaultValue(),
+                        null);
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
 
@@ -358,7 +362,8 @@ class PostgreSQLTableFactoryTest {
                         SCAN_LSN_COMMIT_CHECKPOINTS_DELAY.defaultValue(),
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue(),
                         SCAN_READ_CHANGELOG_AS_APPEND_ONLY_ENABLED.defaultValue(),
-                        SCAN_INCLUDE_PARTITIONED_TABLES_ENABLED.defaultValue());
+                        SCAN_INCLUDE_PARTITIONED_TABLES_ENABLED.defaultValue(),
+                        null);
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/resources/ddl/inventory_partitioned_pg10.sql
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/resources/ddl/inventory_partitioned_pg10.sql
@@ -1,0 +1,50 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- A partitioned table schema compatible with PostgreSQL 10.
+-- In PG10, primary keys are typically defined on child partitions instead of the partition root.
+
+DROP SCHEMA IF EXISTS inventory_partitioned CASCADE;
+CREATE SCHEMA inventory_partitioned;
+SET search_path TO inventory_partitioned;
+
+CREATE TABLE products (
+  id SERIAL NOT NULL,
+  name VARCHAR(255) NOT NULL DEFAULT 'flink',
+  description VARCHAR(512),
+  weight FLOAT,
+  country VARCHAR(20) NOT NULL
+) PARTITION BY LIST(country);
+
+ALTER SEQUENCE products_id_seq RESTART WITH 101;
+
+CREATE TABLE products_uk PARTITION OF products
+    FOR VALUES IN ('uk');
+ALTER TABLE products_uk ADD PRIMARY KEY (id, country);
+
+CREATE TABLE products_us PARTITION OF products
+    FOR VALUES IN ('us');
+ALTER TABLE products_us ADD PRIMARY KEY (id, country);
+
+INSERT INTO products
+VALUES (default,'scooter','Small 2-wheel scooter',3.14, 'us'),
+       (default,'car battery','12V car battery',8.1, 'us'),
+       (default,'12-pack drill bits','12-pack of drill bits with sizes ranging from #40 to #3',0.8, 'us'),
+       (default,'hammer','12oz carpenter''s hammer',0.75, 'us'),
+       (default,'hammer','14oz carpenter''s hammer',0.875, 'us'),
+       (default,'hammer','16oz carpenter''s hammer',1.0, 'uk'),
+       (default,'rocks','box of assorted rocks',5.3, 'uk'),
+       (default,'jacket','water resistent black wind breaker',0.1, 'uk'),
+       (default,'spare tire','24 inch spare tire',22.2, 'uk');

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/resources/ddl/postgres_inventory_partitioned.sql
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/resources/ddl/postgres_inventory_partitioned.sql
@@ -1,0 +1,52 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Partitioned table schema for PostgreSQL 10+ partition routing tests.
+-- In PG10, primary keys are defined on child partitions, not the parent table.
+
+DROP SCHEMA IF EXISTS inventory_partitioned CASCADE;
+CREATE SCHEMA inventory_partitioned;
+SET search_path TO inventory_partitioned;
+
+-- Create partitioned parent table (no PK on parent in PG10 style)
+CREATE TABLE products (
+    id SERIAL NOT NULL,
+    name VARCHAR(255) NOT NULL DEFAULT 'flink',
+    description VARCHAR(512),
+    weight FLOAT,
+    country VARCHAR(20) NOT NULL
+) PARTITION BY LIST(country);
+
+ALTER SEQUENCE products_id_seq RESTART WITH 101;
+
+-- Create child partitions with primary keys
+CREATE TABLE products_uk PARTITION OF products
+    FOR VALUES IN ('uk');
+ALTER TABLE products_uk ADD PRIMARY KEY (id, country);
+ALTER TABLE products_uk REPLICA IDENTITY FULL;
+
+CREATE TABLE products_us PARTITION OF products
+    FOR VALUES IN ('us');
+ALTER TABLE products_us ADD PRIMARY KEY (id, country);
+ALTER TABLE products_us REPLICA IDENTITY FULL;
+
+-- Insert initial data
+INSERT INTO products
+VALUES (default,'scooter','Small 2-wheel scooter',3.14, 'us'),
+       (default,'car battery','12V car battery',8.1, 'us'),
+       (default,'hammer','12oz carpenter''s hammer',0.75, 'us'),
+       (default,'hammer','16oz carpenter''s hammer',1.0, 'uk'),
+       (default,'rocks','box of assorted rocks',5.3, 'uk'),
+       (default,'jacket','water resistent black wind breaker',0.1, 'uk');


### PR DESCRIPTION
## Summary

Add `partition.tables` configuration option to support PostgreSQL 10+ partition table routing, significantly improving performance for databases with many partitions.

**JIRA**: https://issues.apache.org/jira/browse/FLINK-38881

## Background

Related to [Discussion #4079](https://github.com/apache/flink-cdc/discussions/4079) and [PR #2571](https://github.com/apache/flink-cdc/pull/2571).

As noted in PR #2571: *"It's very time-consuming for postgres to refresh schema if there are many tables to read. According to our testing, refreshing 400 tables takes 15 minutes."*

This PR addresses similar performance issues specifically for PostgreSQL partition tables, where hundreds of child partitions can cause severe performance degradation.

## New Features

### PostgreSQL 10+ Partition Table Routing
- **Child-to-parent routing**: WAL events from child partitions are automatically routed to parent table
- **Unified table ID**: All partition data appears under the parent table ID in downstream systems
- **Pattern-based matching**: Use regex patterns to match child partition tables
- **Primary key inheritance**: Parent table automatically inherits primary key from representative child partition

## Performance Improvements

### Before (Problems)
- **Frequent schema refresh**: Schema was refreshed on every table access
- **Full schema load**: Even when requesting single table schema, all tables were loaded
- **Excessive CreateTableEvents**: Hundreds of partition tables generated massive CreateTableEvent storms
- **High memory/DB pressure**: Loading schema for each partition table caused memory bloat and database load
- **Checkpoint timeout risk**: Schema loading time too long, easily triggers Flink checkpoint timeout

### After (Optimizations)
- **Lazy schema loading**: Schema loaded only when needed
- **Single table fetch**: `readSchema()` now fetches only the requested table
- **Event consolidation**: Child partition events routed to parent table, eliminating duplicate CreateTableEvents
- **Reduced DB queries**: Parent table schema cached and reused for all child partitions

## Configuration

**Flink SQL:**
```sql
CREATE TABLE pg_source (...) WITH (
  'connector' = 'postgres-cdc',
  'partition.tables' = 'public.orders:public\.orders_\d{6}'
);
```

**Pipeline YAML:**
```yaml
source:
  type: postgres
  partition.tables: "public.orders:public\.orders_\d{6}"
```

Format: `parent:child_regex` (comma-separated for multiple entries)

## Test Plan

- [x] `PostgresPartitionRulesTest` - Rule parsing tests
- [x] `PostgresPartitionRouterTest` - Routing logic tests
- [x] `PostgresPartitionConnectorConfigTest` - Config and filter tests
- [x] `PostgreSQLPartitionTablesConfigITCase` - End-to-end integration test