### PR TITLE
[hotfix] Fix the value of the document parameter `IsStable`.

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -24,7 +24,7 @@ pygmentsUseClasses = true
 [params]
   # Flag whether this is a stable version or not.
   # Used for the quickstart page.
-  IsStable = false
+  IsStable = true
 
   # Flag to indicate whether an outdated warning should be shown.
   ShowOutDatedWarning = false


### PR DESCRIPTION
Fix the error message "This documentation is for an unreleased version of Apache Flink CDC. We recommend you use the latest stable version." on the website.
<img width="1178" height="516" alt="image" src="https://github.com/user-attachments/assets/0404c851-b6a5-4d8c-aeb2-378d0da39f0b" />
