### PR TITLE
[FLINK-38729] Add flink-cdc-flink*-compat to output t jar for source connector.

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mongodb-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mongodb-cdc/pom.xml
@@ -59,6 +59,7 @@ limitations under the License.
                                     <include>org.apache.flink:flink-cdc-common</include>
                                     <include>org.apache.flink:flink-connector-debezium</include>
                                     <include>org.apache.flink:flink-connector-mongodb-cdc</include>
+                                    <include>org.apache.flink:flink-cdc-flink*-compat</include>
                                     <include>org.mongodb.kafka:mongo-kafka-connect</include>
                                     <include>org.mongodb:mongodb-driver-sync</include>
                                     <include>org.mongodb:mongodb-driver-core</include>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mysql-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mysql-cdc/pom.xml
@@ -60,6 +60,7 @@ limitations under the License.
                                     <include>org.apache.flink:flink-cdc-common</include>
                                     <include>org.apache.flink:flink-connector-debezium</include>
                                     <include>org.apache.flink:flink-connector-mysql-cdc</include>
+                                    <include>org.apache.flink:flink-cdc-flink*-compat</include>
                                     <include>org.antlr:antlr4-runtime</include>
                                     <include>org.apache.kafka:*</include>
                                     <include>com.zendesk:mysql-binlog-connector-java</include>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-oceanbase-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-oceanbase-cdc/pom.xml
@@ -66,6 +66,7 @@ limitations under the License.
                                     <include>org.apache.flink:flink-cdc-common</include>
                                     <include>org.apache.flink:flink-connector-debezium</include>
                                     <include>org.apache.flink:flink-connector-mysql-cdc</include>
+                                    <include>org.apache.flink:flink-cdc-flink*-compat</include>
                                     <include>org.antlr:antlr4-runtime</include>
                                     <include>org.apache.kafka:*</include>
                                     <include>com.zendesk:mysql-binlog-connector-java</include>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-oracle-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-oracle-cdc/pom.xml
@@ -61,6 +61,7 @@ limitations under the License.
                                     <include>org.apache.flink:flink-cdc-base</include>
                                     <include>org.apache.flink:flink-cdc-common</include>
                                     <include>org.apache.flink:flink-connector-oracle-cdc</include>
+                                    <include>org.apache.flink:flink-cdc-flink*-compat</include>
                                     <include>org.antlr:antlr4-runtime</include>
                                     <include>com.github.jsqlparser:jsqlparser</include>
                                     <include>org.apache.kafka:*</include>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-postgres-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-postgres-cdc/pom.xml
@@ -60,6 +60,7 @@ limitations under the License.
                                     <include>org.apache.flink:flink-cdc-common</include>
                                     <include>org.apache.flink:flink-connector-debezium</include>
                                     <include>org.apache.flink:flink-connector-postgres-cdc</include>
+                                    <include>org.apache.flink:flink-cdc-flink*-compat</include>
                                     <include>com.zaxxer:HikariCP</include>
                                     <include>com.google.protobuf:protobuf-java</include>
                                     <include>com.google.guava:*</include>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-sqlserver-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-sqlserver-cdc/pom.xml
@@ -60,6 +60,7 @@ limitations under the License.
                                     <include>org.apache.flink:flink-cdc-base</include>
                                     <include>org.apache.flink:flink-cdc-common</include>
                                     <include>org.apache.flink:flink-connector-sqlserver-cdc</include>
+                                    <include>org.apache.flink:flink-cdc-flink*-compat</include>
                                     <include>com.microsoft.sqlserver:*</include>
                                     <include>org.apache.kafka:*</include>
                                     <include>com.fasterxml.*:*</include>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-tidb-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-tidb-cdc/pom.xml
@@ -55,6 +55,7 @@ limitations under the License.
                                     <include>org.apache.flink:flink-connector-debezium</include>
                                     <include>org.apache.flink:flink-connector-tidb-cdc</include>
                                     <include>org.tikv:tikv-client-java</include>
+                                    <include>org.apache.flink:flink-cdc-flink*-compat</include>
                                     <include>com.google.protobuf:*</include>
                                     <include>io.grpc:*</include>
                                     <!--  Include fixed version 30.1.1-jre-14.0 of flink shaded guava  -->

--- a/flink-cdc-connect/flink-cdc-source-connectors/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/pom.xml
@@ -76,4 +76,32 @@ limitations under the License.
         </dependency>
     </dependencies>
 
+    <profiles>
+        <!-- Default profile: use flink-cdc-flink1-compat -->
+        <profile>
+            <id>flink1</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.flink</groupId>
+                    <artifactId>flink-cdc-flink1-compat</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <!-- Flink 2 profile: use flink-cdc-flink2-compat -->
+        <profile>
+            <id>flink2</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.flink</groupId>
+                    <artifactId>flink-cdc-flink2-compat</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
Add flink-cdc-flink*-compat to output t jar for source connector.